### PR TITLE
Assign resources to gateway

### DIFF
--- a/.chloggen/resources_on_gateway.yaml
+++ b/.chloggen/resources_on_gateway.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, github action)
+component: operator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: add tempo gateway to resource pool, when is enable it will take into account the gateway in the resource calculation.
+
+# One or more tracking issues related to the change
+issues: [201]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/internal/manifests/gateway/gateway.go
+++ b/internal/manifests/gateway/gateway.go
@@ -211,8 +211,7 @@ func deployment(params manifestutils.Params, rbacCfgHash string, tenantsCfgHash 
 									SubPath:   manifestutils.GatewayTenantFileName,
 								},
 							},
-							// TODO(frzifus): add gateway to resource pool.
-							// Resources:       manifestutils.Resources(tempo, tempoComponentName),
+							Resources:       manifestutils.Resources(tempo, manifestutils.GatewayComponentName),
 							SecurityContext: manifestutils.TempoContainerSecurityContext(),
 						},
 					},

--- a/internal/manifests/manifestutils/resources.go
+++ b/internal/manifests/manifestutils/resources.go
@@ -15,17 +15,31 @@ type componentResource struct {
 }
 
 var (
-	resourcesMap = map[string]componentResource{
+	resourcesMapNoGateway = map[string]componentResource{
 		"distributor":    {cpu: 0.27, memory: 0.12},
 		"ingester":       {cpu: 0.38, memory: 0.5},
 		"compactor":      {cpu: 0.16, memory: 0.18},
 		"querier":        {cpu: 0.1, memory: 0.15},
 		"query-frontend": {cpu: 0.09, memory: 0.05},
 	}
+	resourcesMapWithGateway = map[string]componentResource{
+		"distributor":    {cpu: 0.26, memory: 0.11},
+		"ingester":       {cpu: 0.36, memory: 0.49},
+		"compactor":      {cpu: 0.15, memory: 0.17},
+		"querier":        {cpu: 0.09, memory: 0.14},
+		"query-frontend": {cpu: 0.08, memory: 0.04},
+		"gateway":        {cpu: 0.06, memory: 0.05},
+	}
 )
 
 // Resources calculates the resource requirements of a specific component.
 func Resources(tempo v1alpha1.TempoStack, component string) corev1.ResourceRequirements {
+
+	resourcesMap := resourcesMapNoGateway
+	if tempo.Spec.Template.Gateway.Enabled {
+		resourcesMap = resourcesMapWithGateway
+	}
+
 	componentResources, ok := resourcesMap[component]
 	if tempo.Spec.Resources.Total == nil || !ok {
 		return corev1.ResourceRequirements{}

--- a/internal/manifests/manifestutils/resources_test.go
+++ b/internal/manifests/manifestutils/resources_test.go
@@ -13,7 +13,18 @@ import (
 func TestResourceSum(t *testing.T) {
 	cpu := float32(0)
 	mem := float32(0.0)
-	for _, r := range resourcesMap {
+	for _, r := range resourcesMapNoGateway {
+		mem += r.memory
+		cpu += r.cpu
+	}
+	assert.Equal(t, float32(1.0), cpu)
+	assert.Equal(t, float32(1.0), mem)
+}
+
+func TestResourceWithGatewaySum(t *testing.T) {
+	cpu := float32(0)
+	mem := float32(0.0)
+	for _, r := range resourcesMapWithGateway {
 		mem += r.memory
 		cpu += r.cpu
 	}
@@ -56,6 +67,36 @@ func TestResources(t *testing.T) {
 				Requests: corev1.ResourceList{
 					corev1.ResourceCPU:    *resource.NewMilliQuantity(81, resource.BinarySI),
 					corev1.ResourceMemory: *resource.NewQuantity(77309416, resource.BinarySI),
+				},
+			},
+		},
+		{
+			name: "cpu, memory resources set and gateway enable",
+			tempo: v1alpha1.TempoStack{
+				Spec: v1alpha1.TempoStackSpec{
+					Template: v1alpha1.TempoTemplateSpec{
+						Gateway: v1alpha1.TempoGatewaySpec{
+							Enabled: true,
+						},
+					},
+					Resources: v1alpha1.Resources{
+						Total: &corev1.ResourceRequirements{
+							Limits: map[corev1.ResourceName]resource.Quantity{
+								corev1.ResourceMemory: resource.MustParse("2Gi"),
+								corev1.ResourceCPU:    resource.MustParse("1000m"),
+							},
+						},
+					},
+				},
+			},
+			resources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    *resource.NewMilliQuantity(260, resource.BinarySI),
+					corev1.ResourceMemory: *resource.NewQuantity(236223200, resource.BinarySI),
+				},
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    *resource.NewMilliQuantity(78, resource.BinarySI),
+					corev1.ResourceMemory: *resource.NewQuantity(70866960, resource.BinarySI),
 				},
 			},
 		},


### PR DESCRIPTION
This PR assign resources to the tempo gateway

In order to determine what percentage of resources the gateway needs I did some experiments, stressed a tempo stack with a lot of spans, and some queries (this part was done manually) thought the gateway.

Then try to reach the stack ingestion/query limits with the assigned resources, based on the gateway consumption did the math.


We can find more about the experiments here: https://docs.google.com/spreadsheets/d/1rqsh2aKxP24FmgQmC9_Ld_qxtXpoNE7yLaoy1fzjRko/edit?usp=sharing

I have to round the numbers manually so the sum will be 1.0


Fixes #201 
