### PR TITLE
Add OLM targets to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -482,3 +482,14 @@ release-artifacts: set-image-controller
 	mkdir -p dist
 	$(KUSTOMIZE) build config/overlays/community -o dist/tempo-operator.yaml
 	$(KUSTOMIZE) build config/overlays/openshift -o dist/tempo-operator-openshift.yaml
+
+olm/install: operator-sdk
+	-$(OPERATOR_SDK) olm install
+
+olm/create-catalog:
+	CATALOG_IMG=$(CATALOG_IMG) envsubst < hack/olm/catalog.yaml | kubectl apply -f -
+
+olm/create-subscription:
+	kubectl apply -f hack/olm/subscription.yaml
+
+olm/install-operator: olm/install generate bundle docker-build docker-push bundle-build bundle-push catalog-build catalog-push olm/create-catalog olm/create-subscription

--- a/hack/olm/catalog.yaml
+++ b/hack/olm/catalog.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: tempo-catalog
+  namespace: operators
+spec:
+  sourceType: grpc
+  image: ${CATALOG_IMG}
+  displayName: Tempo Catalog
+  publisher: grpc

--- a/hack/olm/subscription.yaml
+++ b/hack/olm/subscription.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: tempo
+  namespace: operators
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: tempo-operator
+  source: tempo-catalog
+  sourceNamespace: operators


### PR DESCRIPTION
Running `make olm/install-operator` on a fresh minikube/kind cluster will install OLM and setup tempo-operator with a single command. Useful for locally debugging OLM related issues.