### PR TITLE
Fix float comparison in unit test

### DIFF
--- a/internal/manifests/manifestutils/resources_test.go
+++ b/internal/manifests/manifestutils/resources_test.go
@@ -17,8 +17,8 @@ func TestResourceSum(t *testing.T) {
 		mem += r.memory
 		cpu += r.cpu
 	}
-	assert.Equal(t, float32(1.0), cpu)
-	assert.Equal(t, float32(1.0), mem)
+	assert.InDelta(t, float32(1.0), cpu, 0.01)
+	assert.InDelta(t, float32(1.0), mem, 0.01)
 }
 
 func TestResourceWithGatewaySum(t *testing.T) {
@@ -28,8 +28,8 @@ func TestResourceWithGatewaySum(t *testing.T) {
 		mem += r.memory
 		cpu += r.cpu
 	}
-	assert.Equal(t, float32(1.0), cpu)
-	assert.Equal(t, float32(1.0), mem)
+	assert.InDelta(t, float32(1.0), cpu, 0.01)
+	assert.InDelta(t, float32(1.0), mem, 0.01)
 }
 
 func TestResources(t *testing.T) {


### PR DESCRIPTION
Sometimes the floats aren't equal due to loss of precision, for example:
```
--- FAIL: TestResourceWithGatewaySum (0.00s)
    resources_test.go:31:
        	Error Trace:	/home/runner/work/tempo-operator/tempo-operator/internal/manifests/manifestutils/resources_test.go:31
        	Error:      	Not equal:
        	            	expected: 1
        	            	actual  : 1.0000001
        	Test:       	TestResourceWithGatewaySum
```
https://github.com/grafana/tempo-operator/actions/runs/5089699823/jobs/9147650291