### PR TITLE
Rename operator deployment

### DIFF
--- a/.chloggen/rename_operator_deployment.yaml
+++ b/.chloggen/rename_operator_deployment.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, target allocator, github action)
+component: operator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Rename operator deployment to enable upgrading from 0.1.0
+
+# One or more tracking issues related to the change
+issues: [432]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/rename_operator_deployment.yaml
+++ b/.chloggen/rename_operator_deployment.yaml
@@ -1,5 +1,5 @@
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: bug_fix
+change_type: breaking
 
 # The name of the component, or a single word describing the area of concern, (e.g. operator, target allocator, github action)
 component: operator
@@ -13,4 +13,6 @@ issues: [432]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext:
+subtext: |
+  If you have installed the operator via Kubernetes manifests, please run `kubectl -n tempo-operator-system delete deployment tempo-operator-controller-manager` to prune the old deployment.
+  If you have installed the operator via OLM, no action is required.

--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	$(KUSTOMIZE) build config/overlays/$(BUNDLE_VARIANT) | kubectl apply -f -
-	kubectl rollout --namespace $(OPERATOR_NAMESPACE) status deployment/tempo-operator-controller-manager-v2
+	kubectl rollout --namespace $(OPERATOR_NAMESPACE) status deployment/tempo-operator-controller
 
 .PHONY: undeploy
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
@@ -331,8 +331,8 @@ e2e:
 .PHONY: prepare-e2e-openshift
 prepare-e2e-openshift: deploy-minio
 	kubectl apply -f ./bundle/openshift/manifests/tempo-operator-manager-config_v1_configmap.yaml -n $(OPERATOR_NAMESPACE)
-	kubectl rollout restart deployment/tempo-operator-controller-manager-v2 -n $(OPERATOR_NAMESPACE)
-	kubectl rollout status deployment/tempo-operator-controller-manager-v2 -n $(OPERATOR_NAMESPACE) --timeout=30s
+	kubectl rollout restart deployment/tempo-operator-controller -n $(OPERATOR_NAMESPACE)
+	kubectl rollout status deployment/tempo-operator-controller -n $(OPERATOR_NAMESPACE) --timeout=30s
 
 .PHONY: e2e-openshift
 e2e-openshift:

--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	$(KUSTOMIZE) build config/overlays/$(BUNDLE_VARIANT) | kubectl apply -f -
-	kubectl rollout --namespace $(OPERATOR_NAMESPACE) status deployment/tempo-operator-controller-manager
+	kubectl rollout --namespace $(OPERATOR_NAMESPACE) status deployment/tempo-operator-controller-manager-v2
 
 .PHONY: undeploy
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
@@ -331,8 +331,8 @@ e2e:
 .PHONY: prepare-e2e-openshift
 prepare-e2e-openshift: deploy-minio
 	kubectl apply -f ./bundle/openshift/manifests/tempo-operator-manager-config_v1_configmap.yaml -n $(OPERATOR_NAMESPACE)
-	kubectl rollout restart deployment/tempo-operator-controller-manager -n $(OPERATOR_NAMESPACE)
-	kubectl rollout status deployment/tempo-operator-controller-manager -n $(OPERATOR_NAMESPACE) --timeout=30s
+	kubectl rollout restart deployment/tempo-operator-controller-manager-v2 -n $(OPERATOR_NAMESPACE)
+	kubectl rollout status deployment/tempo-operator-controller-manager-v2 -n $(OPERATOR_NAMESPACE) --timeout=30s
 
 .PHONY: e2e-openshift
 e2e-openshift:

--- a/bundle/community/manifests/tempo-operator.clusterserviceversion.yaml
+++ b/bundle/community/manifests/tempo-operator.clusterserviceversion.yaml
@@ -640,7 +640,7 @@ spec:
           app.kubernetes.io/name: tempo-operator
           app.kubernetes.io/part-of: tempo-operator
           control-plane: controller-manager
-        name: tempo-operator-controller-manager
+        name: tempo-operator-controller-manager-v2
         spec:
           replicas: 1
           selector:
@@ -805,7 +805,7 @@ spec:
   - admissionReviewVersions:
     - v1
     containerPort: 443
-    deploymentName: tempo-operator-controller-manager
+    deploymentName: tempo-operator-controller-manager-v2
     failurePolicy: Fail
     generateName: mtempostack.tempo.grafana.com
     rules:
@@ -825,7 +825,7 @@ spec:
   - admissionReviewVersions:
     - v1
     containerPort: 443
-    deploymentName: tempo-operator-controller-manager
+    deploymentName: tempo-operator-controller-manager-v2
     failurePolicy: Fail
     generateName: vtempostack.tempo.grafana.com
     rules:

--- a/bundle/community/manifests/tempo-operator.clusterserviceversion.yaml
+++ b/bundle/community/manifests/tempo-operator.clusterserviceversion.yaml
@@ -640,7 +640,7 @@ spec:
           app.kubernetes.io/name: tempo-operator
           app.kubernetes.io/part-of: tempo-operator
           control-plane: controller-manager
-        name: tempo-operator-controller-manager-v2
+        name: tempo-operator-controller
         spec:
           replicas: 1
           selector:
@@ -805,7 +805,7 @@ spec:
   - admissionReviewVersions:
     - v1
     containerPort: 443
-    deploymentName: tempo-operator-controller-manager-v2
+    deploymentName: tempo-operator-controller
     failurePolicy: Fail
     generateName: mtempostack.tempo.grafana.com
     rules:
@@ -825,7 +825,7 @@ spec:
   - admissionReviewVersions:
     - v1
     containerPort: 443
-    deploymentName: tempo-operator-controller-manager-v2
+    deploymentName: tempo-operator-controller
     failurePolicy: Fail
     generateName: vtempostack.tempo.grafana.com
     rules:

--- a/bundle/openshift/manifests/tempo-operator.clusterserviceversion.yaml
+++ b/bundle/openshift/manifests/tempo-operator.clusterserviceversion.yaml
@@ -640,7 +640,7 @@ spec:
           app.kubernetes.io/name: tempo-operator
           app.kubernetes.io/part-of: tempo-operator
           control-plane: controller-manager
-        name: tempo-operator-controller-manager-v2
+        name: tempo-operator-controller
         spec:
           replicas: 1
           selector:
@@ -816,7 +816,7 @@ spec:
   - admissionReviewVersions:
     - v1
     containerPort: 443
-    deploymentName: tempo-operator-controller-manager-v2
+    deploymentName: tempo-operator-controller
     failurePolicy: Fail
     generateName: mtempostack.tempo.grafana.com
     rules:
@@ -836,7 +836,7 @@ spec:
   - admissionReviewVersions:
     - v1
     containerPort: 443
-    deploymentName: tempo-operator-controller-manager-v2
+    deploymentName: tempo-operator-controller
     failurePolicy: Fail
     generateName: vtempostack.tempo.grafana.com
     rules:

--- a/bundle/openshift/manifests/tempo-operator.clusterserviceversion.yaml
+++ b/bundle/openshift/manifests/tempo-operator.clusterserviceversion.yaml
@@ -640,7 +640,7 @@ spec:
           app.kubernetes.io/name: tempo-operator
           app.kubernetes.io/part-of: tempo-operator
           control-plane: controller-manager
-        name: tempo-operator-controller-manager
+        name: tempo-operator-controller-manager-v2
         spec:
           replicas: 1
           selector:
@@ -816,7 +816,7 @@ spec:
   - admissionReviewVersions:
     - v1
     containerPort: 443
-    deploymentName: tempo-operator-controller-manager
+    deploymentName: tempo-operator-controller-manager-v2
     failurePolicy: Fail
     generateName: mtempostack.tempo.grafana.com
     rules:
@@ -836,7 +836,7 @@ spec:
   - admissionReviewVersions:
     - v1
     containerPort: 443
-    deploymentName: tempo-operator-controller-manager
+    deploymentName: tempo-operator-controller-manager-v2
     failurePolicy: Fail
     generateName: vtempostack.tempo.grafana.com
     rules:

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -3,7 +3,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: controller-manager-v2
   namespace: system
 spec:
   template:

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -3,7 +3,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager-v2
+  name: controller
   namespace: system
 spec:
   template:

--- a/config/default/manager_config_patch.yaml
+++ b/config/default/manager_config_patch.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: controller-manager-v2
   namespace: system
 spec:
   template:

--- a/config/default/manager_config_patch.yaml
+++ b/config/default/manager_config_patch.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager-v2
+  name: controller
   namespace: system
 spec:
   template:

--- a/config/default/manager_webhook_patch.yaml
+++ b/config/default/manager_webhook_patch.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: controller-manager-v2
   namespace: system
 spec:
   template:

--- a/config/default/manager_webhook_patch.yaml
+++ b/config/default/manager_webhook_patch.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager-v2
+  name: controller
   namespace: system
 spec:
   template:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -8,7 +8,7 @@ metadata:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: controller-manager-v2
   namespace: system
   labels:
     control-plane: controller-manager

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -8,7 +8,7 @@ metadata:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager-v2
+  name: controller
   namespace: system
   labels:
     control-plane: controller-manager

--- a/config/overlays/openshift/manager_auth_proxy_tls_patch.yaml
+++ b/config/overlays/openshift/manager_auth_proxy_tls_patch.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: controller-manager-v2
   namespace: system
 spec:
   template:

--- a/config/overlays/openshift/manager_auth_proxy_tls_patch.yaml
+++ b/config/overlays/openshift/manager_auth_proxy_tls_patch.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager-v2
+  name: controller
   namespace: system
 spec:
   template:


### PR DESCRIPTION
Commit 7fa448aa2bf28fb44ecf0cb530f7a530855894d6 added additional labels to the operator deployment and its selector field.

Unfortunately the selector field is immutable, and when OLM tries to patch the deployment while upgrading, Kubernetes will reject this update.

A workaround is to rename the deployment, as suggested here: https://github.com/operator-framework/operator-lifecycle-manager/issues/952