### PR TITLE
Always set all status condition values in the tempostack_status_condition metric

### DIFF
--- a/.chloggen/fix_status_condition_metric.yaml
+++ b/.chloggen/fix_status_condition_metric.yaml
@@ -1,0 +1,17 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, github action)
+component: operator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Always set all status condition values in the tempostack_status_condition metric
+
+# One or more tracking issues related to the change
+issues: [452]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Additionally, deprecate the `status` label of the tempostack_status_condition metric.

--- a/apis/tempo/v1alpha1/tempostack_types.go
+++ b/apis/tempo/v1alpha1/tempostack_types.go
@@ -255,6 +255,9 @@ const (
 	ConditionPending ConditionStatus = "Pending"
 )
 
+// AllStatusConditions lists all possible status conditions.
+var AllStatusConditions = []ConditionStatus{ConditionReady, ConditionDegraded, ConditionFailed, ConditionPending}
+
 // ConditionReason defines possible reasons for each condition.
 type ConditionReason string
 

--- a/config/overlays/community/kustomization.yaml
+++ b/config/overlays/community/kustomization.yaml
@@ -1,5 +1,7 @@
 resources:
 - ../../default
+# Uncomment the following to enable the ServiceMonitor of the operator
+#- ../../prometheus
 
 # Adds namespace to all resources.
 namespace: tempo-operator-system

--- a/controllers/tempo/tempostack_controller.go
+++ b/controllers/tempo/tempostack_controller.go
@@ -110,7 +110,7 @@ func (r *TempoStackReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 // status conditions to Degraded. if not it will throw an error as usual.
 func (r *TempoStackReconciler) handleStatus(ctx context.Context, tempo v1alpha1.TempoStack, err error) (ctrl.Result, error) {
 	// First refresh components
-	newStatus, rerr := status.GetComponetsStatus(ctx, r, tempo)
+	newStatus, rerr := status.GetComponentsStatus(ctx, r, tempo)
 	requeue := false
 
 	if rerr != nil {

--- a/internal/status/components.go
+++ b/internal/status/components.go
@@ -17,32 +17,32 @@ func componentsStatus(ctx context.Context, c StatusClient, s v1alpha1.TempoStack
 	components := v1alpha1.ComponentStatus{}
 	components.Compactor, err = appendPodStatus(ctx, c, manifestutils.CompactorComponentName, s)
 	if err != nil {
-		return v1alpha1.ComponentStatus{}, kverrors.Wrap(err, "failed lookup Microservice component pods status", "name", manifestutils.CompactorComponentName)
+		return v1alpha1.ComponentStatus{}, kverrors.Wrap(err, "failed lookup TempoStack component pods status", "name", manifestutils.CompactorComponentName)
 	}
 
 	components.Querier, err = appendPodStatus(ctx, c, manifestutils.QuerierComponentName, s)
 	if err != nil {
-		return v1alpha1.ComponentStatus{}, kverrors.Wrap(err, "failed lookup Microservice component pods status", "name", manifestutils.QuerierComponentName)
+		return v1alpha1.ComponentStatus{}, kverrors.Wrap(err, "failed lookup TempoStack component pods status", "name", manifestutils.QuerierComponentName)
 	}
 
 	components.Distributor, err = appendPodStatus(ctx, c, manifestutils.DistributorComponentName, s)
 	if err != nil {
-		return v1alpha1.ComponentStatus{}, kverrors.Wrap(err, "failed lookup Microservice component pods status", "name", manifestutils.DistributorComponentName)
+		return v1alpha1.ComponentStatus{}, kverrors.Wrap(err, "failed lookup TempoStack component pods status", "name", manifestutils.DistributorComponentName)
 	}
 
 	components.QueryFrontend, err = appendPodStatus(ctx, c, manifestutils.QueryFrontendComponentName, s)
 	if err != nil {
-		return v1alpha1.ComponentStatus{}, kverrors.Wrap(err, "failed lookup Microservice component pods status", "name", manifestutils.QueryFrontendComponentName)
+		return v1alpha1.ComponentStatus{}, kverrors.Wrap(err, "failed lookup TempoStack component pods status", "name", manifestutils.QueryFrontendComponentName)
 	}
 
 	components.Ingester, err = appendPodStatus(ctx, c, manifestutils.IngesterComponentName, s)
 	if err != nil {
-		return v1alpha1.ComponentStatus{}, kverrors.Wrap(err, "failed lookup Microservice component pods status", "name", manifestutils.IngesterComponentName)
+		return v1alpha1.ComponentStatus{}, kverrors.Wrap(err, "failed lookup TempoStack component pods status", "name", manifestutils.IngesterComponentName)
 	}
 
 	components.Gateway, err = appendPodStatus(ctx, c, manifestutils.GatewayComponentName, s)
 	if err != nil {
-		return v1alpha1.ComponentStatus{}, kverrors.Wrap(err, "failed lookup Microservice component pods status", "name", manifestutils.GatewayComponentName)
+		return v1alpha1.ComponentStatus{}, kverrors.Wrap(err, "failed lookup TempoStack component pods status", "name", manifestutils.GatewayComponentName)
 	}
 
 	return components, nil
@@ -53,7 +53,7 @@ func appendPodStatus(ctx context.Context, c StatusClient, componentName string, 
 	pods, err := c.GetPodsComponent(ctx, componentName, stack)
 
 	if err != nil {
-		return nil, kverrors.Wrap(err, "failed to list pods for Microservice component", "name", stack, "component", componentName)
+		return nil, kverrors.Wrap(err, "failed to list pods for TempoStack component", "name", stack, "component", componentName)
 	}
 
 	for _, pod := range pods.Items {
@@ -63,10 +63,10 @@ func appendPodStatus(ctx context.Context, c StatusClient, componentName string, 
 	return psm, nil
 }
 
-// GetComponetsStatus executes an aggregate update of the Microservice Status struct, i.e.
+// GetComponentsStatus executes an aggregate update of the TempoStack Status struct, i.e.
 // - It recreates the Status.Components pod status map per component.
 // - It sets the appropriate Status.Condition to true that matches the pod status maps.
-func GetComponetsStatus(ctx context.Context, k StatusClient, s v1alpha1.TempoStack) (v1alpha1.TempoStackStatus, error) {
+func GetComponentsStatus(ctx context.Context, k StatusClient, s v1alpha1.TempoStack) (v1alpha1.TempoStackStatus, error) {
 
 	cs, err := componentsStatus(ctx, k, s)
 	if err != nil {

--- a/internal/status/components_test.go
+++ b/internal/status/components_test.go
@@ -58,7 +58,7 @@ func TestSetComponentsStatus_WhenListReturnError_ReturnError(t *testing.T) {
 				return &pods, nil
 
 			}
-			_, err := GetComponetsStatus(context.TODO(), k, s)
+			_, err := GetComponentsStatus(context.TODO(), k, s)
 			require.Error(t, err)
 		})
 	}
@@ -115,7 +115,7 @@ func TestSetComponentsStatus_WhenSomePodPending(t *testing.T) {
 		},
 	}
 
-	components, err := GetComponetsStatus(context.TODO(), k, s)
+	components, err := GetComponentsStatus(context.TODO(), k, s)
 
 	// Don't care about timing
 	now := metav1.Now()
@@ -183,7 +183,7 @@ func TestSetComponentsStatus_WhenSomePodFailed(t *testing.T) {
 		},
 	}
 
-	components, err := GetComponetsStatus(context.TODO(), k, s)
+	components, err := GetComponentsStatus(context.TODO(), k, s)
 
 	// Don't care about timing
 	now := metav1.Now()
@@ -251,7 +251,7 @@ func TestSetComponentsStatus_WhenSomePodUnknow(t *testing.T) {
 		},
 	}
 
-	components, err := GetComponetsStatus(context.TODO(), k, s)
+	components, err := GetComponentsStatus(context.TODO(), k, s)
 
 	// Don't care about timing
 	now := metav1.Now()
@@ -318,7 +318,7 @@ func TestSetComponentsStatus_WhenAllReady(t *testing.T) {
 		},
 	}
 
-	components, err := GetComponetsStatus(context.TODO(), k, s)
+	components, err := GetComponentsStatus(context.TODO(), k, s)
 
 	// Don't care about timing
 	now := metav1.Now()

--- a/internal/status/conditions.go
+++ b/internal/status/conditions.go
@@ -10,11 +10,11 @@ import (
 
 const (
 	messageReady   = "All components are operational"
-	messageFailed  = "Some Microservice components failed"
-	messagePending = "Some Microservice components pending on dependencies"
+	messageFailed  = "Some TempoStack components failed"
+	messagePending = "Some TempoStack components are pending on dependencies"
 )
 
-// DegradedError contains information about why the managed Microservice has an invalid configuration.
+// DegradedError contains information about why the managed TempoStack has an invalid configuration.
 type DegradedError struct {
 	Message string
 	Reason  v1alpha1.ConditionReason
@@ -25,7 +25,7 @@ func (e *DegradedError) Error() string {
 	return fmt.Sprintf("cluster degraded: %s", e.Message)
 }
 
-// ReadyCondition updates or appends the condition Ready to the Microservice status conditions.
+// ReadyCondition updates or appends the condition Ready to the TempoStack status conditions.
 // In addition it resets all other Status conditions to false.
 func ReadyCondition(k StatusClient, tempo v1alpha1.TempoStack) []metav1.Condition {
 	ready := metav1.Condition{
@@ -37,7 +37,7 @@ func ReadyCondition(k StatusClient, tempo v1alpha1.TempoStack) []metav1.Conditio
 	return updateCondition(tempo, ready)
 }
 
-// FailedCondition updates or appends the condition Failed to the Microservice status conditions.
+// FailedCondition updates or appends the condition Failed to the TempoStack status conditions.
 // In addition it resets all other Status conditions to false.
 func FailedCondition(k StatusClient, tempo v1alpha1.TempoStack) []metav1.Condition {
 	failed := metav1.Condition{
@@ -49,7 +49,7 @@ func FailedCondition(k StatusClient, tempo v1alpha1.TempoStack) []metav1.Conditi
 	return updateCondition(tempo, failed)
 }
 
-// PendingCondition updates or appends the condition Pending to the Microservice status conditions.
+// PendingCondition updates or appends the condition Pending to the TempoStack status conditions.
 // In addition it resets all other Status conditions to false.
 func PendingCondition(k StatusClient, tempo v1alpha1.TempoStack) []metav1.Condition {
 	pending := metav1.Condition{
@@ -61,7 +61,7 @@ func PendingCondition(k StatusClient, tempo v1alpha1.TempoStack) []metav1.Condit
 	return updateCondition(tempo, pending)
 }
 
-// DegradedCondition appends the condition Degraded to the Microservice status conditions.
+// DegradedCondition appends the condition Degraded to the TempoStack status conditions.
 func DegradedCondition(tempo v1alpha1.TempoStack, msg string, reason v1alpha1.ConditionReason) []metav1.Condition {
 	degraded := metav1.Condition{
 		Type:    string(v1alpha1.ConditionDegraded),


### PR DESCRIPTION
In some cases not all status condition metrics were updated, because for example:
A TempoStack CR gets created with an invalid storage secret (creating a Degraded status condition). Later this CR is deleted, a storage secret is created and a new TempoStack instance is created. Then this TempoStack instance doesn't have the degraded condition in the status.Conditions list.

I also updated a few references of 'Microservices' and fixed a typo in a function name.