### PR TITLE
Fix TLS configuration of ServiceMonitors

### DIFF
--- a/.chloggen/fix_servicemonitor_tls.yaml
+++ b/.chloggen/fix_servicemonitor_tls.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, github action)
+component: operator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix TLS configuration of ServiceMonitors
+
+# One or more tracking issues related to the change
+issues: [481]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/internal/manifests/servicemonitor/servicemonitor.go
+++ b/internal/manifests/servicemonitor/servicemonitor.go
@@ -6,7 +6,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/grafana/tempo-operator/apis/tempo/v1alpha1"
 	"github.com/grafana/tempo-operator/internal/certrotation"
 	"github.com/grafana/tempo-operator/internal/manifests/gateway"
 	"github.com/grafana/tempo-operator/internal/manifests/manifestutils"
@@ -19,21 +18,21 @@ func BuildServiceMonitors(params manifestutils.Params) []client.Object {
 	// Each tempo component has its own TLS certificate, therefore we need separate
 	// ServiceMonitor instances for each component.
 	monitors := []client.Object{
-		buildTempoComponentServiceMonitor(params, manifestutils.CompactorComponentName),
-		buildTempoComponentServiceMonitor(params, manifestutils.DistributorComponentName),
-		buildTempoComponentServiceMonitor(params, manifestutils.IngesterComponentName),
-		buildTempoComponentServiceMonitor(params, manifestutils.QuerierComponentName),
-		buildTempoComponentServiceMonitor(params, manifestutils.QueryFrontendComponentName),
+		buildServiceMonitor(params, manifestutils.CompactorComponentName, manifestutils.HttpPortName),
+		buildServiceMonitor(params, manifestutils.DistributorComponentName, manifestutils.HttpPortName),
+		buildServiceMonitor(params, manifestutils.IngesterComponentName, manifestutils.HttpPortName),
+		buildServiceMonitor(params, manifestutils.QuerierComponentName, manifestutils.HttpPortName),
+		buildServiceMonitor(params, manifestutils.QueryFrontendComponentName, manifestutils.HttpPortName),
 	}
 
 	if params.Tempo.Spec.Template.Gateway.Enabled {
-		monitors = append(monitors, buildGatewayServiceMonitor(params.Tempo))
+		monitors = append(monitors, buildServiceMonitor(params, manifestutils.GatewayComponentName, gateway.InternalPortName))
 	}
 
 	return monitors
 }
 
-func buildTempoComponentServiceMonitor(params manifestutils.Params, component string) *monitoringv1.ServiceMonitor {
+func buildServiceMonitor(params manifestutils.Params, component string, port string) *monitoringv1.ServiceMonitor {
 	tempo := params.Tempo
 	scheme := "http"
 	var tlsConfig *monitoringv1.TLSConfig
@@ -55,18 +54,18 @@ func buildTempoComponentServiceMonitor(params manifestutils.Params, component st
 				Cert: monitoringv1.SecretOrConfigMap{
 					Secret: &corev1.SecretKeySelector{
 						LocalObjectReference: corev1.LocalObjectReference{
-							Name: naming.Name(tempo.Name, component),
+							Name: naming.TLSSecretName(component, tempo.Name),
 						},
 						Key: corev1.TLSCertKey,
 					},
 				},
 				KeySecret: &corev1.SecretKeySelector{
 					LocalObjectReference: corev1.LocalObjectReference{
-						Name: naming.Name(tempo.Name, component),
+						Name: naming.TLSSecretName(component, tempo.Name),
 					},
 					Key: corev1.TLSPrivateKeyKey,
 				},
-				// E.g. tempo-simplest-compactor-http.tempo-operator.svc.cluster.local
+				// E.g. tempo-simplest-compactor.tempo-operator-system.svc.cluster.local
 				ServerName: serverName,
 			},
 		}
@@ -81,7 +80,7 @@ func buildTempoComponentServiceMonitor(params manifestutils.Params, component st
 		Spec: monitoringv1.ServiceMonitorSpec{
 			Endpoints: []monitoringv1.Endpoint{{
 				Scheme:    scheme,
-				Port:      manifestutils.HttpPortName,
+				Port:      port,
 				Path:      "/metrics",
 				TLSConfig: tlsConfig,
 				// Custom relabel configs to be compatible with predefined Tempo dashboards:
@@ -103,40 +102,6 @@ func buildTempoComponentServiceMonitor(params manifestutils.Params, component st
 			},
 			Selector: metav1.LabelSelector{
 				MatchLabels: manifestutils.ComponentLabels(component, tempo.Name),
-			},
-		},
-	}
-}
-
-func buildGatewayServiceMonitor(tempo v1alpha1.TempoStack) *monitoringv1.ServiceMonitor {
-	return &monitoringv1.ServiceMonitor{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: tempo.Namespace,
-			Name:      naming.Name(manifestutils.GatewayComponentName, tempo.Name),
-			Labels:    manifestutils.CommonLabels(tempo.Name),
-		},
-		Spec: monitoringv1.ServiceMonitorSpec{
-			Endpoints: []monitoringv1.Endpoint{{
-				Port: gateway.InternalPortName,
-				// Custom relabel configs to be compatible with predefined Tempo dashboards:
-				// https://grafana.com/docs/tempo/latest/operations/monitoring/#dashboards
-				RelabelConfigs: []*monitoringv1.RelabelConfig{
-					{
-						SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_service_label_app_kubernetes_io_instance"},
-						TargetLabel:  "cluster",
-					},
-					{
-						SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_namespace", "__meta_kubernetes_service_label_app_kubernetes_io_component"},
-						Separator:    "/",
-						TargetLabel:  "job",
-					},
-				},
-			}},
-			NamespaceSelector: monitoringv1.NamespaceSelector{
-				MatchNames: []string{tempo.Namespace},
-			},
-			Selector: metav1.LabelSelector{
-				MatchLabels: manifestutils.ComponentLabels(manifestutils.GatewayComponentName, tempo.Name),
 			},
 		},
 	}

--- a/internal/manifests/servicemonitor/servicemonitor_test.go
+++ b/internal/manifests/servicemonitor/servicemonitor_test.go
@@ -98,14 +98,14 @@ func TestBuildServiceMonitorsTLS(t *testing.T) {
 						Cert: monitoringv1.SecretOrConfigMap{
 							Secret: &corev1.SecretKeySelector{
 								LocalObjectReference: corev1.LocalObjectReference{
-									Name: "tempo-compactor-test",
+									Name: "tempo-test-compactor-mtls",
 								},
 								Key: corev1.TLSCertKey,
 							},
 						},
 						KeySecret: &corev1.SecretKeySelector{
 							LocalObjectReference: corev1.LocalObjectReference{
-								Name: "tempo-compactor-test",
+								Name: "tempo-test-compactor-mtls",
 							},
 							Key: corev1.TLSPrivateKeyKey,
 						},
@@ -159,7 +159,94 @@ func TestBuildGatewayServiceMonitor(t *testing.T) {
 		},
 		Spec: monitoringv1.ServiceMonitorSpec{
 			Endpoints: []monitoringv1.Endpoint{{
-				Port: "internal",
+				Scheme: "http",
+				Port:   "internal",
+				Path:   "/metrics",
+				RelabelConfigs: []*monitoringv1.RelabelConfig{
+					{
+						SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_service_label_app_kubernetes_io_instance"},
+						TargetLabel:  "cluster",
+					},
+					{
+						SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_namespace", "__meta_kubernetes_service_label_app_kubernetes_io_component"},
+						Separator:    "/",
+						TargetLabel:  "job",
+					},
+				},
+			}},
+			NamespaceSelector: monitoringv1.NamespaceSelector{
+				MatchNames: []string{"project1"},
+			},
+			Selector: metav1.LabelSelector{
+				MatchLabels: manifestutils.ComponentLabels(manifestutils.GatewayComponentName, "test"),
+			},
+		},
+	}, objects[5])
+}
+
+func TestBuildGatewayServiceMonitorsTLS(t *testing.T) {
+	objects := BuildServiceMonitors(manifestutils.Params{
+		Gates: configv1alpha1.FeatureGates{
+			HTTPEncryption: true,
+		},
+		Tempo: v1alpha1.TempoStack{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "project1",
+			},
+			Spec: v1alpha1.TempoStackSpec{
+				Template: v1alpha1.TempoTemplateSpec{
+					Gateway: v1alpha1.TempoGatewaySpec{
+						Enabled: true,
+					},
+				},
+				Tenants: &v1alpha1.TenantsSpec{
+					Mode: v1alpha1.OpenShift,
+				},
+			},
+		},
+	})
+
+	labels := manifestutils.CommonLabels("test")
+	assert.Len(t, objects, 6)
+	assert.Equal(t, &monitoringv1.ServiceMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tempo-test-gateway",
+			Namespace: "project1",
+			Labels:    labels,
+		},
+		Spec: monitoringv1.ServiceMonitorSpec{
+			Endpoints: []monitoringv1.Endpoint{{
+				Scheme: "https",
+				Port:   "internal",
+				Path:   "/metrics",
+				TLSConfig: &monitoringv1.TLSConfig{
+					SafeTLSConfig: monitoringv1.SafeTLSConfig{
+						CA: monitoringv1.SecretOrConfigMap{
+							ConfigMap: &corev1.ConfigMapKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: "tempo-test-ca-bundle",
+								},
+								Key: certrotation.CAFile,
+							},
+						},
+						Cert: monitoringv1.SecretOrConfigMap{
+							Secret: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: "tempo-test-gateway-mtls",
+								},
+								Key: corev1.TLSCertKey,
+							},
+						},
+						KeySecret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "tempo-test-gateway-mtls",
+							},
+							Key: corev1.TLSPrivateKeyKey,
+						},
+						ServerName: "tempo-test-gateway.project1.svc.cluster.local",
+					},
+				},
 				RelabelConfigs: []*monitoringv1.RelabelConfig{
 					{
 						SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_service_label_app_kubernetes_io_instance"},


### PR DESCRIPTION
This PR fixes the location of the TLS certificates for the ServiceMonitors.

In #387 the certificate names were changed to `*-mtls`, and because `naming.Name` was used instead of `naming.TLSSecretName` to get the certificate name, the ServiceMonitors used to point to non existing certificates.

The PR also updates the gateway's TLS certificate location in the ServiceMonitor (depends on PR #480).