### PR TITLE
Refactor status handling

### DIFF
--- a/apis/tempo/v1alpha1/tempostack_types.go
+++ b/apis/tempo/v1alpha1/tempostack_types.go
@@ -247,22 +247,22 @@ type TempoStackStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
-// ConditionStatus defines the status of a condition (e.g. ready or degraded).
+// ConditionStatus defines the status of a condition (e.g. ready, failed, pending or configuration error).
 type ConditionStatus string
 
 const (
 	// ConditionReady defines that all components are ready.
 	ConditionReady ConditionStatus = "Ready"
-	// ConditionDegraded defines that one or more components are in a degraded state.
-	ConditionDegraded ConditionStatus = "Degraded"
 	// ConditionFailed defines that one or more components are in a failed state.
 	ConditionFailed ConditionStatus = "Failed"
-	// ConditionPending defines that one or more components are in a degraded state.
+	// ConditionPending defines that one or more components are in a pending state.
 	ConditionPending ConditionStatus = "Pending"
+	// ConditionConfigurationError defines that there is a configuration error.
+	ConditionConfigurationError ConditionStatus = "ConfigurationError"
 )
 
 // AllStatusConditions lists all possible status conditions.
-var AllStatusConditions = []ConditionStatus{ConditionReady, ConditionDegraded, ConditionFailed, ConditionPending}
+var AllStatusConditions = []ConditionStatus{ConditionReady, ConditionFailed, ConditionPending, ConditionConfigurationError}
 
 // ConditionReason defines possible reasons for each condition.
 type ConditionReason string
@@ -284,6 +284,8 @@ const (
 	ReasonMissingGatewayTenantSecret ConditionReason = "ReasonMissingGatewayTenantSecret"
 	// ReasonInvalidTenantsConfiguration when the tenant configuration provided is invalid.
 	ReasonInvalidTenantsConfiguration ConditionReason = "InvalidTenantsConfiguration"
+	// ReasonFailedReconciliation when the operator failed to reconcile.
+	ReasonFailedReconciliation ConditionReason = "FailedReconciliation"
 )
 
 // Resources defines resources configuration.

--- a/apis/tempo/v1alpha1/tempostack_webhook.go
+++ b/apis/tempo/v1alpha1/tempostack_webhook.go
@@ -200,7 +200,7 @@ func (v *validator) validateStorage(ctx context.Context, tempo TempoStack) field
 	err := v.client.Get(ctx, types.NamespacedName{Namespace: tempo.Namespace, Name: tempo.Spec.Storage.Secret.Name}, storageSecret)
 	if err != nil {
 		// Do not fail the validation here, the user can create the storage secret later.
-		// The operator will remain in a degraded condition until the storage secret is set.
+		// The operator will remain in a ConfigurationError status condition until the storage secret is set.
 		return field.ErrorList{}
 	}
 

--- a/docs/operator/api.md
+++ b/docs/operator/api.md
@@ -455,6 +455,11 @@ PodStatusMap
 <td><p>ReasonFailedComponents when all/some Tempo components fail to roll out.</p>
 </td>
 
+</tr><tr><td><p>&#34;FailedReconciliation&#34;</p></td>
+
+<td><p>ReasonFailedReconciliation when the operator failed to reconcile.</p>
+</td>
+
 </tr><tr><td><p>&#34;InvalidStorageConfig&#34;</p></td>
 
 <td><p>ReasonInvalidStorageConfig defines that the object storage configuration is invalid (missing or incomplete storage secret).</p>
@@ -490,7 +495,7 @@ PodStatusMap
 
 <div>
 
-<p>ConditionStatus defines the status of a condition (e.g. ready or degraded).</p>
+<p>ConditionStatus defines the status of a condition (e.g. ready, failed, pending or configuration error).</p>
 
 </div>
 
@@ -508,9 +513,9 @@ PodStatusMap
 
 </thead>
 
-<tbody><tr><td><p>&#34;Degraded&#34;</p></td>
+<tbody><tr><td><p>&#34;ConfigurationError&#34;</p></td>
 
-<td><p>ConditionDegraded defines that one or more components are in a degraded state.</p>
+<td><p>ConditionConfigurationError defines that there is a configuration error.</p>
 </td>
 
 </tr><tr><td><p>&#34;Failed&#34;</p></td>
@@ -520,7 +525,7 @@ PodStatusMap
 
 </tr><tr><td><p>&#34;Pending&#34;</p></td>
 
-<td><p>ConditionPending defines that one or more components are in a degraded state.</p>
+<td><p>ConditionPending defines that one or more components are in a pending state.</p>
 </td>
 
 </tr><tr><td><p>&#34;Ready&#34;</p></td>

--- a/internal/handlers/gateway/basedomain.go
+++ b/internal/handlers/gateway/basedomain.go
@@ -27,10 +27,9 @@ func GetOpenShiftBaseDomain(ctx context.Context, k8sClient client.Client) (strin
 		var clusterDNS configv1.DNS
 		if err := k8sClient.Get(ctx, key, &clusterDNS); err != nil {
 			if apierrors.IsNotFound(err) {
-				return "", &status.DegradedError{
-					Message: "Missing OpenShift ingresscontroller and cluster DNS configuration to read base domain",
+				return "", &status.ConfigurationError{
+					Message: "Missing OpenShift IngressController and cluster DNS configuration to read base domain",
 					Reason:  v1alpha1.ReasonCouldNotGetOpenShiftBaseDomain,
-					Requeue: true,
 				}
 			}
 			return "", kverrors.Wrap(err, "failed to lookup gateway base domain",

--- a/internal/handlers/gateway/oidc_secret.go
+++ b/internal/handlers/gateway/oidc_secret.go
@@ -30,10 +30,9 @@ func GetOIDCTenantSecrets(
 		key := client.ObjectKey{Name: tenant.OIDC.Secret.Name, Namespace: tempo.Namespace}
 		if err := k8sClient.Get(ctx, key, &gatewaySecret); err != nil {
 			if apierrors.IsNotFound(err) {
-				return nil, &status.DegradedError{
+				return nil, &status.ConfigurationError{
 					Message: fmt.Sprintf("Missing secrets for tenant %s", tenant.TenantName),
 					Reason:  v1alpha1.ReasonMissingGatewayTenantSecret,
-					Requeue: true,
 				}
 			}
 			return nil, fmt.Errorf("failed to lookup tempostack gateway tenant secret, name: %s, error: %w", key, err)
@@ -42,10 +41,9 @@ func GetOIDCTenantSecrets(
 		var ts *manifestutils.GatewayTenantOIDCSecret
 		ts, err := extractSecret(&gatewaySecret, tenant.TenantName)
 		if err != nil {
-			return nil, &status.DegradedError{
+			return nil, &status.ConfigurationError{
 				Message: "Invalid gateway tenant secret contents",
 				Reason:  v1alpha1.ReasonMissingGatewayTenantSecret,
-				Requeue: true,
 			}
 		}
 		tenantSecrets = append(tenantSecrets, ts)

--- a/internal/handlers/gateway/oidc_secret_test.go
+++ b/internal/handlers/gateway/oidc_secret_test.go
@@ -43,10 +43,9 @@ func TestGetTenantSecrets(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: &status.DegradedError{
+			expectedErr: &status.ConfigurationError{
 				Message: fmt.Sprintf("Missing secrets for tenant %s", "ups"),
 				Reason:  v1alpha1.ReasonMissingGatewayTenantSecret,
-				Requeue: true,
 			},
 		},
 		{
@@ -68,10 +67,9 @@ func TestGetTenantSecrets(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: &status.DegradedError{
+			expectedErr: &status.ConfigurationError{
 				Message: fmt.Sprintf("Missing secrets for tenant %s", "ups"),
 				Reason:  v1alpha1.ReasonMissingGatewayTenantSecret,
-				Requeue: true,
 			},
 		},
 		{

--- a/internal/status/components.go
+++ b/internal/status/components.go
@@ -88,7 +88,7 @@ func GetComponentsStatus(ctx context.Context, k StatusClient, s v1alpha1.TempoSt
 		len(cs.QueryFrontend[corev1.PodUnknown])
 
 	if failed != 0 || unknown != 0 {
-		s.Status.Conditions = FailedCondition(k, s)
+		s.Status.Conditions = FailedCondition(s)
 		return s.Status, nil
 	}
 
@@ -100,10 +100,10 @@ func GetComponentsStatus(ctx context.Context, k StatusClient, s v1alpha1.TempoSt
 		len(cs.QueryFrontend[corev1.PodPending])
 
 	if pending != 0 {
-		s.Status.Conditions = PendingCondition(k, s)
+		s.Status.Conditions = PendingCondition(s)
 		return s.Status, nil
 
 	}
-	s.Status.Conditions = ReadyCondition(k, s)
+	s.Status.Conditions = ReadyCondition(s)
 	return s.Status, nil
 }

--- a/internal/status/conditions.go
+++ b/internal/status/conditions.go
@@ -14,65 +14,55 @@ const (
 	messagePending = "Some TempoStack components are pending on dependencies"
 )
 
-// DegradedError contains information about why the managed TempoStack has an invalid configuration.
-type DegradedError struct {
-	Message string
+// ConfigurationError contains information about why the managed TempoStack has an invalid configuration.
+type ConfigurationError struct {
 	Reason  v1alpha1.ConditionReason
-	Requeue bool
+	Message string
 }
 
-func (e *DegradedError) Error() string {
-	return fmt.Sprintf("cluster degraded: %s", e.Message)
+func (e *ConfigurationError) Error() string {
+	return fmt.Sprintf("invalid configuration: %s", e.Message)
 }
 
 // ReadyCondition updates or appends the condition Ready to the TempoStack status conditions.
 // In addition it resets all other Status conditions to false.
-func ReadyCondition(k StatusClient, tempo v1alpha1.TempoStack) []metav1.Condition {
+func ReadyCondition(tempo v1alpha1.TempoStack) []metav1.Condition {
 	ready := metav1.Condition{
 		Type:    string(v1alpha1.ConditionReady),
 		Message: messageReady,
 		Reason:  string(v1alpha1.ReasonReady),
 	}
 
-	return updateCondition(tempo, ready)
+	return UpdateCondition(tempo, ready)
 }
 
 // FailedCondition updates or appends the condition Failed to the TempoStack status conditions.
 // In addition it resets all other Status conditions to false.
-func FailedCondition(k StatusClient, tempo v1alpha1.TempoStack) []metav1.Condition {
+func FailedCondition(tempo v1alpha1.TempoStack) []metav1.Condition {
 	failed := metav1.Condition{
 		Type:    string(v1alpha1.ConditionFailed),
 		Message: messageFailed,
 		Reason:  string(v1alpha1.ReasonFailedComponents),
 	}
 
-	return updateCondition(tempo, failed)
+	return UpdateCondition(tempo, failed)
 }
 
 // PendingCondition updates or appends the condition Pending to the TempoStack status conditions.
 // In addition it resets all other Status conditions to false.
-func PendingCondition(k StatusClient, tempo v1alpha1.TempoStack) []metav1.Condition {
+func PendingCondition(tempo v1alpha1.TempoStack) []metav1.Condition {
 	pending := metav1.Condition{
 		Type:    string(v1alpha1.ConditionPending),
 		Message: messagePending,
 		Reason:  string(v1alpha1.ReasonPendingComponents),
 	}
 
-	return updateCondition(tempo, pending)
+	return UpdateCondition(tempo, pending)
 }
 
-// DegradedCondition appends the condition Degraded to the TempoStack status conditions.
-func DegradedCondition(tempo v1alpha1.TempoStack, msg string, reason v1alpha1.ConditionReason) []metav1.Condition {
-	degraded := metav1.Condition{
-		Type:    string(v1alpha1.ConditionDegraded),
-		Message: msg,
-		Reason:  string(reason),
-	}
-
-	return updateCondition(tempo, degraded)
-}
-
-func updateCondition(tempo v1alpha1.TempoStack, condition metav1.Condition) []metav1.Condition {
+// UpdateCondition updates or appends the condition to the TempoStack status conditions.
+// In addition it resets all other status conditions to false.
+func UpdateCondition(tempo v1alpha1.TempoStack, condition metav1.Condition) []metav1.Condition {
 
 	for _, c := range tempo.Status.Conditions {
 		if c.Type == condition.Type &&

--- a/internal/status/conditions_test.go
+++ b/internal/status/conditions_test.go
@@ -71,8 +71,6 @@ func TestReadyCondition(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 
-			client := &statusClientStub{}
-
 			stack := v1alpha1.TempoStack{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "my-stack",
@@ -88,7 +86,7 @@ func TestReadyCondition(t *testing.T) {
 				},
 			}
 
-			conditions := ReadyCondition(client, stack)
+			conditions := ReadyCondition(stack)
 
 			// Don't care about time
 			now := metav1.Now()
@@ -162,8 +160,6 @@ func TestFailedCondition(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 
-			client := &statusClientStub{}
-
 			stack := v1alpha1.TempoStack{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "my-stack",
@@ -179,7 +175,7 @@ func TestFailedCondition(t *testing.T) {
 				},
 			}
 
-			conditions := FailedCondition(client, stack)
+			conditions := FailedCondition(stack)
 
 			// Don't care about time
 			now := metav1.Now()
@@ -253,8 +249,6 @@ func TestPendingCondition(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 
-			client := &statusClientStub{}
-
 			stack := v1alpha1.TempoStack{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "my-stack",
@@ -270,7 +264,7 @@ func TestPendingCondition(t *testing.T) {
 				},
 			}
 
-			conditions := PendingCondition(client, stack)
+			conditions := PendingCondition(stack)
 
 			// Don't care about time
 			now := metav1.Now()
@@ -283,9 +277,8 @@ func TestPendingCondition(t *testing.T) {
 	}
 }
 
-func TestDegradedCondition(t *testing.T) {
-
-	degradedMessage := "super degraded config"
+func TestConfigurationErrorCondition(t *testing.T) {
+	configErrorMessage := "some configuration error"
 	reasonString := "because I want"
 	reason := v1alpha1.ConditionReason(reasonString)
 
@@ -298,16 +291,16 @@ func TestDegradedCondition(t *testing.T) {
 			name: "When Existing PendingCondition set it to true",
 			inputConditions: []metav1.Condition{
 				{
-					Type:    string(v1alpha1.ConditionDegraded),
-					Message: degradedMessage,
+					Type:    string(v1alpha1.ConditionConfigurationError),
+					Message: configErrorMessage,
 					Reason:  reasonString,
 					Status:  metav1.ConditionFalse,
 				},
 			},
 			expectedConditions: []metav1.Condition{
 				{
-					Type:    string(v1alpha1.ConditionDegraded),
-					Message: degradedMessage,
+					Type:    string(v1alpha1.ConditionConfigurationError),
+					Message: configErrorMessage,
 					Reason:  reasonString,
 					Status:  metav1.ConditionTrue,
 				},
@@ -318,8 +311,8 @@ func TestDegradedCondition(t *testing.T) {
 			inputConditions: []metav1.Condition{},
 			expectedConditions: []metav1.Condition{
 				{
-					Type:    string(v1alpha1.ConditionDegraded),
-					Message: degradedMessage,
+					Type:    string(v1alpha1.ConditionConfigurationError),
+					Message: configErrorMessage,
 					Reason:  reasonString,
 					Status:  metav1.ConditionTrue,
 				},
@@ -329,16 +322,16 @@ func TestDegradedCondition(t *testing.T) {
 			name: "When existing PendingCondition and true do nothing",
 			expectedConditions: []metav1.Condition{
 				{
-					Type:    string(v1alpha1.ConditionDegraded),
-					Message: degradedMessage,
+					Type:    string(v1alpha1.ConditionConfigurationError),
+					Message: configErrorMessage,
 					Reason:  reasonString,
 					Status:  metav1.ConditionTrue,
 				},
 			},
 			inputConditions: []metav1.Condition{
 				{
-					Type:    string(v1alpha1.ConditionDegraded),
-					Message: degradedMessage,
+					Type:    string(v1alpha1.ConditionConfigurationError),
+					Message: configErrorMessage,
 					Reason:  reasonString,
 					Status:  metav1.ConditionTrue,
 				},
@@ -364,7 +357,11 @@ func TestDegradedCondition(t *testing.T) {
 				},
 			}
 
-			conditions := DegradedCondition(stack, degradedMessage, reason)
+			conditions := UpdateCondition(stack, metav1.Condition{
+				Type:    string(v1alpha1.ConditionConfigurationError),
+				Reason:  string(reason),
+				Message: configErrorMessage,
+			})
 
 			// Don't care about time
 			now := metav1.Now()
@@ -376,9 +373,9 @@ func TestDegradedCondition(t *testing.T) {
 	}
 }
 
-func TestDegradedError(t *testing.T) {
-	err := DegradedError{
+func TestConfigurationError(t *testing.T) {
+	err := ConfigurationError{
 		Message: "my message",
 	}
-	assert.Equal(t, "cluster degraded: my message", err.Error())
+	assert.Equal(t, "invalid configuration: my message", err.Error())
 }

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -20,8 +20,8 @@ var (
 	}, []string{"stack_namespace", "stack_name", "condition"})
 )
 
-// Refresh updates the status field with the tempo container image versions and updates the tempostack_status_condition metric.
-func Refresh(ctx context.Context, k StatusClient, tempo v1alpha1.TempoStack, status *v1alpha1.TempoStackStatus) (bool, error) {
+// Refresh updates the status field with the Tempo versions and updates the tempostack_status_condition metric.
+func Refresh(ctx context.Context, k StatusClient, tempo v1alpha1.TempoStack, status *v1alpha1.TempoStackStatus) error {
 	changed := tempo.DeepCopy()
 	changed.Status = *status
 
@@ -37,9 +37,9 @@ func Refresh(ctx context.Context, k StatusClient, tempo v1alpha1.TempoStack, sta
 
 	// Update all status condition metrics.
 	// In some cases not all status conditions are present in the status.Conditions list, for example:
-	// A TempoStack CR gets created with an invalid storage secret (creating a Degraded status condition).
+	// A TempoStack CR gets created with an invalid storage secret (creating an ConfigurationError status condition).
 	// Later this CR is deleted, a storage secret is created and a new TempoStack instance is created.
-	// Then this TempoStack instance doesn't have the degraded condition in the status.Conditions list.
+	// Then this TempoStack instance doesn't have the ConfigurationError condition in the status.Conditions list.
 	activeConditions := map[string]float64{}
 	for _, cond := range status.Conditions {
 		if cond.Status == metav1.ConditionTrue {
@@ -54,8 +54,8 @@ func Refresh(ctx context.Context, k StatusClient, tempo v1alpha1.TempoStack, sta
 
 	err := k.PatchStatus(ctx, changed, &tempo)
 	if err != nil {
-		return true, err
+		return err
 	}
 
-	return false, nil
+	return nil
 }

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -33,8 +33,7 @@ func TestRefreshPatchError(t *testing.T) {
 		},
 	}
 	s := &v1alpha1.TempoStackStatus{}
-	requeue, err := Refresh(context.Background(), c, stack, s)
-	assert.True(t, requeue)
+	err := Refresh(context.Background(), c, stack, s)
 	assert.Error(t, err)
 }
 
@@ -57,7 +56,7 @@ func TestRefreshNoError(t *testing.T) {
 	s := v1alpha1.TempoStackStatus{
 		OperatorVersion: "0.1.0",
 		TempoVersion:    "2.0",
-		Conditions:      ReadyCondition(c, stack),
+		Conditions:      ReadyCondition(stack),
 	}
 
 	c.PatchStatusStub = func(ctx context.Context, changed, original *v1alpha1.TempoStack) error {
@@ -66,7 +65,6 @@ func TestRefreshNoError(t *testing.T) {
 		return nil
 	}
 
-	requeue, err := Refresh(context.Background(), c, stack, &s)
-	assert.False(t, requeue)
+	err := Refresh(context.Background(), c, stack, &s)
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
* rename Degraded status condition to ConfigurationError to cleary indicate the type of error
* return `reconcile.TerminalError` for terminal errors requiring human intervention (e.g. ConfigurationErrors)
* add a new status reason `FailedReconciliation` for generic errors, e.g. permission errors during reconciliation, and show the error message
* collect all errors during applying and pruning objects
* remove `requeue` return value from `status.Refresh()` because it was always true if error was set, and therefore redundant
* drop unused `StatusClient` from `status.*Condition()`

Resolves: #488