### PR TITLE
Add new reset Makefile target, cleanup GitHub Action workflows

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -27,8 +27,6 @@ jobs:
 
       - name: "basic checks"
         run: make ci
-        env:
-          IMG_PREFIX: ghcr.io/grafana/tempo-operator  # the ensure-generate-is-noop Makefile target should still work in forked repositories
 
       - name: "upload coverage report"
         uses: codecov/codecov-action@v3

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -20,10 +20,6 @@ jobs:
       - name: Describe the current state
         run: git describe --tags --always
 
-      - name: Set env vars for the job
-        run: |
-          echo "OPERATOR_VERSION=$(git describe --tags --always | sed 's/^v//')" >> $GITHUB_ENV
-
       - name: Docker meta
         id: docker_meta
         uses: docker/metadata-action@v4.6.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,10 @@ The project currently uses the [Grafana Slack](https://grafana.slack.com):
 This is a rough outline of what a contributor's workflow looks like:
 
 - Create a topic branch from where you want to base your work (usually `main`).
+- Update the code and test the changes on your local cluster:
+```
+IMG_PREFIX=docker.io/${USER} OPERATOR_VERSION=$(date +%s).0.0 make docker-build docker-push deploy reset
+```
 - Make commits of logical units.
 - Push your changes to a topic branch in your fork of the repository.
 - Make sure the tests pass, and add any new tests as appropriate.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This is a Kubernetes operator for [Grafana Tempo](https://github.com/grafana/tem
 2. Build and deploy operator:
 
 ```bash
-IMG_PREFIX=docker.io/${USER} OPERATOR_VERSION=$(date +%s) make generate bundle docker-build docker-push deploy
+IMG_PREFIX=docker.io/${USER} OPERATOR_VERSION=$(date +%s).0.0 make docker-build docker-push deploy
 ``` 
 
 3. Create a secret for minio in the namespace you are using:


### PR DESCRIPTION
For local development, the following invocation:
```
IMG_PREFIX=docker.io/${USER} OPERATOR_VERSION=$(date +%s).0.0 make docker-build docker-push deploy reset
```

Builds and deploys the operator to the current cluster and resets all generated files.
Resolves: #62