### PR TITLE
Validate if createServiceMonitors is enabled when enabling createPrometheusRules in the webhook

### DIFF
--- a/.chloggen/validate_createPrometheusRules.yaml
+++ b/.chloggen/validate_createPrometheusRules.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, github action)
+component: operator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Validate if createServiceMonitors is enabled when enabling createPrometheusRules in the webhook
+
+# One or more tracking issues related to the change
+issues: [510]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/apis/tempo/v1alpha1/tempostack_webhook.go
+++ b/apis/tempo/v1alpha1/tempostack_webhook.go
@@ -295,6 +295,13 @@ func (v *validator) validateObservability(tempo TempoStack) field.ErrorList {
 			)}
 	}
 
+	if tempo.Spec.Observability.Metrics.CreatePrometheusRules && !tempo.Spec.Observability.Metrics.CreateServiceMonitors {
+		return field.ErrorList{
+			field.Invalid(metricsBase.Child("createPrometheusRules"), tempo.Spec.Observability.Metrics.CreatePrometheusRules,
+				"the Prometheus rules alert based on collected metrics, therefore the createServiceMonitors feature must be enabled when enabling the createPrometheusRules feature",
+			)}
+	}
+
 	tracingBase := observabilityBase.Child("tracing")
 	if tempo.Spec.Observability.Tracing.SamplingFraction == "" {
 		return nil

--- a/apis/tempo/v1alpha1/tempostack_webhook_test.go
+++ b/apis/tempo/v1alpha1/tempostack_webhook_test.go
@@ -1018,7 +1018,7 @@ func TestValidatorObservabilityTracingConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "createServiceMonitors enabled and serviceMonitor feature gate set",
+			name: "createServiceMonitors enabled and prometheusOperator feature gate set",
 			input: TempoStack{
 				Spec: TempoStackSpec{
 					Observability: ObservabilitySpec{
@@ -1036,7 +1036,7 @@ func TestValidatorObservabilityTracingConfig(t *testing.T) {
 			expected: nil,
 		},
 		{
-			name: "createServiceMonitors enabled but serviceMonitor feature gate not set",
+			name: "createServiceMonitors enabled but prometheusOperator feature gate not set",
 			input: TempoStack{
 				Spec: TempoStackSpec{
 					Observability: ObservabilitySpec{
@@ -1055,7 +1055,7 @@ func TestValidatorObservabilityTracingConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "enableAlerts enabled but enableAlerts feature gate not set",
+			name: "createPrometheusRules enabled but prometheusOperator feature gate not set",
 			input: TempoStack{
 				Spec: TempoStackSpec{
 					Observability: ObservabilitySpec{
@@ -1074,7 +1074,26 @@ func TestValidatorObservabilityTracingConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "enableAlerts enabled but enableAlerts feature gate set",
+			name: "createPrometheusRules and createServiceMonitors enabled and prometheusOperator feature gate set",
+			input: TempoStack{
+				Spec: TempoStackSpec{
+					Observability: ObservabilitySpec{
+						Metrics: MetricsConfigSpec{
+							CreateServiceMonitors: true,
+							CreatePrometheusRules: true,
+						},
+					},
+				},
+			},
+			ctrlConfig: v1alpha1.ProjectConfig{
+				Gates: v1alpha1.FeatureGates{
+					PrometheusOperator: true,
+				},
+			},
+			expected: nil,
+		},
+		{
+			name: "createPrometheusRules enabled but createServiceMonitors not enabled",
 			input: TempoStack{
 				Spec: TempoStackSpec{
 					Observability: ObservabilitySpec{
@@ -1089,7 +1108,13 @@ func TestValidatorObservabilityTracingConfig(t *testing.T) {
 					PrometheusOperator: true,
 				},
 			},
-			expected: nil,
+			expected: field.ErrorList{
+				field.Invalid(
+					metricsBase.Child("createPrometheusRules"),
+					true,
+					"the Prometheus rules alert based on collected metrics, therefore the createServiceMonitors feature must be enabled when enabling the createPrometheusRules feature",
+				),
+			},
 		},
 		{
 			name: "sampling fraction not a float",


### PR DESCRIPTION
Validate if createServiceMonitors is enabled when enabling createPrometheusRules in the webhook