### PR TITLE
Publish API docs only as a md file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -450,10 +450,6 @@ api-docs: docs/operator/api.md docs/operator/feature-gates.md
 TYPES_TARGET := $(shell find apis/tempo -type f -iname "*_types.go")
 docs/operator/api.md: $(TYPES_TARGET) gen-crd-api-reference-docs
 	$(GEN_CRD) -api-dir "github.com/grafana/tempo-operator/apis/tempo/" -config "$(PWD)/config/docs/config.json" -template-dir "$(PWD)/config/docs/templates" -out-file "$(PWD)/$@"
-	sed -i 's/+docs:/  docs:/' $@
-	sed -i 's/+parent:/    parent:/' $@
-	sed -i 's/##/\n##/' $@
-	sed -i 's/+newline/\n/' $@
 
 
 FEATURE_GATES_TARGET := $(shell find apis/config -type f -iname "*_types.go")

--- a/config/docs/templates/pkg.tpl
+++ b/config/docs/templates/pkg.tpl
@@ -1,16 +1,4 @@
 {{ define "packages" }}
----
-title: "API"
-description: "Generated API docs for the Tempo Operator"
-lead: ""
-draft: false
-images: []
-menu:
-+docs:
-+parent: "operator"
-weight: 1000
-toc: true
----
 
 This Document contains the types introduced by the Tempo Operator to be consumed by users.
 

--- a/docs/operator/api.md
+++ b/docs/operator/api.md
@@ -13,7 +13,6 @@ This Document contains the types introduced by the Tempo Operator to be consumed
 
 <b>Resource Types:</b>
 
-
 ## AuthenticationSpec { #tempo-grafana-com-v1alpha1-AuthenticationSpec }
 
 <p>
@@ -117,7 +116,6 @@ OIDCSpec
 </tbody>
 </table>
 
-
 ## AuthorizationSpec { #tempo-grafana-com-v1alpha1-AuthorizationSpec }
 
 <p>
@@ -205,7 +203,6 @@ configuration per tenant for tempo Gateway component.</p>
 
 </tbody>
 </table>
-
 
 ## ComponentStatus { #tempo-grafana-com-v1alpha1-ComponentStatus }
 
@@ -402,7 +399,6 @@ PodStatusMap
 </tbody>
 </table>
 
-
 ## ConditionReason { #tempo-grafana-com-v1alpha1-ConditionReason }
 
 (<code>string</code> alias)
@@ -475,7 +471,6 @@ PodStatusMap
 </tr></tbody>
 </table>
 
-
 ## ConditionStatus { #tempo-grafana-com-v1alpha1-ConditionStatus }
 
 (<code>string</code> alias)
@@ -522,7 +517,6 @@ PodStatusMap
 
 </tr></tbody>
 </table>
-
 
 ## Defaulter { #tempo-grafana-com-v1alpha1-Defaulter }
 
@@ -573,7 +567,6 @@ Feature Gates.ProjectConfig
 
 </tbody>
 </table>
-
 
 ## IngestionLimitSpec { #tempo-grafana-com-v1alpha1-IngestionLimitSpec }
 
@@ -699,7 +692,6 @@ int
 
 </tbody>
 </table>
-
 
 ## IngressSpec { #tempo-grafana-com-v1alpha1-IngressSpec }
 
@@ -860,7 +852,6 @@ RouteSpec
 </tbody>
 </table>
 
-
 ## IngressType { #tempo-grafana-com-v1alpha1-IngressType }
 
 (<code>string</code> alias)
@@ -908,7 +899,6 @@ RouteSpec
 
 </tr></tbody>
 </table>
-
 
 ## JaegerQuerySpec { #tempo-grafana-com-v1alpha1-JaegerQuerySpec }
 
@@ -992,7 +982,6 @@ IngressSpec
 
 </tbody>
 </table>
-
 
 ## LimitSpec { #tempo-grafana-com-v1alpha1-LimitSpec }
 
@@ -1081,7 +1070,6 @@ RateLimitSpec
 </tbody>
 </table>
 
-
 ## ManagementStateType { #tempo-grafana-com-v1alpha1-ManagementStateType }
 
 (<code>string</code> alias)
@@ -1126,7 +1114,6 @@ reconciled by the operator.</p>
 
 </tr></tbody>
 </table>
-
 
 ## MetricsConfigSpec { #tempo-grafana-com-v1alpha1-MetricsConfigSpec }
 
@@ -1207,7 +1194,6 @@ bool
 </tbody>
 </table>
 
-
 ## ModeType { #tempo-grafana-com-v1alpha1-ModeType }
 
 (<code>string</code> alias)
@@ -1252,7 +1238,6 @@ using an in-process OpenPolicyAgent Rego authorizer.</p>
 
 </tr></tbody>
 </table>
-
 
 ## OIDCSpec { #tempo-grafana-com-v1alpha1-OIDCSpec }
 
@@ -1406,7 +1391,6 @@ string
 </tbody>
 </table>
 
-
 ## ObjectStorageSecretSpec { #tempo-grafana-com-v1alpha1-ObjectStorageSecretSpec }
 
 <p>
@@ -1486,7 +1470,6 @@ string
 </tbody>
 </table>
 
-
 ## ObjectStorageSecretType { #tempo-grafana-com-v1alpha1-ObjectStorageSecretType }
 
 (<code>string</code> alias)
@@ -1534,7 +1517,6 @@ string
 
 </tr></tbody>
 </table>
-
 
 ## ObjectStorageSpec { #tempo-grafana-com-v1alpha1-ObjectStorageSpec }
 
@@ -1623,7 +1605,6 @@ Name of a secret in the same namespace as the tempo TempoStack custom resource.<
 </tbody>
 </table>
 
-
 ## ObjectStorageTLSSpec { #tempo-grafana-com-v1alpha1-ObjectStorageTLSSpec }
 
 <p>
@@ -1680,7 +1661,6 @@ It needs to be in the same namespace as the Tempo custom resource.</p>
 
 </tbody>
 </table>
-
 
 ## ObservabilitySpec { #tempo-grafana-com-v1alpha1-ObservabilitySpec }
 
@@ -1769,7 +1749,6 @@ TracingConfigSpec
 </tbody>
 </table>
 
-
 ## PermissionType { #tempo-grafana-com-v1alpha1-PermissionType }
 
 (<code>string</code> alias)
@@ -1813,7 +1792,6 @@ TracingConfigSpec
 </tr></tbody>
 </table>
 
-
 ## PodStatusMap { #tempo-grafana-com-v1alpha1-PodStatusMap }
 
 (<code>map[k8s.io/api/core/v1.PodPhase][]string</code> alias)
@@ -1829,7 +1807,6 @@ TracingConfigSpec
 <p>PodStatusMap defines the type for mapping pod status to pod name.</p>
 
 </div>
-
 
 ## QueryLimit { #tempo-grafana-com-v1alpha1-QueryLimit }
 
@@ -1940,7 +1917,6 @@ If this value is not set, then spec.search.maxDuration is used.</p>
 </tbody>
 </table>
 
-
 ## RateLimitSpec { #tempo-grafana-com-v1alpha1-RateLimitSpec }
 
 <p>
@@ -2028,7 +2004,6 @@ QueryLimit
 </tbody>
 </table>
 
-
 ## Resources { #tempo-grafana-com-v1alpha1-Resources }
 
 <p>
@@ -2092,7 +2067,6 @@ See <a href="http://github.com/grafana/tempo/issues/1540">http://github.com/graf
 </tbody>
 </table>
 
-
 ## RetentionConfig { #tempo-grafana-com-v1alpha1-RetentionConfig }
 
 <p>
@@ -2154,7 +2128,6 @@ default: value is 48h.</p>
 
 </tbody>
 </table>
-
 
 ## RetentionSpec { #tempo-grafana-com-v1alpha1-RetentionSpec }
 
@@ -2242,7 +2215,6 @@ RetentionConfig
 
 </tbody>
 </table>
-
 
 ## RoleBindingsSpec { #tempo-grafana-com-v1alpha1-RoleBindingsSpec }
 
@@ -2337,7 +2309,6 @@ string
 
 </tbody>
 </table>
-
 
 ## RoleSpec { #tempo-grafana-com-v1alpha1-RoleSpec }
 
@@ -2452,7 +2423,6 @@ string
 </tbody>
 </table>
 
-
 ## RouteSpec { #tempo-grafana-com-v1alpha1-RouteSpec }
 
 <p>
@@ -2512,7 +2482,6 @@ TLSRouteTerminationType
 
 </tbody>
 </table>
-
 
 ## SearchSpec { #tempo-grafana-com-v1alpha1-SearchSpec }
 
@@ -2622,7 +2591,6 @@ The default value of 0 disables this limit.</p>
 </tbody>
 </table>
 
-
 ## Subject { #tempo-grafana-com-v1alpha1-Subject }
 
 <p>
@@ -2698,7 +2666,6 @@ SubjectKind
 </tbody>
 </table>
 
-
 ## SubjectKind { #tempo-grafana-com-v1alpha1-SubjectKind }
 
 (<code>string</code> alias)
@@ -2741,7 +2708,6 @@ SubjectKind
 
 </tr></tbody>
 </table>
-
 
 ## TLSRouteTerminationType { #tempo-grafana-com-v1alpha1-TLSRouteTerminationType }
 
@@ -2798,7 +2764,6 @@ and re-encrypt using a new certificate.</p>
 
 </tr></tbody>
 </table>
-
 
 ## TempoComponentSpec { #tempo-grafana-com-v1alpha1-TempoComponentSpec }
 
@@ -2905,7 +2870,6 @@ map[string]string
 
 </tbody>
 </table>
-
 
 ## TempoGatewaySpec { #tempo-grafana-com-v1alpha1-TempoGatewaySpec }
 
@@ -3016,7 +2980,6 @@ IngressSpec
 </tbody>
 </table>
 
-
 ## TempoQueryFrontendSpec { #tempo-grafana-com-v1alpha1-TempoQueryFrontendSpec }
 
 <p>
@@ -3106,7 +3069,6 @@ JaegerQuerySpec
 
 </tbody>
 </table>
-
 
 ## TempoStack { #tempo-grafana-com-v1alpha1-TempoStack }
 
@@ -3207,7 +3169,6 @@ TempoStackSpec
 
 </tbody>
 </table>
-
 
 ## TempoStackSpec { #tempo-grafana-com-v1alpha1-TempoStackSpec }
 
@@ -3605,7 +3566,6 @@ ObservabilitySpec
 </tbody>
 </table>
 
-
 ## TempoStackStatus { #tempo-grafana-com-v1alpha1-TempoStackStatus }
 
 <p>
@@ -3762,7 +3722,6 @@ per component.</p>
 
 </tbody>
 </table>
-
 
 ## TempoTemplateSpec { #tempo-grafana-com-v1alpha1-TempoTemplateSpec }
 
@@ -3960,7 +3919,6 @@ TempoGatewaySpec
 </tbody>
 </table>
 
-
 ## TenantSecretSpec { #tempo-grafana-com-v1alpha1-TenantSecretSpec }
 
 <p>
@@ -4017,7 +3975,6 @@ string
 
 </tbody>
 </table>
-
 
 ## TenantsSpec { #tempo-grafana-com-v1alpha1-TenantsSpec }
 
@@ -4132,7 +4089,6 @@ AuthorizationSpec
 </tbody>
 </table>
 
-
 ## TracingConfigSpec { #tempo-grafana-com-v1alpha1-TracingConfigSpec }
 
 <p>
@@ -4214,6 +4170,5 @@ string
 
 <hr/>
 
-
-
++newline
 

--- a/docs/operator/api.md
+++ b/docs/operator/api.md
@@ -1,17 +1,4 @@
 
----
-title: "API"
-description: "Generated API docs for the Tempo Operator"
-lead: ""
-draft: false
-images: []
-menu:
-  docs:
-    parent: "operator"
-weight: 1000
-toc: true
----
-
 This Document contains the types introduced by the Tempo Operator to be consumed by users.
 
 > This page is automatically generated with `gen-crd-api-reference-docs`.

--- a/docs/operator/feature-gates.md
+++ b/docs/operator/feature-gates.md
@@ -1,17 +1,4 @@
 
----
-title: "Feature Gates"
-description: "Generated API docs for the Tempo Operator"
-lead: ""
-draft: false
-images: []
-menu:
-  docs:
-    parent: "operator"
-weight: 1000
-toc: true
----
-
 This Document contains the types introduced by the Tempo Operator to be consumed by users.
 
 > This page is automatically generated with `gen-crd-api-reference-docs`.


### PR DESCRIPTION
The API docs will be published only as .md files and referenced from https://grafana.com/docs/tempo/next/setup/operator/ 