### PR TITLE
Remove command from pod spec in CSV

### DIFF
--- a/bundle/community/manifests/tempo-operator.clusterserviceversion.yaml
+++ b/bundle/community/manifests/tempo-operator.clusterserviceversion.yaml
@@ -33,7 +33,7 @@ metadata:
     capabilities: Deep Insights
     categories: Logging & Tracing
     containerImage: ghcr.io/grafana/tempo-operator/tempo-operator
-    createdAt: "2023-07-17T12:16:41Z"
+    createdAt: "2023-07-28T11:58:59Z"
     description: Create and manage deployments of Tempo, a high-scale distributed
       tracing backend.
     operators.operatorframework.io/builder: operator-sdk-v1.27.0
@@ -720,8 +720,6 @@ spec:
               - args:
                 - start
                 - --config=controller_manager_config.yaml
-                command:
-                - /manager
                 image: ghcr.io/grafana/tempo-operator/tempo-operator:v0.2.0
                 livenessProbe:
                   httpGet:

--- a/bundle/openshift/manifests/tempo-operator.clusterserviceversion.yaml
+++ b/bundle/openshift/manifests/tempo-operator.clusterserviceversion.yaml
@@ -33,7 +33,7 @@ metadata:
     capabilities: Deep Insights
     categories: Logging & Tracing
     containerImage: ghcr.io/grafana/tempo-operator/tempo-operator
-    createdAt: "2023-07-17T12:15:00Z"
+    createdAt: "2023-07-28T11:58:58Z"
     description: Create and manage deployments of Tempo, a high-scale distributed
       tracing backend.
     operators.operatorframework.io/builder: operator-sdk-v1.27.0
@@ -720,8 +720,6 @@ spec:
               - args:
                 - start
                 - --config=controller_manager_config.yaml
-                command:
-                - /manager
                 image: ghcr.io/grafana/tempo-operator/tempo-operator:v0.2.0
                 livenessProbe:
                   httpGet:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -34,12 +34,10 @@ spec:
         # seccompProfile:
         #   type: RuntimeDefault
       containers:
-      - command:
-        - /manager
+      - name: manager
+        image: controller:latest
         args:
         - --leader-elect
-        image: controller:latest
-        name: manager
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:


### PR DESCRIPTION
The command is redundant, as it is specified in the ENTRYPOINT of the Dockerfile.