### PR TITLE
Remove operator ServiceMonitor and PrometheusRule when operator deployment is removed

### DIFF
--- a/.chloggen/prune_operator_manifests.yaml
+++ b/.chloggen/prune_operator_manifests.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, github action)
+component: operator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove operator ServiceMonitor and PrometheusRule when operator deployment is removed
+
+# One or more tracking issues related to the change
+issues: [536]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |

--- a/bundle/community/manifests/tempo-operator.clusterserviceversion.yaml
+++ b/bundle/community/manifests/tempo-operator.clusterserviceversion.yaml
@@ -586,6 +586,12 @@ spec:
           - update
           - watch
         - apiGroups:
+          - apps
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
           - config.openshift.io
           resources:
           - dnses

--- a/bundle/openshift/manifests/tempo-operator.clusterserviceversion.yaml
+++ b/bundle/openshift/manifests/tempo-operator.clusterserviceversion.yaml
@@ -586,6 +586,12 @@ spec:
           - update
           - watch
         - apiGroups:
+          - apps
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
           - config.openshift.io
           resources:
           - dnses

--- a/cmd/start/main.go
+++ b/cmd/start/main.go
@@ -123,6 +123,7 @@ func addDependencies(mgr ctrl.Manager, ctrlConfig configv1alpha1.ProjectConfig, 
 	err = mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
 		reconciler := &controllers.OperatorReconciler{
 			Client: mgr.GetClient(),
+			Scheme: mgr.GetScheme(),
 		}
 		return reconciler.Reconcile(ctx, ctrlConfig)
 	}))

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -35,6 +35,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apps
+  resources:
+  - deployments/finalizers
+  verbs:
+  - update
+- apiGroups:
   - config.openshift.io
   resources:
   - dnses

--- a/controllers/tempo/operator_controller_test.go
+++ b/controllers/tempo/operator_controller_test.go
@@ -57,6 +57,7 @@ func TestReconcileOperator(t *testing.T) {
 
 	reconciler := OperatorReconciler{
 		Client: k8sClient,
+		Scheme: testScheme,
 	}
 	err := reconciler.Reconcile(context.Background(), configv1alpha1.ProjectConfig{
 		Gates: configv1alpha1.FeatureGates{

--- a/controllers/tempo/tempostack_controller.go
+++ b/controllers/tempo/tempostack_controller.go
@@ -43,6 +43,7 @@ type TempoStackReconciler struct {
 
 // +kubebuilder:rbac:groups="",resources=services;configmaps;serviceaccounts;secrets;pods,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps,resources=deployments;statefulsets,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=apps,resources=deployments/finalizers,verbs=update
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings;clusterroles,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=route.openshift.io,resources=routes;routes/custom-host,verbs=get;list;watch;create;update;delete


### PR DESCRIPTION
Remove operator ServiceMonitor and PrometheusRule when operator deployment is removed, by setting the owner references on the operator manifests.