### PR TITLE
Always render the PodStatusMaps in the CR status

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,11 @@ This is a rough outline of what a contributor's workflow looks like:
 ```
 IMG_PREFIX=docker.io/${USER} OPERATOR_VERSION=$(date +%s).0.0 make docker-build docker-push deploy reset
 ```
+- On OpenShift, you can install the operator via OLM:
+```
+kubectl create namespace tempo-operator-system
+IMG_PREFIX=docker.io/${USER} OPERATOR_VERSION=$(date +%s).0.0 BUNDLE_VARIANT=openshift make docker-build docker-push bundle bundle-build bundle-push olm-deploy reset
+```
 - Make commits of logical units.
 - Push your changes to a topic branch in your fork of the repository.
 - Make sure the tests pass, and add any new tests as appropriate.

--- a/apis/tempo/v1alpha1/tempostack_types.go
+++ b/apis/tempo/v1alpha1/tempostack_types.go
@@ -180,42 +180,42 @@ type ComponentStatus struct {
 	// +optional
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=status,xDescriptors="urn:alm:descriptor:com.tectonic.ui:podStatuses",displayName="Compactor",order=5
-	Compactor PodStatusMap `json:"compactor,omitempty"`
+	Compactor PodStatusMap `json:"compactor"`
 
 	// Distributor is a map to the per pod status of the distributor deployment
 	//
 	// +optional
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=status,xDescriptors="urn:alm:descriptor:com.tectonic.ui:podStatuses",displayName="Distributor",order=1
-	Distributor PodStatusMap `json:"distributor,omitempty"`
+	Distributor PodStatusMap `json:"distributor"`
 
 	// Ingester is a map to the per pod status of the ingester statefulset
 	//
 	// +optional
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=status,xDescriptors="urn:alm:descriptor:com.tectonic.ui:podStatuses",displayName="Ingester",order=2
-	Ingester PodStatusMap `json:"ingester,omitempty"`
+	Ingester PodStatusMap `json:"ingester"`
 
 	// Querier is a map to the per pod status of the querier deployment
 	//
 	// +optional
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=status,xDescriptors="urn:alm:descriptor:com.tectonic.ui:podStatuses",displayName="Querier",order=3
-	Querier PodStatusMap `json:"querier,omitempty"`
+	Querier PodStatusMap `json:"querier"`
 
 	// QueryFrontend is a map to the per pod status of the query frontend deployment
 	//
 	// +optional
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=status,xDescriptors="urn:alm:descriptor:com.tectonic.ui:podStatuses",displayName="Query Frontend",order=4
-	QueryFrontend PodStatusMap `json:"queryFrontend,omitempty"`
+	QueryFrontend PodStatusMap `json:"queryFrontend"`
 
 	// Gateway is a map to the per pod status of the query frontend deployment
 	//
 	// +optional
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=status,xDescriptors="urn:alm:descriptor:com.tectonic.ui:podStatuses",displayName="Query Frontend",order=4
-	Gateway PodStatusMap `json:"gateway,omitempty"`
+	Gateway PodStatusMap `json:"gateway"`
 }
 
 // TempoStackStatus defines the observed state of TempoStack.


### PR DESCRIPTION
The path specified in `statusDescriptors` in the CSV must be always present, otherwise a warning is shown in the UI.

This fixes the following issue in case no pods were created due to a configuration error: 
![Bildschirmfoto vom 2023-08-04 13-41-06](https://github.com/grafana/tempo-operator/assets/538011/fffd8746-46f1-4012-b154-2afcbd713ca2)

I also added instructions to deploy the operator via OLM in the `CONTRIBUTING.md` file.