### PR TITLE
Disable mTLS by default, to allow connections from Grafana to the query-frontend

### DIFF
--- a/.chloggen/disable_mtls.yaml
+++ b/.chloggen/disable_mtls.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, github action)
+component: operator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Disable mTLS by default, to allow connections from Grafana to the query-frontend component
+
+# One or more tracking issues related to the change
+issues: [552]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |

--- a/bundle/community/manifests/tempo-operator-manager-config_v1_configmap.yaml
+++ b/bundle/community/manifests/tempo-operator-manager-config_v1_configmap.yaml
@@ -33,11 +33,11 @@ data:
         openshiftRoute: false
         servingCertsService: false
       prometheusOperator: false
-      httpEncryption: true
-      grpcEncryption: true
+      httpEncryption: false
+      grpcEncryption: false
       tlsProfile: Modern
       builtInCertManagement:
-        enabled: true
+        enabled: false
         # CA certificate validity: 5 years
         caValidity: 43830h
         # CA certificate refresh at 80% of validity

--- a/bundle/community/manifests/tempo-operator.clusterserviceversion.yaml
+++ b/bundle/community/manifests/tempo-operator.clusterserviceversion.yaml
@@ -33,7 +33,7 @@ metadata:
     capabilities: Deep Insights
     categories: Logging & Tracing
     containerImage: ghcr.io/grafana/tempo-operator/tempo-operator
-    createdAt: "2023-08-02T03:01:20Z"
+    createdAt: "2023-08-16T14:00:23Z"
     description: Create and manage deployments of Tempo, a high-scale distributed
       tracing backend.
     operators.operatorframework.io/builder: operator-sdk-v1.27.0

--- a/bundle/openshift/manifests/tempo-operator-manager-config_v1_configmap.yaml
+++ b/bundle/openshift/manifests/tempo-operator-manager-config_v1_configmap.yaml
@@ -33,11 +33,11 @@ data:
         openshiftRoute: true
         servingCertsService: true
       prometheusOperator: true
-      httpEncryption: true
-      grpcEncryption: true
+      httpEncryption: false
+      grpcEncryption: false
       tlsProfile: Modern
       builtInCertManagement:
-        enabled: true
+        enabled: false
         # CA certificate validity: 5 years
         caValidity: 43830h
         # CA certificate refresh at 80% of validity

--- a/bundle/openshift/manifests/tempo-operator.clusterserviceversion.yaml
+++ b/bundle/openshift/manifests/tempo-operator.clusterserviceversion.yaml
@@ -33,7 +33,7 @@ metadata:
     capabilities: Deep Insights
     categories: Logging & Tracing
     containerImage: ghcr.io/grafana/tempo-operator/tempo-operator
-    createdAt: "2023-08-02T03:01:18Z"
+    createdAt: "2023-08-16T14:00:21Z"
     description: Create and manage deployments of Tempo, a high-scale distributed
       tracing backend.
     operators.operatorframework.io/builder: operator-sdk-v1.27.0

--- a/config/overlays/community/controller_manager_config.yaml
+++ b/config/overlays/community/controller_manager_config.yaml
@@ -30,11 +30,11 @@ featureGates:
     openshiftRoute: false
     servingCertsService: false
   prometheusOperator: false
-  httpEncryption: true
-  grpcEncryption: true
+  httpEncryption: false
+  grpcEncryption: false
   tlsProfile: Modern
   builtInCertManagement:
-    enabled: true
+    enabled: false
     # CA certificate validity: 5 years
     caValidity: 43830h
     # CA certificate refresh at 80% of validity

--- a/config/overlays/openshift/controller_manager_config.yaml
+++ b/config/overlays/openshift/controller_manager_config.yaml
@@ -30,11 +30,11 @@ featureGates:
     openshiftRoute: true
     servingCertsService: true
   prometheusOperator: true
-  httpEncryption: true
-  grpcEncryption: true
+  httpEncryption: false
+  grpcEncryption: false
   tlsProfile: Modern
   builtInCertManagement:
-    enabled: true
+    enabled: false
     # CA certificate validity: 5 years
     caValidity: 43830h
     # CA certificate refresh at 80% of validity

--- a/tests/e2e-openshift/monitoring/02-assert.yaml
+++ b/tests/e2e-openshift/monitoring/02-assert.yaml
@@ -141,20 +141,7 @@ spec:
       - __meta_kubernetes_namespace
       - __meta_kubernetes_service_label_app_kubernetes_io_component
       targetLabel: job
-    scheme: https
-    tlsConfig:
-      ca:
-        configMap:
-          key: service-ca.crt
-          name: tempo-tempostack-ca-bundle
-      cert:
-        secret:
-          key: tls.crt
-          name: tempo-tempostack-compactor-mtls
-      keySecret:
-        key: tls.key
-        name: tempo-tempostack-compactor-mtls
-      serverName: tempo-tempostack-compactor.kuttl-monitoring.svc.cluster.local
+    scheme: http
   namespaceSelector:
     matchNames:
     - kuttl-monitoring
@@ -190,20 +177,7 @@ spec:
       - __meta_kubernetes_namespace
       - __meta_kubernetes_service_label_app_kubernetes_io_component
       targetLabel: job
-    scheme: https
-    tlsConfig:
-      ca:
-        configMap:
-          key: service-ca.crt
-          name: tempo-tempostack-ca-bundle
-      cert:
-        secret:
-          key: tls.crt
-          name: tempo-tempostack-distributor-mtls
-      keySecret:
-        key: tls.key
-        name: tempo-tempostack-distributor-mtls
-      serverName: tempo-tempostack-distributor.kuttl-monitoring.svc.cluster.local
+    scheme: http
   namespaceSelector:
     matchNames:
     - kuttl-monitoring
@@ -239,20 +213,7 @@ spec:
       - __meta_kubernetes_namespace
       - __meta_kubernetes_service_label_app_kubernetes_io_component
       targetLabel: job
-    scheme: https
-    tlsConfig:
-      ca:
-        configMap:
-          key: service-ca.crt
-          name: tempo-tempostack-ca-bundle
-      cert:
-        secret:
-          key: tls.crt
-          name: tempo-tempostack-ingester-mtls
-      keySecret:
-        key: tls.key
-        name: tempo-tempostack-ingester-mtls
-      serverName: tempo-tempostack-ingester.kuttl-monitoring.svc.cluster.local
+    scheme: http
   namespaceSelector:
     matchNames:
     - kuttl-monitoring
@@ -288,20 +249,7 @@ spec:
       - __meta_kubernetes_namespace
       - __meta_kubernetes_service_label_app_kubernetes_io_component
       targetLabel: job
-    scheme: https
-    tlsConfig:
-      ca:
-        configMap:
-          key: service-ca.crt
-          name: tempo-tempostack-ca-bundle
-      cert:
-        secret:
-          key: tls.crt
-          name: tempo-tempostack-querier-mtls
-      keySecret:
-        key: tls.key
-        name: tempo-tempostack-querier-mtls
-      serverName: tempo-tempostack-querier.kuttl-monitoring.svc.cluster.local
+    scheme: http
   namespaceSelector:
     matchNames:
     - kuttl-monitoring
@@ -337,20 +285,7 @@ spec:
       - __meta_kubernetes_namespace
       - __meta_kubernetes_service_label_app_kubernetes_io_component
       targetLabel: job
-    scheme: https
-    tlsConfig:
-      ca:
-        configMap:
-          key: service-ca.crt
-          name: tempo-tempostack-ca-bundle
-      cert:
-        secret:
-          key: tls.crt
-          name: tempo-tempostack-query-frontend-mtls
-      keySecret:
-        key: tls.key
-        name: tempo-tempostack-query-frontend-mtls
-      serverName: tempo-tempostack-query-frontend.kuttl-monitoring.svc.cluster.local
+    scheme: http
   namespaceSelector:
     matchNames:
     - kuttl-monitoring

--- a/tests/e2e-openshift/multitenancy/01-assert.yaml
+++ b/tests/e2e-openshift/multitenancy/01-assert.yaml
@@ -156,16 +156,11 @@ spec:
           - --web.listen=0.0.0.0:8080
           - --web.internal.listen=0.0.0.0:8081
           - --traces.write.endpoint=tempo-simplest-distributor.kuttl-multitenancy.svc.cluster.local:4317
-          - --traces.read.endpoint=https://tempo-simplest-query-frontend.kuttl-multitenancy.svc.cluster.local:16686
+          - --traces.read.endpoint=http://tempo-simplest-query-frontend.kuttl-multitenancy.svc.cluster.local:16686
           - --grpc.listen=0.0.0.0:8090
           - --rbac.config=/etc/tempo-gateway/cm/rbac.yaml
           - --tenants.config=/etc/tempo-gateway/secret/tenants.yaml
           - --log.level=info
-          - --tls.internal.server.key-file=/var/run/tls/server/tls.key
-          - --tls.internal.server.cert-file=/var/run/tls/server/tls.crt
-          - --traces.tls.key-file=/var/run/tls/server/tls.key
-          - --traces.tls.cert-file=/var/run/tls/server/tls.crt
-          - --traces.tls.ca-file=/var/run/ca/service-ca.crt
           - --tls.server.cert-file=/etc/tempo-gateway/serving-certs/tls.crt
           - --tls.server.key-file=/etc/tempo-gateway/serving-certs/tls.key
           - --tls.healthchecks.server-ca-file=/etc/tempo-gateway/cabundle/service-ca.crt
@@ -190,10 +185,6 @@ spec:
               name: tenant
               readOnly: true
               subPath: tenants.yaml
-            - mountPath: /var/run/ca
-              name: tempo-simplest-ca-bundle
-            - mountPath: /var/run/tls/server
-              name: tempo-simplest-gateway-mtls
             - mountPath: /etc/tempo-gateway/serving-certs
               name: serving-certs
               readOnly: true
@@ -226,14 +217,6 @@ spec:
               - key: tenants.yaml
                 path: tenants.yaml
             secretName: tempo-simplest-gateway
-        - configMap:
-            defaultMode: 420
-            name: tempo-simplest-ca-bundle
-          name: tempo-simplest-ca-bundle
-        - name: tempo-simplest-gateway-mtls
-          secret:
-            defaultMode: 420
-            secretName: tempo-simplest-gateway-mtls
         - name: serving-certs
           secret:
             defaultMode: 420

--- a/tests/e2e/gateway/02-assert.yaml
+++ b/tests/e2e/gateway/02-assert.yaml
@@ -109,10 +109,6 @@ spec:
           name: tenant
           readOnly: true
           subPath: tenants.yaml
-        - mountPath: /var/run/ca
-          name: tempo-foo-ca-bundle
-        - mountPath: /var/run/tls/server
-          name: tempo-foo-gateway-mtls
       volumes:
       - configMap:
           defaultMode: 420
@@ -128,14 +124,5 @@ spec:
           - key: tenants.yaml
             path: tenants.yaml
           secretName: tempo-foo-gateway
-      - configMap:
-          defaultMode: 420
-          name: tempo-foo-ca-bundle
-        name: tempo-foo-ca-bundle
-      - name: tempo-foo-gateway-mtls
-        secret:
-          defaultMode: 420
-          secretName: tempo-foo-gateway-mtls
-
 status:
   readyReplicas: 1

--- a/tests/e2e/smoketest-with-jaeger/03-verify-traces.yaml
+++ b/tests/e2e/smoketest-with-jaeger/03-verify-traces.yaml
@@ -14,13 +14,10 @@ spec:
         - -c
         args:
         - |
-          namespace=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
+          # The query frontend must be accessible via HTTP (no mTLS) to enable connections from Grafana
           curl \
             -v -G \
-            --cert /var/run/tls/server/tls.crt \
-            --key /var/run/tls/server/tls.key \
-            --cacert /var/run/ca/service-ca.crt \
-            https://tempo-simplest-query-frontend.${namespace}.svc:3200/api/search \
+            http://tempo-simplest-query-frontend:3200/api/search \
             --data-urlencode "q={}" \
             | tee /tmp/tempo.out
           num_traces=$(jq ".traces | length" /tmp/tempo.out)
@@ -35,18 +32,4 @@ spec:
             echo && echo "The Jaeger API returned $num_traces instead of 10 traces."
             exit 1
           fi
-        volumeMounts:
-        - name: tempo-simplest-ca-bundle
-          mountPath: /var/run/ca
-        - name: tempo-simplest-gateway-mtls
-          mountPath: /var/run/tls/server
-      volumes:
-      - name: tempo-simplest-ca-bundle
-        configMap:
-          name: tempo-simplest-ca-bundle
-          defaultMode: 420
-      - name: tempo-simplest-gateway-mtls
-        secret:
-          secretName: tempo-simplest-gateway-mtls
-          defaultMode: 420
       restartPolicy: Never


### PR DESCRIPTION
Disable mTLS by default, to allow connections from Grafana to the query-frontend component.

Resolves: #552