### PR TITLE
Add pprof flag to optionally expose pprof data

### DIFF
--- a/.chloggen/pprof.yaml
+++ b/.chloggen/pprof.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, github action)
+component: operator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add pprof flag to optionally expose pprof data
+
+# One or more tracking issues related to the change
+issues: [242]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/cmd/start/main.go
+++ b/cmd/start/main.go
@@ -31,6 +31,8 @@ func start(c *cobra.Command, args []string) {
 	setupLog := ctrl.Log.WithName("setup")
 	version := version.Get()
 
+	options.PprofBindAddress, _ = c.Flags().GetString("pprof-addr")
+
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), options)
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
@@ -136,9 +138,11 @@ func addDependencies(mgr ctrl.Manager, ctrlConfig configv1alpha1.ProjectConfig, 
 
 // NewStartCommand returns a new start command.
 func NewStartCommand() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "start",
 		Short: "Start the Tempo operator",
 		Run:   start,
 	}
+	cmd.Flags().String("pprof-addr", "", "The address the pprof server binds to. Default is empty string which disables the pprof server.")
+	return cmd
 }


### PR DESCRIPTION
### Example usage:

update operator deployment, add `--pprof-addr=0.0.0.0:6060` argument
```
kubectl port-forward -n tempo-operator-system deployment/tempo-operator-controller 6060

go install github.com/google/pprof@latest
pprof -http=localhost:8080 localhost:6060/debug/pprof/heap
```

Resolves: #242