### PR TITLE
Use tempo SA to query RED metrics from OpenShift monitoring stack

### DIFF
--- a/.chloggen/redmetrics-cluster-role.yaml
+++ b/.chloggen/redmetrics-cluster-role.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, github action)
+component: operator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Use tempo service account to query metrics from OpenShift monitoring stack.
+
+# One or more tracking issues related to the change
+issues: [526]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: On OpenShift tempo service account is used to query metrics from OpenShift monitoring stack for the monitor tab.

--- a/bundle/openshift/manifests/tempo-operator-manager-rolebinding-cluster-monitoring-view_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+++ b/bundle/openshift/manifests/tempo-operator-manager-rolebinding-cluster-monitoring-view_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: operator-lifecycle-manager
+    app.kubernetes.io/name: tempo-operator
+    app.kubernetes.io/part-of: tempo-operator
+  name: tempo-operator-manager-rolebinding-cluster-monitoring-view
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-monitoring-view
+subjects:
+- kind: ServiceAccount
+  name: tempo-operator-controller-manager
+  namespace: openshift-operators-redhat

--- a/config/overlays/openshift/kustomization.yaml
+++ b/config/overlays/openshift/kustomization.yaml
@@ -3,6 +3,7 @@ resources:
 # Give OpenShift in-cluster-monitoring permissions to list, watch and get services, endpoints and pods in the namespace of the operator
 - prometheus_role.yaml
 - prometheus_role_binding.yaml
+- role_binding_cluster_monitoring_view.yaml
 
 # Adds namespace to all resources.
 namespace: openshift-operators-redhat

--- a/config/overlays/openshift/role_binding_cluster_monitoring_view.yaml
+++ b/config/overlays/openshift/role_binding_cluster_monitoring_view.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: manager-rolebinding-cluster-monitoring-view
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-monitoring-view
+subjects:
+  - kind: ServiceAccount
+    name: controller-manager
+    namespace: system

--- a/config/overlays/openshift/role_binding_cluster_monitoring_view.yaml
+++ b/config/overlays/openshift/role_binding_cluster_monitoring_view.yaml
@@ -1,3 +1,5 @@
+# The operator needs cluster-monitoring-view role
+# because it creates the same binding for the operands
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/internal/manifests/queryfrontend/query_frontend.go
+++ b/internal/manifests/queryfrontend/query_frontend.go
@@ -83,7 +83,8 @@ func BuildQueryFrontend(params manifestutils.Params) ([]client.Object, error) {
 		}
 	}
 
-	if tempo.Spec.Template.QueryFrontend.JaegerQuery.Enabled && tempo.Spec.Template.QueryFrontend.JaegerQuery.MonitorTab.Enabled {
+	if tempo.Spec.Template.QueryFrontend.JaegerQuery.Enabled && tempo.Spec.Template.QueryFrontend.JaegerQuery.MonitorTab.Enabled &&
+		tempo.Spec.Template.QueryFrontend.JaegerQuery.MonitorTab.PrometheusEndpoint == thanosQuerierOpenShiftMonitoring {
 		clusterRoleBinding := openShiftMonitoringClusterRoleBinding(tempo)
 		manifests = append(manifests, &clusterRoleBinding)
 	}

--- a/internal/manifests/queryfrontend/query_frontend.go
+++ b/internal/manifests/queryfrontend/query_frontend.go
@@ -6,9 +6,10 @@ import (
 
 	"github.com/imdario/mergo"
 	routev1 "github.com/openshift/api/route/v1"
-	v1 "k8s.io/api/apps/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8slabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -29,6 +30,8 @@ const (
 	portJaegerGRPCQuery   = 16685
 	portJaegerUI          = 16686
 	portJaegerMetrics     = 16687
+
+	thanosQuerierOpenShiftMonitoring = "https://thanos-querier.openshift-monitoring.svc.cluster.local:9091"
 )
 
 // BuildQueryFrontend creates the query-frontend objects.
@@ -80,25 +83,30 @@ func BuildQueryFrontend(params manifestutils.Params) ([]client.Object, error) {
 		}
 	}
 
+	if tempo.Spec.Template.QueryFrontend.JaegerQuery.Enabled && tempo.Spec.Template.QueryFrontend.JaegerQuery.MonitorTab.Enabled {
+		clusterRoleBinding := openShiftMonitoringClusterRoleBinding(tempo)
+		manifests = append(manifests, &clusterRoleBinding)
+	}
+
 	return manifests, nil
 }
 
-func deployment(params manifestutils.Params) (*v1.Deployment, error) {
+func deployment(params manifestutils.Params) (*appsv1.Deployment, error) {
 	tempo := params.Tempo
 	labels := manifestutils.ComponentLabels(manifestutils.QueryFrontendComponentName, tempo.Name)
 	annotations := manifestutils.CommonAnnotations(params.ConfigChecksum)
 	cfg := tempo.Spec.Template.QueryFrontend
 
-	d := &v1.Deployment{
+	d := &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: v1.SchemeGroupVersion.String(),
+			APIVersion: appsv1.SchemeGroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      naming.Name(manifestutils.QueryFrontendComponentName, tempo.Name),
 			Namespace: tempo.Namespace,
 			Labels:    labels,
 		},
-		Spec: v1.DeploymentSpec{
+		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: labels,
 			},
@@ -286,12 +294,13 @@ func enableMonitoringTab(tempo v1alpha1.TempoStack, jaegerQueryContainer corev1.
 	}
 	// If the endpoint matches Prometheus on OpenShift, configure TLS and token based auth
 	prometheusEndpoint := strings.TrimSpace(tempo.Spec.Template.QueryFrontend.JaegerQuery.MonitorTab.PrometheusEndpoint)
-	if prometheusEndpoint == "https://thanos-querier.openshift-monitoring.svc.cluster.local:9091" {
+	if prometheusEndpoint == thanosQuerierOpenShiftMonitoring {
 		container.Args = append(container.Args,
 			"--prometheus.tls.enabled=true",
 			// This enables token propagation, however flag --query.bearer-token-propagation=true
-			// overrides the settings and token from the context (incoming) request is used.
+			// enabled bearer token propagation, overrides the settings and token from the context (incoming) request is used.
 			"--prometheus.token-file=/var/run/secrets/kubernetes.io/serviceaccount/token",
+			"--prometheus.token-override-from-context=false",
 			"--prometheus.tls.ca=/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt")
 	}
 
@@ -300,6 +309,28 @@ func enableMonitoringTab(tempo v1alpha1.TempoStack, jaegerQueryContainer corev1.
 		return corev1.Container{}, err
 	}
 	return jaegerQueryContainer, nil
+}
+
+func openShiftMonitoringClusterRoleBinding(tempo v1alpha1.TempoStack) rbacv1.ClusterRoleBinding {
+	labels := manifestutils.ComponentLabels(manifestutils.QueryFrontendComponentName, tempo.Name)
+	return rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   naming.Name("cluster-monitoring-view", tempo.Name),
+			Labels: labels,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Name:      naming.DefaultServiceAccountName(tempo.Name),
+				Kind:      "ServiceAccount",
+				Namespace: tempo.Namespace,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     "cluster-monitoring-view",
+		},
+	}
 }
 
 func services(tempo v1alpha1.TempoStack) []*corev1.Service {

--- a/internal/manifests/queryfrontend/query_frontend_test.go
+++ b/internal/manifests/queryfrontend/query_frontend_test.go
@@ -570,6 +570,9 @@ func TestBuildQueryFrontendWithJaegerMonitorTab(t *testing.T) {
 		{
 			name: "OpenShift user-workload monitoring",
 			tempo: v1alpha1.TempoStack{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "simplest",
+				},
 				Spec: v1alpha1.TempoStackSpec{
 					Template: v1alpha1.TempoTemplateSpec{
 						QueryFrontend: v1alpha1.TempoQueryFrontendSpec{
@@ -584,7 +587,7 @@ func TestBuildQueryFrontendWithJaegerMonitorTab(t *testing.T) {
 					},
 				},
 			},
-			args: []string{"--query.base-path=/", "--grpc-storage-plugin.configuration-file=/conf/tempo-query.yaml", "--query.bearer-token-propagation=true", "--prometheus.query.support-spanmetrics-connector", "--prometheus.tls.enabled=true", "--prometheus.token-file=/var/run/secrets/kubernetes.io/serviceaccount/token", "--prometheus.tls.ca=/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"},
+			args: []string{"--query.base-path=/", "--grpc-storage-plugin.configuration-file=/conf/tempo-query.yaml", "--query.bearer-token-propagation=true", "--prometheus.query.support-spanmetrics-connector", "--prometheus.tls.enabled=true", "--prometheus.token-file=/var/run/secrets/kubernetes.io/serviceaccount/token", "--prometheus.token-override-from-context=false", "--prometheus.tls.ca=/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"},
 			env:  []corev1.EnvVar{{Name: "METRICS_STORAGE_TYPE", Value: "prometheus"}, {Name: "PROMETHEUS_SERVER_URL", Value: "https://thanos-querier.openshift-monitoring.svc.cluster.local:9091"}},
 		},
 	}
@@ -598,6 +601,16 @@ func TestBuildQueryFrontendWithJaegerMonitorTab(t *testing.T) {
 
 			assert.Equal(t, test.args, dep.Spec.Template.Spec.Containers[1].Args)
 			assert.Equal(t, test.env, dep.Spec.Template.Spec.Containers[1].Env)
+
+			if test.tempo.Spec.Template.QueryFrontend.JaegerQuery.MonitorTab.PrometheusEndpoint == thanosQuerierOpenShiftMonitoring {
+				objects, err := BuildQueryFrontend(manifestutils.Params{
+					Tempo: test.tempo,
+				})
+				require.NoError(t, err)
+				assert.Equal(t, 4, len(objects))
+
+				assert.Equal(t, "tempo-simplest-cluster-monitoring-view", objects[3].GetName())
+			}
 		})
 	}
 }

--- a/tests/e2e-openshift/red-metrics/02-assert.yaml
+++ b/tests/e2e-openshift/red-metrics/02-assert.yaml
@@ -32,3 +32,15 @@ metadata:
   name: tempo-redmetrics-compactor
 status:
   readyReplicas: 1
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tempo-query-cluster-monitoring-view
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-monitoring-view
+subjects:
+  - kind: ServiceAccount
+    name: tempo-redmetrics-cluster-monitoring-view

--- a/tests/e2e-openshift/red-metrics/02-install-tempo.yaml
+++ b/tests/e2e-openshift/red-metrics/02-install-tempo.yaml
@@ -31,20 +31,3 @@ spec:
         ingress:
           type: route
 ---
-# Allow all OCP users to query metrics in the user-workload monitoring stack.
-# tempo-query flag --query.bearer-token-propagation=true propagates token from the browser to the metrics store.
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: tempo-query-cluster-monitoring-view
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cluster-monitoring-view
-subjects:
-  - kind: Group
-    apiGroup: rbac.authorization.k8s.io
-    name: system:authenticated
-  - kind: Group
-    apiGroup: rbac.authorization.k8s.io
-    name: system:unauthenticated


### PR DESCRIPTION
Resolves #526 

Depends on https://github.com/jaegertracing/jaeger/pull/4726 and released tempo-query with the feature.

Notable changes:
- tempo operator SA on OCP gets `cluster-monitoring-view` cluster role - it needs it because it needs to create the same `clusterrolebinding` for instances.
- tempo instance SA gets `cluster-monitoring-view` cluster role - needed to access metrics for the monitor tab