### PR TITLE
Update gateway image

### DIFF
--- a/bundle/community/manifests/tempo-operator-manager-config_v1_configmap.yaml
+++ b/bundle/community/manifests/tempo-operator-manager-config_v1_configmap.yaml
@@ -26,7 +26,7 @@ data:
     images:
       tempo: docker.io/grafana/tempo:2.2.1
       tempoQuery: docker.io/grafana/tempo-query:2.2.1
-      tempoGateway: quay.io/observatorium/api:main-2023-07-31-5904ad0
+      tempoGateway: quay.io/observatorium/api:main-2023-09-13-14e06c6
       tempoGatewayOpa: quay.io/observatorium/opa-openshift:main-2023-05-24-8e91537
     featureGates:
       openshift:

--- a/bundle/openshift/manifests/tempo-operator-manager-config_v1_configmap.yaml
+++ b/bundle/openshift/manifests/tempo-operator-manager-config_v1_configmap.yaml
@@ -26,7 +26,7 @@ data:
     images:
       tempo: docker.io/grafana/tempo:2.2.1
       tempoQuery: docker.io/grafana/tempo-query:2.2.1
-      tempoGateway: quay.io/observatorium/api:main-2023-07-31-5904ad0
+      tempoGateway: quay.io/observatorium/api:main-2023-09-13-14e06c6
       tempoGatewayOpa: quay.io/observatorium/opa-openshift:main-2023-05-24-8e91537
     featureGates:
       openshift:

--- a/config/overlays/community/controller_manager_config.yaml
+++ b/config/overlays/community/controller_manager_config.yaml
@@ -23,7 +23,7 @@ leaderElection:
 images:
   tempo: docker.io/grafana/tempo:2.2.1
   tempoQuery: docker.io/grafana/tempo-query:2.2.1
-  tempoGateway: quay.io/observatorium/api:main-2023-07-31-5904ad0
+  tempoGateway: quay.io/observatorium/api:main-2023-09-13-14e06c6
   tempoGatewayOpa: quay.io/observatorium/opa-openshift:main-2023-05-24-8e91537
 featureGates:
   openshift:

--- a/config/overlays/openshift/controller_manager_config.yaml
+++ b/config/overlays/openshift/controller_manager_config.yaml
@@ -23,7 +23,7 @@ leaderElection:
 images:
   tempo: docker.io/grafana/tempo:2.2.1
   tempoQuery: docker.io/grafana/tempo-query:2.2.1
-  tempoGateway: quay.io/observatorium/api:main-2023-07-31-5904ad0
+  tempoGateway: quay.io/observatorium/api:main-2023-09-13-14e06c6
   tempoGatewayOpa: quay.io/observatorium/opa-openshift:main-2023-05-24-8e91537
 featureGates:
   openshift:


### PR DESCRIPTION
The new image has fix https://github.com/observatorium/api/pull/570 that is needed to make the Jaeger monitor tab work with Gateway 