### PR TITLE
Expose the OTLP HTTP port in the distributor service

### DIFF
--- a/.chloggen/otlp_http.yaml
+++ b/.chloggen/otlp_http.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, github action)
+component: operator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Expose the OTLP HTTP port in the distributor service.
+
+# One or more tracking issues related to the change
+issues: [610]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/internal/manifests/distributor/distributor.go
+++ b/internal/manifests/distributor/distributor.go
@@ -65,6 +65,11 @@ func deployment(params manifestutils.Params) *v1.Deployment {
 	if !tempo.Spec.Template.Gateway.Enabled {
 		containerPorts = append(containerPorts, []corev1.ContainerPort{
 			{
+				Name:          manifestutils.PortOtlpHttpName,
+				ContainerPort: manifestutils.PortOtlpHttp,
+				Protocol:      corev1.ProtocolTCP,
+			},
+			{
 				Name:          manifestutils.PortJaegerThriftHTTPName,
 				ContainerPort: manifestutils.PortJaegerThriftHTTP,
 				Protocol:      corev1.ProtocolTCP,
@@ -187,6 +192,12 @@ func service(tempo v1alpha1.TempoStack) *corev1.Service {
 
 	if !tempo.Spec.Template.Gateway.Enabled {
 		servicePorts = append(servicePorts, []corev1.ServicePort{
+			{
+				Name:       manifestutils.PortOtlpHttpName,
+				Port:       manifestutils.PortOtlpHttp,
+				TargetPort: intstr.FromString(manifestutils.PortOtlpHttpName),
+				Protocol:   corev1.ProtocolTCP,
+			},
 			{
 				Name:       manifestutils.PortJaegerThriftHTTPName,
 				Port:       manifestutils.PortJaegerThriftHTTP,

--- a/internal/manifests/distributor/distributor_test.go
+++ b/internal/manifests/distributor/distributor_test.go
@@ -47,6 +47,11 @@ func TestBuildDistributor(t *testing.T) {
 					Protocol:      corev1.ProtocolTCP,
 				},
 				{
+					Name:          manifestutils.PortOtlpHttpName,
+					ContainerPort: manifestutils.PortOtlpHttp,
+					Protocol:      corev1.ProtocolTCP,
+				},
+				{
 					Name:          manifestutils.PortJaegerThriftHTTPName,
 					ContainerPort: manifestutils.PortJaegerThriftHTTP,
 					Protocol:      corev1.ProtocolTCP,
@@ -84,6 +89,12 @@ func TestBuildDistributor(t *testing.T) {
 					Protocol:   corev1.ProtocolTCP,
 					Port:       manifestutils.PortHTTPServer,
 					TargetPort: intstr.FromString(manifestutils.HttpPortName),
+				},
+				{
+					Name:       manifestutils.PortOtlpHttpName,
+					Port:       manifestutils.PortOtlpHttp,
+					TargetPort: intstr.FromString(manifestutils.PortOtlpHttpName),
+					Protocol:   corev1.ProtocolTCP,
 				},
 				{
 					Name:       manifestutils.PortJaegerThriftHTTPName,

--- a/internal/manifests/manifestutils/constants.go
+++ b/internal/manifests/manifestutils/constants.go
@@ -40,6 +40,11 @@ const (
 	// PortOtlpGrpcServer declares the port number of the OpenTelemetry Collector gRPC receiver port.
 	PortOtlpGrpcServer = 4317
 
+	// PortOtlpHttpName declares the port name of the OpenTelemetry protocol over HTTP.
+	PortOtlpHttpName = "otlp-http"
+	// PortOtlpHttp declares the port number of the OpenTelemetry protocol over HTTP.
+	PortOtlpHttp = 4318
+
 	// PortJaegerThriftHTTPName declares the port name of the Jaeger Thrift HTTP protocol.
 	PortJaegerThriftHTTPName = "thrift-http"
 	// PortJaegerThriftHTTP declares the port number of the Jaeger Thrift HTTP protocol.

--- a/tests/e2e/generate/01-assert.yaml
+++ b/tests/e2e/generate/01-assert.yaml
@@ -37,6 +37,10 @@ spec:
       port: 3200
       protocol: TCP
       targetPort: http
+    - name: otlp-http
+      port: 4318
+      protocol: TCP
+      targetPort: otlp-http
     - name: thrift-http
       port: 14268
       protocol: TCP

--- a/tests/e2e/smoketest-with-jaeger/01-assert.yaml
+++ b/tests/e2e/smoketest-with-jaeger/01-assert.yaml
@@ -165,6 +165,10 @@ spec:
       port: 3200
       protocol: TCP
       targetPort: http
+    - name: otlp-http
+      port: 4318
+      protocol: TCP
+      targetPort: otlp-http
     - name: thrift-http
       port: 14268
       protocol: TCP


### PR DESCRIPTION
Required e.g. for running the hotrod example application

```
$ docker run --network=host -e OTEL_EXPORTER_OTLP_ENDPOINT=http://tempo-simplest-distributor.default.svc.cluster.local:4318 jaegertracing/example-hotrod:1.46 all --otel-exporter=otlp
```