### PR TITLE
Revert "build(deps): Bump codecov/codecov-action from 3 to 4 (#615)"

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -29,7 +29,7 @@ jobs:
         run: make ci
 
       - name: "upload coverage report"
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         with:
           files: cover.out
           flags: unittests


### PR DESCRIPTION
This reverts commit 7de479668c4e6c57d46b745c7b79e1ac6f74f714.

v4 is not released yet (or got un-released?), the CI run worked fine 4 days ago:
https://github.com/grafana/tempo-operator/actions/runs/6192772421/job/16813342328?pr=615