### PR TITLE
Fix flaky upgrade and scorecard tests

### DIFF
--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -48,11 +48,11 @@ jobs:
           sudo chown $(id -u):$(id -g) ~/.kube/config
 
       - name: "run community scorecard tests"
-        run: make scorecard-tests
+        run: for i in {1..5}; do make scorecard-tests && break || sleep 10; done
         env:
           BUNDLE_VARIANT: community
 
       - name: "run OpenShift scorecard tests"
-        run: make scorecard-tests
+        run: for i in {1..5}; do make scorecard-tests && break || sleep 10; done
         env:
           BUNDLE_VARIANT: openshift

--- a/tests/e2e-upgrade/upgrade/02-assert.yaml
+++ b/tests/e2e-upgrade/upgrade/02-assert.yaml
@@ -26,3 +26,13 @@ status:
   # assert that the readiness probes of both containers (kube-rbac-proxy and tempo-operator) are successful
   - ready: true
   - ready: true
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+# kuttl will retry this command until a timeout is reached, and it won't stop retrying if the webhook is not reachable.
+# This makes sure that the operator is ready and accepting new TempoStack CRs.
+- command: kubectl apply -f tests/e2e-upgrade/upgrade/tempostack.yaml
+  namespaced: true
+- command: kubectl delete tempo check-operator-ready
+  namespaced: true

--- a/tests/e2e-upgrade/upgrade/tempostack.yaml
+++ b/tests/e2e-upgrade/upgrade/tempostack.yaml
@@ -1,0 +1,9 @@
+apiVersion: tempo.grafana.com/v1alpha1
+kind: TempoStack
+metadata:
+  name: check-operator-ready
+spec:
+  storage:
+    secret:
+      name: example
+      type: s3


### PR DESCRIPTION
* upgrade: retry until creating a new TempoStack works
* scorecard: repeat on error (max 5 times)

Workaround for #380
Closes #380
Signed-off-by: Andreas Gerstmayr <agerstmayr@redhat.com>