### PR TITLE
Fix object storage CA validation

### DIFF
--- a/apis/tempo/v1alpha1/tempostack_webhook.go
+++ b/apis/tempo/v1alpha1/tempostack_webhook.go
@@ -427,7 +427,7 @@ func (v *validator) validate(ctx context.Context, obj runtime.Object) (admission
 	allWarnings = append(allWarnings, warnings...)
 	allErrors = append(allErrors, errors...)
 
-	if tempo.Spec.Storage.TLS.CA == "" {
+	if tempo.Spec.Storage.TLS.CA != "" {
 		warnings, errors = v.validateStorageCA(ctx, *tempo)
 		allWarnings = append(allWarnings, warnings...)
 		allErrors = append(allErrors, errors...)


### PR DESCRIPTION
Run validation in webhook only if CA is not empty.