### PR TITLE
[chore] Replace official dex image

### DIFF
--- a/tests/e2e/gateway/00-assert.yaml
+++ b/tests/e2e/gateway/00-assert.yaml
@@ -19,7 +19,9 @@ spec:
         - dex
         - serve
         - /data/dex/dex.yaml
-        image: dexidp/dex:v2.30.0
+        # How to build this image: https://gist.github.com/iblancasa/bc5bae33fa14736b367716205229defb
+        # TODO: https://github.com/grafana/tempo-operator/issues/643
+        image: ghcr.io/iblancasa/dex:v2.37.0
         ports:
         - containerPort: 5556
           name: public

--- a/tests/e2e/gateway/00-install.yaml
+++ b/tests/e2e/gateway/00-install.yaml
@@ -55,7 +55,9 @@ spec:
             - dex
             - serve
             - /data/dex/dex.yaml
-          image: dexidp/dex:v2.30.0
+          # How to build this image: https://gist.github.com/iblancasa/bc5bae33fa14736b367716205229defb
+          # TODO: https://github.com/grafana/tempo-operator/issues/643
+          image: ghcr.io/iblancasa/dex:v2.37.0
           imagePullPolicy: IfNotPresent
           name: hydra
           env:


### PR DESCRIPTION
Replace the official dex image with one providing support for `linux/s390x`.

More context in #643.