### PR TITLE
Use github app token to bypass branch protection

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ jobs:
         app_id: ${{ secrets.PUBLISH_APP_ID }}
         private_key: ${{ secrets.PUBLISH_APP_PRIVATE_KEY }}
         installation_retrieval_payload:  ${{ secrets.PUBLISH_APP_INSTALLATION_ID }}
-
+        installation_retrieval_mode: id
 
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,20 @@ jobs:
       uses: actions/setup-go@v4
       with:
         go-version: "1.20"
+
+    - name: Generate token
+      id: generate_token
+      uses: tibdex/github-app-token@v1
+      with:
+        app_id: ${{ secrets.PUBLISH_APP_ID }}
+        private_key: ${{ secrets.PUBLISH_APP_PRIVATE_KEY }}
+        installation_retrieval_payload:  ${{ secrets.PUBLISH_APP_INSTALLATION_ID }}
+
+
     - uses: actions/checkout@v4
+      with:
+        token: ${{ steps.generate_token.outputs.token }}
+
 
     - name: Generate bundle
       run: make bundle

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
 
     - name: Generate token
       id: generate_token
-      uses: tibdex/github-app-token@v1
+      uses: tibdex/github-app-token@v2
       with:
         app_id: ${{ secrets.PUBLISH_APP_ID }}
         private_key: ${{ secrets.PUBLISH_APP_PRIVATE_KEY }}


### PR DESCRIPTION
I got an error trying to release

I think with this method we can bypass the protection, adding the app to the actions who can bypass the protection


Unfortunatelly I'm not able to modify for this repo because I don't have permissions


Attached an screenshot of what we need to do (but with the grafana app)

![Screenshot from 2023-10-20 19-17-50](https://github.com/grafana/tempo-operator/assets/3799716/a34e3c20-3a2f-4e36-82c7-e815230a8af1)
