### PR TITLE
[Chore] Fix RED metrics test case.

### DIFF
--- a/tests/e2e-openshift/red-metrics/03-assert.yaml
+++ b/tests/e2e-openshift/red-metrics/03-assert.yaml
@@ -32,15 +32,21 @@ metadata:
   name: tempo-redmetrics-compactor
 status:
   readyReplicas: 1
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: tempo-query-cluster-monitoring-view
+  labels:
+    app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/instance: redmetrics
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+  name: tempo-redmetrics-cluster-monitoring-view
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: cluster-monitoring-view
 subjects:
-  - kind: ServiceAccount
-    name: tempo-redmetrics-cluster-monitoring-view
+- kind: ServiceAccount
+  name: tempo-redmetrics


### PR DESCRIPTION
```
$ kuttl test --test=red-metrics --timeout=300 tests/e2e-openshift/
2023/11/03 10:06:51 kutt-test config testdirs is overridden with args: [ tests/e2e-openshift/ ]
=== RUN   kuttl
    harness.go:462: starting setup
    harness.go:252: running tests using configured kubeconfig.
    harness.go:275: Successful connection to cluster at: https://REDACTED:6443
    harness.go:360: running tests
    harness.go:73: going to run test suite with timeout of 300 seconds for each step
    harness.go:372: testsuite: tests/e2e-openshift/ has 4 tests
=== RUN   kuttl/harness
=== RUN   kuttl/harness/red-metrics
=== PAUSE kuttl/harness/red-metrics
=== CONT  kuttl/harness/red-metrics
    logger.go:42: 10:06:55 | red-metrics | Ignoring check_user_workload_monitoring.sh as it does not match file name regexp: ^(\d+)-(?:[^\.]+)(?:\.yaml)?$
    logger.go:42: 10:06:55 | red-metrics | Creating namespace: kuttl-test-valid-bengal
    logger.go:42: 10:06:55 | red-metrics/0-install-storage | starting test step 0-install-storage
    logger.go:42: 10:06:56 | red-metrics/0-install-storage | PersistentVolumeClaim:kuttl-test-valid-bengal/minio created
    logger.go:42: 10:06:57 | red-metrics/0-install-storage | Deployment:kuttl-test-valid-bengal/minio created
    logger.go:42: 10:06:58 | red-metrics/0-install-storage | Service:kuttl-test-valid-bengal/minio created
    logger.go:42: 10:07:15 | red-metrics/0-install-storage | test step completed 0-install-storage
    logger.go:42: 10:07:15 | red-metrics/1-install-workload-monitoring | starting test step 1-install-workload-monitoring
    logger.go:42: 10:07:17 | red-metrics/1-install-workload-monitoring | ConfigMap:openshift-monitoring/cluster-monitoring-config updated
    logger.go:42: 10:07:17 | red-metrics/1-install-workload-monitoring | running command: [sh -c ./tests/e2e-openshift/red-metrics/check_user_workload_monitoring.sh]
    logger.go:42: 10:07:24 | red-metrics/1-install-workload-monitoring | test step completed 1-install-workload-monitoring
    logger.go:42: 10:07:24 | red-metrics/2-install-otel-collector | starting test step 2-install-otel-collector
    logger.go:42: 10:07:26 | red-metrics/2-install-otel-collector | OpenTelemetryCollector:kuttl-test-valid-bengal/otel created
    logger.go:42: 10:07:27 | red-metrics/2-install-otel-collector | PodMonitor:kuttl-test-valid-bengal/otel-collector created
    logger.go:42: 10:07:36 | red-metrics/2-install-otel-collector | test step completed 2-install-otel-collector
    logger.go:42: 10:07:36 | red-metrics/3-install-tempo | starting test step 3-install-tempo
    logger.go:42: 10:07:38 | red-metrics/3-install-tempo | Secret:kuttl-test-valid-bengal/minio-test created
    logger.go:42: 10:07:39 | red-metrics/3-install-tempo | TempoStack:kuttl-test-valid-bengal/redmetrics created
    logger.go:42: 10:08:55 | red-metrics/3-install-tempo | test step completed 3-install-tempo
    logger.go:42: 10:08:55 | red-metrics/4-install-hotrod | starting test step 4-install-hotrod
    logger.go:42: 10:08:56 | red-metrics/4-install-hotrod | Deployment:kuttl-test-valid-bengal/hotrod created
    logger.go:42: 10:08:57 | red-metrics/4-install-hotrod | Service:kuttl-test-valid-bengal/hotrod created
    logger.go:42: 10:09:03 | red-metrics/4-install-hotrod | test step completed 4-install-hotrod
    logger.go:42: 10:09:03 | red-metrics/5-install-generate-traces | starting test step 5-install-generate-traces
    logger.go:42: 10:09:05 | red-metrics/5-install-generate-traces | Job:kuttl-test-valid-bengal/hotrod-curl created
    logger.go:42: 10:09:13 | red-metrics/5-install-generate-traces | test step completed 5-install-generate-traces
    logger.go:42: 10:09:13 | red-metrics/6-intall-assert-job | starting test step 6-intall-assert-job
    logger.go:42: 10:09:16 | red-metrics/6-intall-assert-job | Job:kuttl-test-valid-bengal/verify-metrics created
    logger.go:42: 10:09:21 | red-metrics/6-intall-assert-job | test step completed 6-intall-assert-job
    logger.go:42: 10:09:22 | red-metrics | red-metrics events from ns kuttl-test-valid-bengal:
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:06:56 +0000 UTC	Normal	PersistentVolumeClaim minio		WaitForFirstConsumer	waiting for first consumer to be created before binding	persistentvolume-controller	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:06:57 +0000 UTC	Normal	ReplicaSet.apps minio-5c87b5b89d		SuccessfulCreate	Created pod: minio-5c87b5b89d-wzjtn	replicaset-controller	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:06:57 +0000 UTC	Normal	Deployment.apps minio		ScalingReplicaSet	Scaled up replica set minio-5c87b5b89d to 1	deployment-controller	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:06:57 +0000 UTC	Normal	PersistentVolumeClaim minio		Provisioning	External provisioner is provisioning volume for claim "kuttl-test-valid-bengal/minio"		
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:06:57 +0000 UTC	Normal	PersistentVolumeClaim minio		ExternalProvisioning	waiting for a volume to be created, either by external provisioner "pd.csi.storage.gke.io" or manually created by system administrator	persistentvolume-controller	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:07:01 +0000 UTC	Normal	PersistentVolumeClaim minio		ProvisioningSucceeded	Successfully provisioned volume pvc-6272d421-9ff3-495a-9d27-1066a4570148		
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:07:02 +0000 UTC	Normal	Pod minio-5c87b5b89d-wzjtn	Binding	Scheduled	Successfully assigned kuttl-test-valid-bengal/minio-5c87b5b89d-wzjtn to REDACTED	default-scheduler	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:07:10 +0000 UTC	Normal	Pod minio-5c87b5b89d-wzjtn		SuccessfulAttachVolume	AttachVolume.Attach succeeded for volume "pvc-6272d421-9ff3-495a-9d27-1066a4570148" 	attachdetach-controller	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:07:12 +0000 UTC	Normal	Pod minio-5c87b5b89d-wzjtn		AddedInterface	Add eth0 [10.128.2.90/23] from openshift-sdn		
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:07:12 +0000 UTC	Normal	Pod minio-5c87b5b89d-wzjtn.spec.containers{minio}		Pulling	Pulling image "minio/minio"	kubelet	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:07:13 +0000 UTC	Normal	Pod minio-5c87b5b89d-wzjtn.spec.containers{minio}		PulledSuccessfully pulled image "minio/minio" in 783.513265ms (783.529555ms including waiting)	kubelet	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:07:13 +0000 UTC	Normal	Pod minio-5c87b5b89d-wzjtn.spec.containers{minio}		Created	Created container minio	kubelet	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:07:13 +0000 UTC	Normal	Pod minio-5c87b5b89d-wzjtn.spec.containers{minio}		Started	Started container minio	kubelet	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:07:26 +0000 UTC	Normal	Pod otel-collector-6c57955875-sxmbg	Binding	Scheduled	Successfully assigned kuttl-test-valid-bengal/otel-collector-6c57955875-sxmbg to REDACTED	default-scheduler	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:07:26 +0000 UTC	Normal	ReplicaSet.apps otel-collector-6c57955875		SuccessfulCreate	Created pod: otel-collector-6c57955875-sxmbg	replicaset-controller	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:07:26 +0000 UTC	Normal	Deployment.apps otel-collector		ScalingReplicaSet	Scaled up replica set otel-collector-6c57955875 to 1	deployment-controller	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:07:28 +0000 UTC	Normal	Pod otel-collector-6c57955875-sxmbg		AddedInterface	Add eth0 [10.128.2.91/23] from openshift-sdn		
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:07:28 +0000 UTC	Normal	Pod otel-collector-6c57955875-sxmbg.spec.containers{otc-container}	Pulling	Pulling image "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.83.0"	kubelet	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:07:34 +0000 UTC	Normal	Pod otel-collector-6c57955875-sxmbg.spec.containers{otc-container}	Pulled	Successfully pulled image "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.83.0" in 6.1777567s (6.177771762s including waiting)	kubelet	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:07:34 +0000 UTC	Normal	Pod otel-collector-6c57955875-sxmbg.spec.containers{otc-container}	Created	Created container otc-container	kubelet	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:07:34 +0000 UTC	Normal	Pod otel-collector-6c57955875-sxmbg.spec.containers{otc-container}	Started	Started container otc-container	kubelet	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:07:40 +0000 UTC	Normal	PersistentVolumeClaim data-tempo-redmetrics-ingester-0		WaitForFirstConsumer	waiting for first consumer to be created before binding	persistentvolume-controller	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:07:40 +0000 UTC	Normal	PersistentVolumeClaim data-tempo-redmetrics-ingester-0		Provisioning	External provisioner is provisioning volume for claim "kuttl-test-valid-bengal/data-tempo-redmetrics-ingester-0"		
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:07:40 +0000 UTC	Normal	PersistentVolumeClaim data-tempo-redmetrics-ingester-0		ExternalProvisioning	waiting for a volume to be created, either by external provisioner "pd.csi.storage.gke.io" or manually created by system administrator	persistentvolume-controller	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:07:40 +0000 UTC	Normal	Pod tempo-redmetrics-compactor-6b474bf54-p57nv	Binding	Scheduled	Successfully assigned kuttl-test-valid-bengal/tempo-redmetrics-compactor-6b474bf54-p57nv to REDACTED	default-scheduler	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:07:40 +0000 UTC	Normal	ReplicaSet.apps tempo-redmetrics-compactor-6b474bf54		SuccessfulCreate	Created pod: tempo-redmetrics-compactor-6b474bf54-p57nv	replicaset-controller	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:07:40 +0000 UTC	Normal	Deployment.apps tempo-redmetrics-compactor		ScalingReplicaSet	Scaled up replica set tempo-redmetrics-compactor-6b474bf54 to 1	deployment-controller	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:07:40 +0000 UTC	Normal	Pod tempo-redmetrics-distributor-5987f7f4bd-wspj6	Binding	Scheduled	Successfully assigned kuttl-test-valid-bengal/tempo-redmetrics-distributor-5987f7f4bd-wspj REDACTED default-scheduler	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:07:40 +0000 UTC	Normal	ReplicaSet.apps tempo-redmetrics-distributor-5987f7f4bd		SuccessfulCreate	Created pod: tempo-redmetrics-distributor-5987f7f4bd-wspj6	replicaset-controller	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:07:40 +0000 UTC	Normal	Deployment.apps tempo-redmetrics-distributor		ScalingReplicaSet	Scaled up replica set tempo-redmetrics-distributor-5987f7f4bd to 1	deployment-controller	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:07:40 +0000 UTC	Normal	StatefulSet.apps tempo-redmetrics-ingester		SuccessfulCreate	create Claim data-tempo-redmetrics-ingester-0 Pod tempo-redmetrics-ingester-0 in StatefulSet tempo-redmetrics-ingester success	statefulset-controller
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:07:40 +0000 UTC	Normal	StatefulSet.apps tempo-redmetrics-ingester		SuccessfulCreate	create Pod tempo-redmetrics-ingester-0 in StatefulSet tempo-redmetrics-ingester successful	statefulset-controller	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:07:40 +0000 UTC	Normal	Pod tempo-redmetrics-querier-795867467-wv22m	Binding	Scheduled	Successfully assigned kuttl-test-valid-bengal/tempo-redmetrics-querier-795867467-wv22m to REDACTED	default-scheduler	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:07:40 +0000 UTC	Normal	ReplicaSet.apps tempo-redmetrics-querier-795867467		SuccessfulCreate	Created pod: tempo-redmetrics-querier-795867467-wv22m	replicaset-controller	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:07:40 +0000 UTC	Normal	Deployment.apps tempo-redmetrics-querier		ScalingReplicaSet	Scaled up replica set tempo-redmetrics-querier-795867467 to 1	deployment-controller	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:07:40 +0000 UTC	Normal	Pod tempo-redmetrics-query-frontend-5bd8466576-pd6wj	Binding	Scheduled	Successfully assigned kuttl-test-valid-bengal/tempo-redmetrics-query-frontend-5bd8466 REDACTED	default-scheduler	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:07:40 +0000 UTC	Normal	ReplicaSet.apps tempo-redmetrics-query-frontend-5bd8466576		SuccessfulCreate	Created pod: tempo-redmetrics-query-frontend-5bd8466576-pd6wj	replicaset-controller	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:07:40 +0000 UTC	Normal	Deployment.apps tempo-redmetrics-query-frontend		ScalingReplicaSet	Scaled up replica set tempo-redmetrics-query-frontend-5bd8466576 to 1	deployment-controller	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:07:42 +0000 UTC	Normal	Pod tempo-redmetrics-compactor-6b474bf54-p57nv		AddedInterfaceAdd eth0 [10.128.2.92/23] from openshift-sdn		
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:07:42 +0000 UTC	Normal	Pod tempo-redmetrics-compactor-6b474bf54-p57nv.spec.containers{tempo}Pulled	Container image "docker.io/grafana/tempo:2.2.3" already present on machine	kubelet	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:07:42 +0000 UTC	Normal	Pod tempo-redmetrics-compactor-6b474bf54-p57nv.spec.containers{tempo}Created	Created container tempo	kubelet	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:07:42 +0000 UTC	Normal	Pod tempo-redmetrics-compactor-6b474bf54-p57nv.spec.containers{tempo}Started	Started container tempo	kubelet	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:07:42 +0000 UTC	Normal	Pod tempo-redmetrics-distributor-5987f7f4bd-wspj6		AddedInterface	Add eth0 [10.131.0.52/23] from openshift-sdn		
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:07:42 +0000 UTC	Normal	Pod tempo-redmetrics-distributor-5987f7f4bd-wspj6.spec.containers{tempo}		Pulled	Container image "docker.io/grafana/tempo:2.2.3" already present on machine	kubelet	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:07:42 +0000 UTC	Normal	Pod tempo-redmetrics-distributor-5987f7f4bd-wspj6.spec.containers{tempo}		Created	Created container tempo	kubelet	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:07:42 +0000 UTC	Normal	Pod tempo-redmetrics-distributor-5987f7f4bd-wspj6.spec.containers{tempo}		Started	Started container tempo	kubelet	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:07:42 +0000 UTC	Normal	Pod tempo-redmetrics-querier-795867467-wv22m		AddedInterfaceAdd eth0 [10.131.0.53/23] from openshift-sdn		
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:07:42 +0000 UTC	Normal	Pod tempo-redmetrics-querier-795867467-wv22m.spec.containers{tempo}	Pulled	Container image "docker.io/grafana/tempo:2.2.3" already present on machine	kubelet	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:07:42 +0000 UTC	Normal	Pod tempo-redmetrics-query-frontend-5bd8466576-pd6wj		AddedInterface	Add eth0 [10.129.2.62/23] from openshift-sdn		
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:07:42 +0000 UTC	Normal	Pod tempo-redmetrics-query-frontend-5bd8466576-pd6wj.spec.containers{tempo}		Pulled	Container image "docker.io/grafana/tempo:2.2.3" already present on machine	kubelet	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:07:42 +0000 UTC	Normal	Pod tempo-redmetrics-query-frontend-5bd8466576-pd6wj.spec.containers{tempo}		Created	Created container tempo	kubelet	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:07:42 +0000 UTC	Normal	Pod tempo-redmetrics-query-frontend-5bd8466576-pd6wj.spec.containers{tempo}		Started	Started container tempo	kubelet	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:07:42 +0000 UTC	Normal	Pod tempo-redmetrics-query-frontend-5bd8466576-pd6wj.spec.containers{tempo-query}		Pulled	Container image "docker.io/grafana/tempo-query:main-2e5e27a" already present on machine	kubelet	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:07:42 +0000 UTC	Normal	Pod tempo-redmetrics-query-frontend-5bd8466576-pd6wj.spec.containers{tempo-query}		Created	Created container tempo-query	kubelet	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:07:42 +0000 UTC	Normal	Pod tempo-redmetrics-query-frontend-5bd8466576-pd6wj.spec.containers{tempo-query}		Started	Started container tempo-query	kubelet	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:07:43 +0000 UTC	Normal	Pod tempo-redmetrics-querier-795867467-wv22m.spec.containers{tempo}	Created	Created container tempo	kubelet	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:07:43 +0000 UTC	Normal	Pod tempo-redmetrics-querier-795867467-wv22m.spec.containers{tempo}	Started	Started container tempo	kubelet	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:07:44 +0000 UTC	Normal	PersistentVolumeClaim data-tempo-redmetrics-ingester-0		ProvisioningSucceeded	Successfully provisioned volume pvc-9f0c37b0-0c07-4df4-b8bc-b25becd75b97		
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:07:44 +0000 UTC	Normal	Pod tempo-redmetrics-ingester-0	Binding	Scheduled	Successfully assigned kuttl-test-valid-bengal/tempo-redmetrics-ingester-0 to REDACTED	default-scheduler	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:07:48 +0000 UTC	Normal	Pod tempo-redmetrics-ingester-0		SuccessfulAttachVolume	AttachVolume.Attach succeeded for volume "pvc-9f0c37b0-0c07-4df4-b8bc-b25becd75b97" 	attachdetach-controller	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:07:51 +0000 UTC	Normal	Pod tempo-redmetrics-ingester-0		AddedInterface	Add eth0 [10.128.2.93/23] from openshift-sdn		
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:07:51 +0000 UTC	Normal	Pod tempo-redmetrics-ingester-0.spec.containers{tempo}		PulledContainer image "docker.io/grafana/tempo:2.2.3" already present on machine	kubelet	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:07:51 +0000 UTC	Normal	Pod tempo-redmetrics-ingester-0.spec.containers{tempo}		Created	Created container tempo	kubelet	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:07:51 +0000 UTC	Normal	Pod tempo-redmetrics-ingester-0.spec.containers{tempo}		Started	Started container tempo	kubelet	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:08:01 +0000 UTC	Warning	Pod tempo-redmetrics-compactor-6b474bf54-p57nv.spec.containers{tempo}Unhealthy	Readiness probe failed: HTTP probe failed with statuscode: 503	kubelet	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:08:09 +0000 UTC	Warning	Pod tempo-redmetrics-ingester-0.spec.containers{tempo}		Unhealthy	Readiness probe failed: HTTP probe failed with statuscode: 503	kubelet	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:08:56 +0000 UTC	Normal	Pod hotrod-57d4948b8f-4285w	Binding	Scheduled	Successfully assigned kuttl-test-valid-bengal/hotrod-57d4948b8f-4285w to REDACTED	default-scheduler	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:08:56 +0000 UTC	Normal	ReplicaSet.apps hotrod-57d4948b8f		SuccessfulCreate	Created pod: hotrod-57d4948b8f-4285w	replicaset-controller	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:08:56 +0000 UTC	Normal	Deployment.apps hotrod		ScalingReplicaSet	Scaled up replica set hotrod-57d4948b8f to 1	deployment-controller	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:08:58 +0000 UTC	Normal	Pod hotrod-57d4948b8f-4285w		AddedInterface	Add eth0 [10.131.0.54/23] from openshift-sdn		
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:08:58 +0000 UTC	Normal	Pod hotrod-57d4948b8f-4285w.spec.containers{hotrod}		Pulling	Pulling image "jaegertracing/example-hotrod:1.46.0"	kubelet	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:09:01 +0000 UTC	Normal	Pod hotrod-57d4948b8f-4285w.spec.containers{hotrod}		PulledSuccessfully pulled image "jaegertracing/example-hotrod:1.46.0" in 2.932013304s (2.932029188s including waiting)	kubelet	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:09:01 +0000 UTC	Normal	Pod hotrod-57d4948b8f-4285w.spec.containers{hotrod}		Created	Created container hotrod	kubelet	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:09:01 +0000 UTC	Normal	Pod hotrod-57d4948b8f-4285w.spec.containers{hotrod}		Started	Started container hotrod	kubelet	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:09:05 +0000 UTC	Normal	Pod hotrod-curl-jv8ng	Binding	Scheduled	Successfully assigned kuttl-test-valid-bengal/hotrod-curl-jv8ng to REDACTED	default-scheduler	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:09:05 +0000 UTC	Normal	Job.batch hotrod-curl		SuccessfulCreate	Created pod: hotrod-curl-jv8ng	job-controller	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:09:06 +0000 UTC	Normal	Pod hotrod-curl-jv8ng		AddedInterface	Add eth0 [10.129.2.63/23] from openshift-sdn		
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:09:07 +0000 UTC	Normal	Pod hotrod-curl-jv8ng.spec.containers{hotrod-curl}		Pulling	Pulling image "curlimages/curl"	kubelet	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:09:09 +0000 UTC	Normal	Pod hotrod-curl-jv8ng.spec.containers{hotrod-curl}		PulledSuccessfully pulled image "curlimages/curl" in 2.023049058s (2.023060007s including waiting)	kubelet	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:09:09 +0000 UTC	Normal	Pod hotrod-curl-jv8ng.spec.containers{hotrod-curl}		Created	Created container hotrod-curl	kubelet	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:09:09 +0000 UTC	Normal	Pod hotrod-curl-jv8ng.spec.containers{hotrod-curl}		Started	Started container hotrod-curl	kubelet	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:09:12 +0000 UTC	Normal	Job.batch hotrod-curl		Completed	Job completed	job-controller	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:09:15 +0000 UTC	Normal	Pod verify-metrics-stg4x	Binding	Scheduled	Successfully assigned kuttl-test-valid-bengal/verify-metrics-stg4x to REDACTED	default-scheduler	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:09:15 +0000 UTC	Normal	Job.batch verify-metrics		SuccessfulCreate	Created pod: verify-metrics-stg4x	job-controller	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:09:17 +0000 UTC	Normal	Pod verify-metrics-stg4x		AddedInterface	Add eth0 [10.128.2.94/23] from openshift-sdn		
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:09:17 +0000 UTC	Normal	Pod verify-metrics-stg4x.spec.containers{verify-metrics}		Pulled	Container image "registry.access.redhat.com/ubi9/ubi:9.1" already present on machine	kubelet	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:09:17 +0000 UTC	Normal	Pod verify-metrics-stg4x.spec.containers{verify-metrics}		Created	Created container verify-metrics	kubelet	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:09:17 +0000 UTC	Normal	Pod verify-metrics-stg4x.spec.containers{verify-metrics}		Started	Started container verify-metrics	kubelet	
    logger.go:42: 10:09:22 | red-metrics | 2023-11-03 10:09:20 +0000 UTC	Normal	Job.batch verify-metrics		Completed	Job completedjob-controller	
    logger.go:42: 10:09:26 | red-metrics | Deleting namespace: kuttl-test-valid-bengal
=== CONT  kuttl
    harness.go:405: run tests finished
    harness.go:513: cleaning up
    harness.go:570: removing temp folder: ""
--- PASS: kuttl (191.44s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/red-metrics (187.75s)
PASS
```
