### PR TITLE
[Chore] Fix custom-ca test case to work on OpenShift

### DIFF
--- a/tests/e2e/custom-ca/00-install-storage.yaml
+++ b/tests/e2e/custom-ca/00-install-storage.yaml
@@ -27,7 +27,7 @@ spec:
             - -c
             - |
               mkdir -p /storage/tempo && \
-              minio server /storage
+              minio server --certs-dir=/root/.minio/certs /storage
           env:
             - name: MINIO_ACCESS_KEY
               value: tempo

--- a/tests/e2e/custom-ca/01-install-tempo.yaml
+++ b/tests/e2e/custom-ca/01-install-tempo.yaml
@@ -1,20 +1,3 @@
-apiVersion: tempo.grafana.com/v1alpha1
-kind: TempoStack
-metadata:
-  name: simplest
-spec:
-  storage:
-    secret:
-      name: minio
-      type: s3
-    tls:
-      caName: custom-ca
-  storageSize: 200M
-  template:
-    queryFrontend:
-      jaegerQuery:
-        enabled: true
----
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -50,3 +33,21 @@ data:
     xtdKFBv1LLup2pr/hbmbP+0XHNFuUK36I7oantHhagXL/pGO3vcugppAd+YNzOW9
     Qr67VgKeixOrNiK6W9FzuaWYadv0XOgrJbFhsvmtYqpEMDGZzfdb5dAzdA==
     -----END CERTIFICATE-----
+
+---
+apiVersion: tempo.grafana.com/v1alpha1
+kind: TempoStack
+metadata:
+  name: simplest
+spec:
+  storage:
+    secret:
+      name: minio
+      type: s3
+    tls:
+      caName: custom-ca
+  storageSize: 200M
+  template:
+    queryFrontend:
+      jaegerQuery:
+        enabled: true


### PR DESCRIPTION
```
$ kuttl test --test=custom-ca --timeout=180 tests/e2e
2023/11/03 12:15:29 kutt-test config testdirs is overridden with args: [ tests/e2e ]
=== RUN   kuttl
    harness.go:462: starting setup
    harness.go:252: running tests using configured kubeconfig.
    harness.go:275: Successful connection to cluster at: https://REDACTED:6443
    harness.go:360: running tests
    harness.go:73: going to run test suite with timeout of 180 seconds for each step
    harness.go:372: testsuite: tests/e2e has 7 tests
=== RUN   kuttl/harness
=== RUN   kuttl/harness/custom-ca
=== PAUSE kuttl/harness/custom-ca
=== CONT  kuttl/harness/custom-ca
    logger.go:42: 12:15:34 | custom-ca | Ignoring README.md as it does not match file name regexp: ^(\d+)-(?:[^\.]+)(?:\.yaml)?$
    logger.go:42: 12:15:34 | custom-ca | Creating namespace: kuttl-test-merry-dassie
    logger.go:42: 12:15:34 | custom-ca/0-install-storage | starting test step 0-install-storage
    logger.go:42: 12:15:36 | custom-ca/0-install-storage | Secret:kuttl-test-merry-dassie/minio-cert created
    logger.go:42: 12:15:37 | custom-ca/0-install-storage | Deployment:kuttl-test-merry-dassie/minio created
    logger.go:42: 12:15:38 | custom-ca/0-install-storage | Service:kuttl-test-merry-dassie/minio created
    logger.go:42: 12:15:39 | custom-ca/0-install-storage | Secret:kuttl-test-merry-dassie/minio created
    logger.go:42: 12:15:42 | custom-ca/0-install-storage | test step completed 0-install-storage
    logger.go:42: 12:15:42 | custom-ca/1-install-tempo | starting test step 1-install-tempo
    logger.go:42: 12:15:44 | custom-ca/1-install-tempo | ConfigMap:kuttl-test-merry-dassie/custom-ca created
    logger.go:42: 12:15:45 | custom-ca/1-install-tempo | TempoStack:kuttl-test-merry-dassie/simplest created
    logger.go:42: 12:17:01 | custom-ca/1-install-tempo | test step completed 1-install-tempo
    logger.go:42: 12:17:01 | custom-ca/2-generate-traces | starting test step 2-generate-traces
    logger.go:42: 12:17:03 | custom-ca/2-generate-traces | Job:kuttl-test-merry-dassie/generate-traces created
    logger.go:42: 12:17:08 | custom-ca/2-generate-traces | test step completed 2-generate-traces
    logger.go:42: 12:17:08 | custom-ca/3-verify-traces | starting test step 3-verify-traces
    logger.go:42: 12:17:13 | custom-ca/3-verify-traces | Job:kuttl-test-merry-dassie/verify-traces created
    logger.go:42: 12:17:18 | custom-ca/3-verify-traces | test step completed 3-verify-traces
    logger.go:42: 12:17:20 | custom-ca | custom-ca events from ns kuttl-test-merry-dassie:
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:15:37 +0000 UTC	Normal	Pod minio-86b8b9ffd8-nvb5v	Binding	Scheduled	Successfully assigned kuttl-test-merry-dassie/minio-86b8b9ffd8-nvb5v to REDACTED	
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:15:37 +0000 UTC	Normal	ReplicaSet.apps minio-86b8b9ffd8		SuccessfulCreate	Created pod: minio-86b8b9ffd8-nvb5v	replicaset-controller	
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:15:37 +0000 UTC	Normal	Deployment.apps minio		ScalingReplicaSet	Scaled up replica set minio-86b8b9ffd8 to 1	deployment-controller	
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:15:39 +0000 UTC	Normal	Pod minio-86b8b9ffd8-nvb5v		AddedInterface	Add eth0 [10.128.2.122/23] from openshift-sdn		
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:15:39 +0000 UTC	Normal	Pod minio-86b8b9ffd8-nvb5v.spec.containers{minio}		Pulling	Pulling image "minio/minio"	kubelet	
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:15:40 +0000 UTC	Normal	Pod minio-86b8b9ffd8-nvb5v.spec.containers{minio}		Pulled	Successfully pulled image "minio/minio" in 1.033281718s (1.033295593s including waiting)	kubelet	
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:15:40 +0000 UTC	Normal	Pod minio-86b8b9ffd8-nvb5v.spec.containers{minio}		Created	Created container minio	kubelet	
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:15:40 +0000 UTC	Normal	Pod minio-86b8b9ffd8-nvb5v.spec.containers{minio}		Started	Started container minio	kubelet	
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:15:46 +0000 UTC	Normal	PersistentVolumeClaim data-tempo-simplest-ingester-0		WaitForFirstConsumer	waiting for first consumer to be created before binding	persistentvolume-controller	
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:15:46 +0000 UTC	Normal	PersistentVolumeClaim data-tempo-simplest-ingester-0		Provisioning	External provisioner is provisioning volume for claim "kuttl-test-merry-dassie/data-tempo-simplest-ingester-0"		
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:15:46 +0000 UTC	Normal	PersistentVolumeClaim data-tempo-simplest-ingester-0		ExternalProvisioning	waiting for a volume to be created, either by external provisioner "pd.csi.storage.gke.io" or manually created by system administrator	persistentvolume-controller	
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:15:46 +0000 UTC	Normal	Pod tempo-simplest-compactor-59d8cbbd5b-5rvfz	Binding	Scheduled	Successfully assigned kuttl-test-merry-dassie/tempo-simplest-compactor-59d8cbbd5b-5rvfz to REDACTED	default-scheduler	
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:15:46 +0000 UTC	Normal	ReplicaSet.apps tempo-simplest-compactor-59d8cbbd5b		SuccessfulCreate	Created pod: tempo-simplest-compactor-59d8cbbd5b-5rvfz	replicaset-controller	
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:15:46 +0000 UTC	Normal	Deployment.apps tempo-simplest-compactor		ScalingReplicaSet	Scaled up replica set tempo-simplest-compactor-59d8cbbd5b to 1	deployment-controller	
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:15:46 +0000 UTC	Normal	Pod tempo-simplest-distributor-59dc7d48c-xqdwb	Binding	Scheduled	Successfully assigned kuttl-test-merry-dassie/tempo-simplest-distributor-59dc7d48c-xqdwb to REDACTED	default-scheduler	
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:15:46 +0000 UTC	Normal	ReplicaSet.apps tempo-simplest-distributor-59dc7d48c		SuccessfulCreate	Created pod: tempo-simplest-distributor-59dc7d48c-xqdwb	replicaset-controller	
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:15:46 +0000 UTC	Normal	Deployment.apps tempo-simplest-distributor		ScalingReplicaSet	Scaled up replica set tempo-simplest-distributor-59dc7d48c to 1	deployment-controller	
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:15:46 +0000 UTC	Normal	StatefulSet.apps tempo-simplest-ingester		SuccessfulCreate	create Claim data-tempo-simplest-ingester-0 Pod tempo-simplest-ingester-0 in StatefulSet tempo-simplest-ingester success	statefulset-controller	
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:15:46 +0000 UTC	Normal	StatefulSet.apps tempo-simplest-ingester		SuccessfulCreate	create Pod tempo-simplest-ingester-0 in StatefulSet tempo-simplest-ingester successful	statefulset-controller	
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:15:46 +0000 UTC	Normal	Pod tempo-simplest-querier-7ff88f9475-9mrn2	Binding	Scheduled	Successfully assigned kuttl-test-merry-dassie/tempo-simplest-querier-7ff88f9475-9mrn2 to REDACTED	default-scheduler	
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:15:46 +0000 UTC	Normal	ReplicaSet.apps tempo-simplest-querier-7ff88f9475		SuccessfulCreate	Created pod: tempo-simplest-querier-7ff88f9475-9mrn2	replicaset-controller	
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:15:46 +0000 UTC	Normal	Deployment.apps tempo-simplest-querier		ScalingReplicaSet	Scaled up replica set tempo-simplest-querier-7ff88f9475 to 1	deployment-controller	
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:15:46 +0000 UTC	Normal	Pod tempo-simplest-query-frontend-dc7f5d4bd-lsmdq	Binding	Scheduled	Successfully assigned kuttl-test-merry-dassie/tempo-simplest-query-frontend-dc7f5d4bd-lsmdq to REDACTED	default-scheduler	
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:15:46 +0000 UTC	Normal	ReplicaSet.apps tempo-simplest-query-frontend-dc7f5d4bd		SuccessfulCreate	Created pod: tempo-simplest-query-frontend-dc7f5d4bd-lsmdq	replicaset-controller	
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:15:46 +0000 UTC	Normal	Deployment.apps tempo-simplest-query-frontend		ScalingReplicaSet	Scaled up replica set tempo-simplest-query-frontend-dc7f5d4bd to 1	deployment-controller	
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:15:48 +0000 UTC	Normal	Pod tempo-simplest-compactor-59d8cbbd5b-5rvfz		AddedInterface	Add eth0 [10.131.0.59/23] from openshift-sdn		
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:15:48 +0000 UTC	Normal	Pod tempo-simplest-compactor-59d8cbbd5b-5rvfz.spec.containers{tempo}		Pulled	Container image "docker.io/grafana/tempo:2.2.3" already present on machine	kubelet	
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:15:48 +0000 UTC	Normal	Pod tempo-simplest-compactor-59d8cbbd5b-5rvfz.spec.containers{tempo}		Created	Created container tempo	kubelet	
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:15:48 +0000 UTC	Normal	Pod tempo-simplest-compactor-59d8cbbd5b-5rvfz.spec.containers{tempo}		Started	Started container tempo	kubelet	
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:15:48 +0000 UTC	Normal	Pod tempo-simplest-distributor-59dc7d48c-xqdwb		AddedInterface	Add eth0 [10.128.2.124/23] from openshift-sdn		
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:15:48 +0000 UTC	Normal	Pod tempo-simplest-distributor-59dc7d48c-xqdwb.spec.containers{tempo}		Pulled	Container image "docker.io/grafana/tempo:2.2.3" already present on machine	kubelet	
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:15:48 +0000 UTC	Normal	Pod tempo-simplest-distributor-59dc7d48c-xqdwb.spec.containers{tempo}		Created	Created container tempo	kubelet	
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:15:48 +0000 UTC	Normal	Pod tempo-simplest-distributor-59dc7d48c-xqdwb.spec.containers{tempo}		Started	Started container tempo	kubelet	
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:15:48 +0000 UTC	Normal	Pod tempo-simplest-querier-7ff88f9475-9mrn2		AddedInterface	Add eth0 [10.128.2.123/23] from openshift-sdn		
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:15:48 +0000 UTC	Normal	Pod tempo-simplest-querier-7ff88f9475-9mrn2.spec.containers{tempo}		Pulled	Container image "docker.io/grafana/tempo:2.2.3" already present on machine	kubelet	
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:15:48 +0000 UTC	Normal	Pod tempo-simplest-querier-7ff88f9475-9mrn2.spec.containers{tempo}		Created	Created container tempo	kubelet	
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:15:48 +0000 UTC	Normal	Pod tempo-simplest-querier-7ff88f9475-9mrn2.spec.containers{tempo}		Started	Started container tempo	kubelet	
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:15:48 +0000 UTC	Normal	Pod tempo-simplest-query-frontend-dc7f5d4bd-lsmdq		AddedInterfaceAdd eth0 [10.129.2.69/23] from openshift-sdn		
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:15:48 +0000 UTC	Normal	Pod tempo-simplest-query-frontend-dc7f5d4bd-lsmdq.spec.containers{tempo}	Pulled	Container image "docker.io/grafana/tempo:2.2.3" already present on machine	kubelet	
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:15:48 +0000 UTC	Normal	Pod tempo-simplest-query-frontend-dc7f5d4bd-lsmdq.spec.containers{tempo}	Created	Created container tempo	kubelet	
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:15:48 +0000 UTC	Normal	Pod tempo-simplest-query-frontend-dc7f5d4bd-lsmdq.spec.containers{tempo}	Started	Started container tempo	kubelet	
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:15:48 +0000 UTC	Normal	Pod tempo-simplest-query-frontend-dc7f5d4bd-lsmdq.spec.containers{tempo-query}Pulled	Container image "docker.io/grafana/tempo-query:main-2e5e27a" already present on machine	kubelet	
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:15:48 +0000 UTC	Normal	Pod tempo-simplest-query-frontend-dc7f5d4bd-lsmdq.spec.containers{tempo-query}Created	Created container tempo-query	kubelet	
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:15:49 +0000 UTC	Normal	Pod tempo-simplest-query-frontend-dc7f5d4bd-lsmdq.spec.containers{tempo-query}Started	Started container tempo-query	kubelet	
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:15:50 +0000 UTC	Normal	PersistentVolumeClaim data-tempo-simplest-ingester-0		ProvisioningSucceeded	Successfully provisioned volume pvc-42986d21-8bd7-4cc1-94b1-2fa3d4aabc53		
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:15:50 +0000 UTC	Normal	Pod tempo-simplest-ingester-0	Binding	Scheduled	Successfully assigned kuttl-test-merry-dassie/tempo-simplest-ingester-0 to REDACTED	default-scheduler	
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:15:58 +0000 UTC	Normal	Pod tempo-simplest-ingester-0		SuccessfulAttachVolume	AttachVolume.Attach succeeded for volume "pvc-42986d21-8bd7-4cc1-94b1-2fa3d4aabc53" 	attachdetach-controller	
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:16:00 +0000 UTC	Normal	Pod tempo-simplest-ingester-0		AddedInterface	Add eth0 [10.131.0.60/23] from openshift-sdn		
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:16:00 +0000 UTC	Normal	Pod tempo-simplest-ingester-0.spec.containers{tempo}		Pulled	Container image "docker.io/grafana/tempo:2.2.3" already present on machine	kubelet	
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:16:00 +0000 UTC	Normal	Pod tempo-simplest-ingester-0.spec.containers{tempo}		Created	Created container tempo	kubelet	
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:16:00 +0000 UTC	Normal	Pod tempo-simplest-ingester-0.spec.containers{tempo}		Started	Started container tempo	kubelet	
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:16:07 +0000 UTC	Warning	Pod tempo-simplest-compactor-59d8cbbd5b-5rvfz.spec.containers{tempo}		Unhealthy	Readiness probe failed: HTTP probe failed with statuscode: 503	kubelet	
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:16:19 +0000 UTC	Warning	Pod tempo-simplest-ingester-0.spec.containers{tempo}		Unhealthy	Readiness probe failed: HTTP probe failed with statuscode: 503	kubelet	
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:17:03 +0000 UTC	Normal	Pod generate-traces-g6lxs	Binding	Scheduled	Successfully assigned kuttl-test-merry-dassie/generate-traces-g6lxs to REDACTED	default-scheduler	
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:17:03 +0000 UTC	Normal	Job.batch generate-traces		SuccessfulCreate	Created pod: generate-traces-g6lxs	job-controller	
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:17:04 +0000 UTC	Normal	Pod generate-traces-g6lxs		AddedInterface	Add eth0 [10.128.2.125/23] from openshift-sdn		
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:17:04 +0000 UTC	Normal	Pod generate-traces-g6lxs.spec.containers{telemetrygen}		Pulled	Container image "ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.75.0" already present on machine	kubelet	
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:17:04 +0000 UTC	Normal	Pod generate-traces-g6lxs.spec.containers{telemetrygen}		Created	Created container telemetrygen	kubelet	
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:17:04 +0000 UTC	Normal	Pod generate-traces-g6lxs.spec.containers{telemetrygen}		Started	Started container telemetrygen	kubelet	
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:17:06 +0000 UTC	Normal	Job.batch generate-traces		Completed	Job completed	job-controller	
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:17:12 +0000 UTC	Normal	Pod verify-traces-tstqx	Binding	Scheduled	Successfully assigned kuttl-test-merry-dassie/verify-traces-tstqx to REDACTED	default-scheduler	
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:17:12 +0000 UTC	Normal	Job.batch verify-traces		SuccessfulCreate	Created pod: verify-traces-tstqx	job-controller	
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:17:15 +0000 UTC	Normal	Pod verify-traces-tstqx		AddedInterface	Add eth0 [10.128.2.126/23] from openshift-sdn		
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:17:15 +0000 UTC	Normal	Pod verify-traces-tstqx.spec.containers{verify-traces}		Pulled	Container image "registry.gitlab.com/gitlab-ci-utils/curl-jq:1.1.0" already present on machine	kubelet	
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:17:15 +0000 UTC	Normal	Pod verify-traces-tstqx.spec.containers{verify-traces}		Created	Created container verify-traces	kubelet	
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:17:15 +0000 UTC	Normal	Pod verify-traces-tstqx.spec.containers{verify-traces}		Started	Started container verify-traces	kubelet	
    logger.go:42: 12:17:20 | custom-ca | 2023-11-03 12:17:17 +0000 UTC	Normal	Job.batch verify-traces		Completed	Job completed	job-controller
    logger.go:42: 12:17:22 | custom-ca | Deleting namespace: kuttl-test-merry-dassie
=== CONT  kuttl
    harness.go:405: run tests finished
    harness.go:513: cleaning up
    harness.go:570: removing temp folder: ""
--- PASS: kuttl (148.10s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/custom-ca (144.03s)
PASS
```
