### PR TITLE
Unset (default) images in TempoStack CR

### DIFF
--- a/.chloggen/unset_images_in_cr.yaml
+++ b/.chloggen/unset_images_in_cr.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, github action)
+component: operator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Unset (default) images in TempoStack CR
+
+# One or more tracking issues related to the change
+issues: [674]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: From 0.6.0 onwards, the image location is not stored in the TempoStack CR unless it got changed manually

--- a/.chloggen/unset_images_in_cr.yaml
+++ b/.chloggen/unset_images_in_cr.yaml
@@ -13,4 +13,6 @@ issues: [674]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext: From 0.6.0 onwards, the image location is not stored in the TempoStack CR unless it got changed manually
+subtext: |
+  This upgrade reverts any change to the `spec.images` fields of any TempoStack instance.
+  Beginning with version 0.6.0, the image location is not stored in the TempoStack instance unless it is changed manually.

--- a/apis/tempo/v1alpha1/tempostack_webhook.go
+++ b/apis/tempo/v1alpha1/tempostack_webhook.go
@@ -74,31 +74,6 @@ func (d *Defaulter) Default(ctx context.Context, obj runtime.Object) error {
 	}
 	r.Labels["tempo.grafana.com/distribution"] = d.ctrlConfig.Distribution
 
-	if r.Spec.Images.Tempo == "" {
-		if d.ctrlConfig.DefaultImages.Tempo == "" {
-			return fmt.Errorf("please specify a tempo image in the CR or in the %s env var", v1alpha1.EnvRelatedImageTempo)
-		}
-		r.Spec.Images.Tempo = d.ctrlConfig.DefaultImages.Tempo
-	}
-	if r.Spec.Images.TempoQuery == "" {
-		if d.ctrlConfig.DefaultImages.TempoQuery == "" {
-			return fmt.Errorf("please specify a tempoQuery image in the CR or in the %s env var", v1alpha1.EnvRelatedImageTempoQuery)
-		}
-		r.Spec.Images.TempoQuery = d.ctrlConfig.DefaultImages.TempoQuery
-	}
-	if r.Spec.Images.TempoGateway == "" {
-		if d.ctrlConfig.DefaultImages.TempoGateway == "" {
-			return fmt.Errorf("please specify a tempoGateway image in the CR or in the %s env var", v1alpha1.EnvRelatedImageTempoGateway)
-		}
-		r.Spec.Images.TempoGateway = d.ctrlConfig.DefaultImages.TempoGateway
-	}
-	if r.Spec.Images.TempoGatewayOpa == "" {
-		if d.ctrlConfig.DefaultImages.TempoGatewayOpa == "" {
-			return fmt.Errorf("please specify a tempoGatewayOpa image in the CR or in the %s env var", v1alpha1.EnvRelatedImageTempoGatewayOpa)
-		}
-		r.Spec.Images.TempoGatewayOpa = d.ctrlConfig.DefaultImages.TempoGatewayOpa
-	}
-
 	if r.Spec.ServiceAccount == "" {
 		r.Spec.ServiceAccount = naming.DefaultServiceAccountName(r.Name)
 	}

--- a/apis/tempo/v1alpha1/tempostack_webhook_test.go
+++ b/apis/tempo/v1alpha1/tempostack_webhook_test.go
@@ -134,13 +134,8 @@ func TestDefault(t *testing.T) {
 				},
 				Spec: TempoStackSpec{
 					ReplicationFactor: 1,
-					Images: v1alpha1.ImagesSpec{
-						Tempo:           "docker.io/grafana/tempo:x.y.z",
-						TempoQuery:      "docker.io/grafana/tempo-query:x.y.z",
-						TempoGateway:    "docker.io/observatorium/gateway:1.2.3",
-						TempoGatewayOpa: "docker.io/observatorium/opa-openshift:1.2.3",
-					},
-					ServiceAccount: "tempo-test",
+					Images:            v1alpha1.ImagesSpec{},
+					ServiceAccount:    "tempo-test",
 					Retention: RetentionSpec{
 						Global: RetentionConfig{
 							Traces: metav1.Duration{Duration: 48 * time.Hour},
@@ -201,13 +196,8 @@ func TestDefault(t *testing.T) {
 				},
 				Spec: TempoStackSpec{
 					ReplicationFactor: 1,
-					Images: v1alpha1.ImagesSpec{
-						Tempo:           "docker.io/grafana/tempo:x.y.z",
-						TempoQuery:      "docker.io/grafana/tempo-query:x.y.z",
-						TempoGateway:    "docker.io/observatorium/gateway:1.2.3",
-						TempoGatewayOpa: "docker.io/observatorium/opa-openshift:1.2.3",
-					},
-					ServiceAccount: "tempo-test",
+					Images:            v1alpha1.ImagesSpec{},
+					ServiceAccount:    "tempo-test",
 					Retention: RetentionSpec{
 						Global: RetentionConfig{
 							Traces: metav1.Duration{Duration: 48 * time.Hour},

--- a/cmd/generate/main_test.go
+++ b/cmd/generate/main_test.go
@@ -19,15 +19,15 @@ import (
 )
 
 func TestBuild(t *testing.T) {
-	ctrlConfig := configv1alpha1.ProjectConfig{
-		DefaultImages: configv1alpha1.ImagesSpec{
-			Tempo:           "tempo-image",
-			TempoQuery:      "tempo-query-image",
-			TempoGateway:    "tempo-gateway-image",
-			TempoGatewayOpa: "tempo-gateway-opa-image",
-		},
-	}
 	params := manifestutils.Params{
+		CtrlConfig: configv1alpha1.ProjectConfig{
+			DefaultImages: configv1alpha1.ImagesSpec{
+				Tempo:           "tempo-image",
+				TempoQuery:      "tempo-query-image",
+				TempoGateway:    "tempo-gateway-image",
+				TempoGatewayOpa: "tempo-gateway-opa-image",
+			},
+		},
 		StorageParams: manifestutils.StorageParams{
 			AzureStorage: &manifestutils.AzureStorage{},
 			GCS:          &manifestutils.GCS{},
@@ -35,7 +35,7 @@ func TestBuild(t *testing.T) {
 		},
 	}
 
-	objects, err := build(ctrlConfig, params)
+	objects, err := build(params)
 	require.NoError(t, err)
 	require.Equal(t, 14, len(objects))
 }

--- a/controllers/tempo/tempostack_create_or_update.go
+++ b/controllers/tempo/tempostack_create_or_update.go
@@ -152,7 +152,7 @@ func (r *TempoStackReconciler) createOrUpdate(ctx context.Context, log logr.Logg
 	managedObjects, err := manifests.BuildAll(manifestutils.Params{
 		Tempo:               tempo,
 		StorageParams:       storageConfig,
-		Gates:               r.CtrlConfig.Gates,
+		CtrlConfig:          r.CtrlConfig,
 		TLSProfile:          tlsProfile,
 		GatewayTenantSecret: tenantSecrets,
 		GatewayTenantsData:  gatewayTenantsData,

--- a/internal/manifests/config/build.go
+++ b/internal/manifests/config/build.go
@@ -47,7 +47,7 @@ func fromRateLimitSpecToRateLimitOptionsMap(ratemaps map[string]v1alpha1.RateLim
 
 func buildQueryFrontEndConfig(params manifestutils.Params) ([]byte, error) {
 	if !params.Tempo.Spec.Template.Gateway.Enabled {
-		params.Gates.HTTPEncryption = false
+		params.CtrlConfig.Gates.HTTPEncryption = false
 	}
 
 	return buildConfiguration(params)
@@ -58,7 +58,7 @@ func buildConfiguration(params manifestutils.Params) ([]byte, error) {
 	tlsopts := tlsOptions{}
 	var err error
 
-	if params.Gates.GRPCEncryption || params.Gates.HTTPEncryption {
+	if params.CtrlConfig.Gates.GRPCEncryption || params.CtrlConfig.Gates.HTTPEncryption {
 		tlsopts, err = buildTLSConfig(params)
 		if err != nil {
 			return []byte{}, err
@@ -79,8 +79,8 @@ func buildConfiguration(params manifestutils.Params) ([]byte, error) {
 		Multitenancy:           tempo.Spec.Tenants != nil,
 		Gateway:                tempo.Spec.Template.Gateway.Enabled,
 		Gates: featureGates{
-			GRPCEncryption: params.Gates.GRPCEncryption,
-			HTTPEncryption: params.Gates.HTTPEncryption,
+			GRPCEncryption: params.CtrlConfig.Gates.GRPCEncryption,
+			HTTPEncryption: params.CtrlConfig.Gates.HTTPEncryption,
 		},
 		TLS:         tlsopts,
 		ReceiverTLS: buildReceiverTLSConfig(tempo),
@@ -151,8 +151,8 @@ func buildTempoQueryConfig(params manifestutils.Params) ([]byte, error) {
 		TLS:      tlsopts,
 		HTTPPort: manifestutils.PortHTTPServer,
 		Gates: featureGates{
-			GRPCEncryption: params.Gates.GRPCEncryption,
-			HTTPEncryption: params.Gates.HTTPEncryption,
+			GRPCEncryption: params.CtrlConfig.Gates.GRPCEncryption,
+			HTTPEncryption: params.CtrlConfig.Gates.HTTPEncryption,
 		},
 		TenantHeader: manifestutils.TenantHeader,
 		Gateway:      params.Tempo.Spec.Template.Gateway.Enabled,

--- a/internal/manifests/config/build_test.go
+++ b/internal/manifests/config/build_test.go
@@ -1512,9 +1512,11 @@ ingester_client:
 				"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384"},
 			MinTLSVersion: "VersionTLS12",
 		},
-		Gates: configv1alpha1.FeatureGates{
-			HTTPEncryption: true,
-			GRPCEncryption: true,
+		CtrlConfig: configv1alpha1.ProjectConfig{
+			Gates: configv1alpha1.FeatureGates{
+				HTTPEncryption: true,
+				GRPCEncryption: true,
+			},
 		},
 	})
 	require.NoError(t, err)
@@ -1669,9 +1671,11 @@ ingester_client:
 				"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384"},
 			MinTLSVersion: "VersionTLS12",
 		},
-		Gates: configv1alpha1.FeatureGates{
-			HTTPEncryption: true,
-			GRPCEncryption: true,
+		CtrlConfig: configv1alpha1.ProjectConfig{
+			Gates: configv1alpha1.FeatureGates{
+				HTTPEncryption: true,
+				GRPCEncryption: true,
+			},
 		},
 	})
 	require.NoError(t, err)

--- a/internal/manifests/gateway/gateway_test.go
+++ b/internal/manifests/gateway/gateway_test.go
@@ -62,12 +62,12 @@ func TestRbacConfig(t *testing.T) {
 		StorageParams:       manifestutils.StorageParams{},
 		ConfigChecksum:      "",
 		Tempo:               tempo,
-		Gates:               configv1alpha1.FeatureGates{},
+		CtrlConfig:          configv1alpha1.ProjectConfig{},
 		TLSProfile:          tlsprofile.TLSProfileOptions{},
 		GatewayTenantSecret: []*manifestutils.GatewayTenantOIDCSecret{},
 	}
 
-	cfgOpts := newOptions(params.Tempo, params.Gates.OpenShift.BaseDomain, params.GatewayTenantSecret, params.GatewayTenantsData)
+	cfgOpts := newOptions(params.Tempo, params.CtrlConfig.Gates.OpenShift.BaseDomain, params.GatewayTenantSecret, params.GatewayTenantsData)
 	tenantsCfg, _, err := buildConfigFiles(cfgOpts)
 	assert.NoError(t, err)
 
@@ -113,12 +113,12 @@ func TestTenantsConfig(t *testing.T) {
 		StorageParams:       manifestutils.StorageParams{},
 		ConfigChecksum:      "",
 		Tempo:               tempo,
-		Gates:               configv1alpha1.FeatureGates{},
+		CtrlConfig:          configv1alpha1.ProjectConfig{},
 		TLSProfile:          tlsprofile.TLSProfileOptions{},
 		GatewayTenantSecret: []*manifestutils.GatewayTenantOIDCSecret{},
 	}
 
-	cfgOpts := newOptions(params.Tempo, params.Gates.OpenShift.BaseDomain, params.GatewayTenantSecret, params.GatewayTenantsData)
+	cfgOpts := newOptions(params.Tempo, params.CtrlConfig.Gates.OpenShift.BaseDomain, params.GatewayTenantSecret, params.GatewayTenantsData)
 	_, tenantsCfg, err := buildConfigFiles(cfgOpts)
 	assert.NoError(t, err)
 
@@ -158,11 +158,13 @@ func TestBuildGateway_openshift(t *testing.T) {
 	}
 	objects, err := BuildGateway(manifestutils.Params{
 		Tempo: tempo,
-		Gates: configv1alpha1.FeatureGates{
-			OpenShift: configv1alpha1.OpenShiftFeatureGates{
-				ServingCertsService: true,
-				OpenShiftRoute:      true,
-				BaseDomain:          "domain",
+		CtrlConfig: configv1alpha1.ProjectConfig{
+			Gates: configv1alpha1.FeatureGates{
+				OpenShift: configv1alpha1.OpenShiftFeatureGates{
+					ServingCertsService: true,
+					OpenShiftRoute:      true,
+					BaseDomain:          "domain",
+				},
 			},
 		},
 	})
@@ -418,10 +420,12 @@ func TestTLSParameters(t *testing.T) {
 	// test with TLS
 	objects, err := BuildGateway(manifestutils.Params{
 		Tempo: tempo,
-		Gates: configv1alpha1.FeatureGates{
-			HTTPEncryption: true,
-			OpenShift: configv1alpha1.OpenShiftFeatureGates{
-				BaseDomain: "domain",
+		CtrlConfig: configv1alpha1.ProjectConfig{
+			Gates: configv1alpha1.FeatureGates{
+				HTTPEncryption: true,
+				OpenShift: configv1alpha1.OpenShiftFeatureGates{
+					BaseDomain: "domain",
+				},
 			},
 		},
 	})
@@ -449,10 +453,12 @@ func TestTLSParameters(t *testing.T) {
 	// test without TLS
 	objects, err = BuildGateway(manifestutils.Params{
 		Tempo: tempo,
-		Gates: configv1alpha1.FeatureGates{
-			HTTPEncryption: false,
-			OpenShift: configv1alpha1.OpenShiftFeatureGates{
-				BaseDomain: "domain",
+		CtrlConfig: configv1alpha1.ProjectConfig{
+			Gates: configv1alpha1.FeatureGates{
+				HTTPEncryption: false,
+				OpenShift: configv1alpha1.OpenShiftFeatureGates{
+					BaseDomain: "domain",
+				},
 			},
 		},
 	})

--- a/internal/manifests/gateway/openshift_test.go
+++ b/internal/manifests/gateway/openshift_test.go
@@ -11,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/grafana/tempo-operator/apis/tempo/v1alpha1"
+	"github.com/grafana/tempo-operator/internal/manifests/manifestutils"
 	"github.com/grafana/tempo-operator/internal/manifests/naming"
 )
 
@@ -36,7 +37,7 @@ func TestPatchOPAContainer(t *testing.T) {
 			},
 		},
 	}
-	dep, err := patchOCPOPAContainer(tempo, &appsv1.Deployment{})
+	dep, err := patchOCPOPAContainer(manifestutils.Params{Tempo: tempo}, &appsv1.Deployment{})
 	require.NoError(t, err)
 	require.Equal(t, 1, len(dep.Spec.Template.Spec.Containers))
 	assert.Equal(t, []string{

--- a/internal/manifests/manifestutils/params.go
+++ b/internal/manifests/manifestutils/params.go
@@ -11,7 +11,7 @@ type Params struct {
 	StorageParams       StorageParams
 	ConfigChecksum      string
 	Tempo               v1alpha1.TempoStack
-	Gates               configv1alpha1.FeatureGates
+	CtrlConfig          configv1alpha1.ProjectConfig
 	TLSProfile          tlsprofile.TLSProfileOptions
 	GatewayTenantSecret []*GatewayTenantOIDCSecret
 	GatewayTenantsData  []*GatewayTenantsData

--- a/internal/manifests/queryfrontend/query_frontend_test.go
+++ b/internal/manifests/queryfrontend/query_frontend_test.go
@@ -482,9 +482,11 @@ func TestQueryFrontendJaegerRoute(t *testing.T) {
 
 func TestQueryFrontendJaegerTLS(t *testing.T) {
 	objects, err := BuildQueryFrontend(manifestutils.Params{
-		Gates: configv1alpha1.FeatureGates{
-			HTTPEncryption: true,
-			GRPCEncryption: true,
+		CtrlConfig: configv1alpha1.ProjectConfig{
+			Gates: configv1alpha1.FeatureGates{
+				HTTPEncryption: true,
+				GRPCEncryption: true,
+			},
 		},
 		Tempo: v1alpha1.TempoStack{
 			ObjectMeta: metav1.ObjectMeta{

--- a/internal/manifests/servicemonitor/servicemonitor.go
+++ b/internal/manifests/servicemonitor/servicemonitor.go
@@ -37,7 +37,7 @@ func buildServiceMonitor(params manifestutils.Params, component string, port str
 	scheme := "http"
 	var tlsConfig *monitoringv1.TLSConfig
 
-	if params.Gates.HTTPEncryption {
+	if params.CtrlConfig.Gates.HTTPEncryption {
 		scheme = "https"
 		serverName := naming.ServiceFqdn(tempo.Namespace, tempo.Name, component)
 

--- a/internal/manifests/servicemonitor/servicemonitor_test.go
+++ b/internal/manifests/servicemonitor/servicemonitor_test.go
@@ -60,8 +60,10 @@ func TestBuildServiceMonitors(t *testing.T) {
 
 func TestBuildServiceMonitorsTLS(t *testing.T) {
 	objects := BuildServiceMonitors(manifestutils.Params{
-		Gates: configv1alpha1.FeatureGates{
-			HTTPEncryption: true,
+		CtrlConfig: configv1alpha1.ProjectConfig{
+			Gates: configv1alpha1.FeatureGates{
+				HTTPEncryption: true,
+			},
 		},
 		Tempo: v1alpha1.TempoStack{
 			ObjectMeta: metav1.ObjectMeta{
@@ -186,8 +188,10 @@ func TestBuildGatewayServiceMonitor(t *testing.T) {
 
 func TestBuildGatewayServiceMonitorsTLS(t *testing.T) {
 	objects := BuildServiceMonitors(manifestutils.Params{
-		Gates: configv1alpha1.FeatureGates{
-			HTTPEncryption: true,
+		CtrlConfig: configv1alpha1.ProjectConfig{
+			Gates: configv1alpha1.FeatureGates{
+				HTTPEncryption: true,
+			},
 		},
 		Tempo: v1alpha1.TempoStack{
 			ObjectMeta: metav1.ObjectMeta{

--- a/internal/tlsprofile/options.go
+++ b/internal/tlsprofile/options.go
@@ -38,6 +38,6 @@ func (o TLSProfileOptions) MinVersionShort() (string, error) {
 	case string(openshiftconfigv1.VersionTLS13):
 		return "1.3", nil
 	default:
-		return "", errors.New("invalid TLS version")
+		return "", ErrInvalidTLSVersion
 	}
 }

--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -163,33 +163,11 @@ func (u Upgrade) updateTempoStackCR(ctx context.Context, tempo v1alpha1.TempoSta
 		}
 	}
 
-	// update all tempo images to the new default images on every upgrade
-	updateTempoStackImages(u, &tempo)
-
 	// at the end of the upgrade process, the CR is up to date with the current running component versions (Operator, Tempo, TempoQuery)
 	// update all component versions in the Status field of the CR with the current running versions
 	updateTempoStackVersions(u, &tempo)
 
 	return tempo, nil
-}
-
-// updateTempoStackImages updates all images with the default images of the operator configuration.
-func updateTempoStackImages(u Upgrade, tempo *v1alpha1.TempoStack) {
-	if u.CtrlConfig.DefaultImages.Tempo != "" {
-		tempo.Spec.Images.Tempo = u.CtrlConfig.DefaultImages.Tempo
-	}
-
-	if u.CtrlConfig.DefaultImages.TempoQuery != "" {
-		tempo.Spec.Images.TempoQuery = u.CtrlConfig.DefaultImages.TempoQuery
-	}
-
-	if u.CtrlConfig.DefaultImages.TempoGateway != "" {
-		tempo.Spec.Images.TempoGateway = u.CtrlConfig.DefaultImages.TempoGateway
-	}
-
-	if u.CtrlConfig.DefaultImages.TempoGatewayOpa != "" {
-		tempo.Spec.Images.TempoGatewayOpa = u.CtrlConfig.DefaultImages.TempoGatewayOpa
-	}
 }
 
 // updateTempoStackVersions updates all component versions in the CR with the current running component versions.

--- a/internal/upgrade/upgrade_test.go
+++ b/internal/upgrade/upgrade_test.go
@@ -29,12 +29,7 @@ func createTempoCR(t *testing.T, nsn types.NamespacedName, version string, manag
 		},
 		Spec: v1alpha1.TempoStackSpec{
 			ManagementState: managementState,
-			Images: configv1alpha1.ImagesSpec{
-				Tempo:           "docker.io/grafana/tempo:0.0.0",
-				TempoQuery:      "docker.io/grafana/tempo-query:0.0.0",
-				TempoGateway:    "quay.io/observatorium/api:0.0.0",
-				TempoGatewayOpa: "quay.io/observatorium/opa-openshift:0.0.0",
-			},
+			Images:          configv1alpha1.ImagesSpec{},
 			Storage: v1alpha1.ObjectStorageSpec{
 				Secret: v1alpha1.ObjectStorageSecretSpec{
 					Type: v1alpha1.ObjectStorageSecretS3,
@@ -82,14 +77,10 @@ func TestUpgradeToLatest(t *testing.T) {
 	upgradedTempo := v1alpha1.TempoStack{}
 	err = k8sClient.Get(context.Background(), nsn, &upgradedTempo)
 	assert.NoError(t, err)
+
+	// assert versions were updated
 	assert.Equal(t, currentV.OperatorVersion, upgradedTempo.Status.OperatorVersion)
 	assert.Equal(t, currentV.TempoVersion, upgradedTempo.Status.TempoVersion)
-
-	// assert images were updated
-	assert.Equal(t, "docker.io/grafana/tempo:latest", upgradedTempo.Spec.Images.Tempo)
-	assert.Equal(t, "docker.io/grafana/tempo-query:latest", upgradedTempo.Spec.Images.TempoQuery)
-	assert.Equal(t, "quay.io/observatorium/api:latest", upgradedTempo.Spec.Images.TempoGateway)
-	assert.Equal(t, "quay.io/observatorium/opa-openshift:latest", upgradedTempo.Spec.Images.TempoGatewayOpa)
 }
 
 func TestSkipUpgrade(t *testing.T) {

--- a/internal/upgrade/v0_6_0.go
+++ b/internal/upgrade/v0_6_0.go
@@ -1,0 +1,17 @@
+package upgrade
+
+import (
+	"context"
+
+	"github.com/grafana/tempo-operator/apis/tempo/v1alpha1"
+)
+
+// This upgrade unsets the image fields in the TempoStack CR.
+// From 0.6.0 onwards, the image location is not stored in the CR unless it got changed manually.
+func upgrade0_6_0(ctx context.Context, u Upgrade, tempo *v1alpha1.TempoStack) (*v1alpha1.TempoStack, error) {
+	tempo.Spec.Images.Tempo = ""
+	tempo.Spec.Images.TempoQuery = ""
+	tempo.Spec.Images.TempoGateway = ""
+	tempo.Spec.Images.TempoGatewayOpa = ""
+	return tempo, nil
+}

--- a/internal/upgrade/versions.go
+++ b/internal/upgrade/versions.go
@@ -31,5 +31,9 @@ var (
 			version: *semver.MustParse("0.5.0"),
 			upgrade: upgrade0_5_0,
 		},
+		{
+			version: *semver.MustParse("0.6.0"),
+			upgrade: upgrade0_6_0,
+		},
 	}
 )

--- a/tests/e2e/generate/01-generate.yaml
+++ b/tests/e2e/generate/01-generate.yaml
@@ -7,6 +7,6 @@ commands:
       RELATED_IMAGE_TEMPO_QUERY=docker.io/grafana/tempo-query:2.2.1
       RELATED_IMAGE_TEMPO_GATEWAY=quay.io/observatorium/api:main-2023-09-13-14e06c6
       RELATED_IMAGE_TEMPO_GATEWAY_OPA=quay.io/observatorium/opa-openshift:main-2023-05-24-8e91537
-      ../../../bin/manager generate --config ../../../config/overlays/community/controller_manager_config.yaml --cr cr.yaml --output generated.yaml"
+      ../../../bin/manager generate --config config.yaml --cr cr.yaml --output generated.yaml"
   - command: kubectl apply -f generated.yaml
     namespaced: true

--- a/tests/e2e/generate/config.yaml
+++ b/tests/e2e/generate/config.yaml
@@ -1,0 +1,44 @@
+apiVersion: config.tempo.grafana.com/v1alpha1
+kind: ProjectConfig
+distribution: community
+health:
+  healthProbeBindAddress: :8081
+metrics:
+  bindAddress: 127.0.0.1:8080
+webhook:
+  port: 9443
+leaderElection:
+  leaderElect: true
+  resourceName: 8b886b0f.grafana.com
+# leaderElectionReleaseOnCancel defines if the leader should step down volume
+# when the Manager ends. This requires the binary to immediately end when the
+# Manager is stopped, otherwise, this setting is unsafe. Setting this significantly
+# speeds up voluntary leader transitions as the new leader don't have to wait
+# LeaseDuration time first.
+# In the default scaffold provided, the program ends immediately after
+# the manager stops, so would be fine to enable this option. However,
+# if you are doing or is intended to do any operation such as perform cleanups
+# after the manager stops then its usage might be unsafe.
+# leaderElectionReleaseOnCancel: true
+featureGates:
+  openshift:
+    openshiftRoute: false
+    servingCertsService: false
+  prometheusOperator: false
+  httpEncryption: false
+  grpcEncryption: false
+  tlsProfile: Modern
+  builtInCertManagement:
+    enabled: false
+    # CA certificate validity: 5 years
+    caValidity: 43830h
+    # CA certificate refresh at 80% of validity
+    caRefresh: 35064h
+    # Target certificate validity: 90d
+    certValidity: 2160h
+    # Target certificate refresh at 80% of validity
+    certRefresh: 1728h
+  observability:
+    metrics:
+      createServiceMonitors: false
+      createPrometheusRules: false


### PR DESCRIPTION
Various tools are capable of automatic rebuilding of images in case of
CVEs (e.g. freshmaker [1]). These tools rebuild all images and update
the RELATED_IMAGE_ environment variables in the CSV accordingly (ref. #638).

However, they do not update the version field (the
github.com/grafana/tempo-operator/internal/version.operatorVersion LDFLAG
when building the operator), they only update the version of the CSV.
Therefore the upgrade process won't run, and nothing will replace the
images field in the TempoStack CRs, i.e. the tempo/tempo-query/gateway
pods are not updated with the new image version.

This PR modifies the handling to use the default images if the image
field of the TempoStack CR is unset. Then the operator will use the image
from RELATED_IMAGE_ env variables, and the containers are always using the
latest images as specified in the RELATED_IMAGE_ env vars. As a bonus,
if a user is manually editing the images field, it won't get reset on every
upgrade.

[1] https://github.com/redhat-exd-rebuilds/freshmaker

Resolves: #674