### PR TITLE
Fix empty ciphers in TLS1.3

### DIFF
--- a/internal/manifests/config/build_test.go
+++ b/internal/manifests/config/build_test.go
@@ -1363,7 +1363,22 @@ query_frontend:
 }
 
 func TestBuildConfigurationTLS(t *testing.T) {
-	expCfg := `
+
+	testCases := []struct {
+		name    string
+		options tlsprofile.TLSProfileOptions
+		expect  string
+	}{
+		{
+			name: "tls with options",
+			options: tlsprofile.TLSProfileOptions{
+				Ciphers: []string{"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+					"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+					"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+					"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384"},
+				MinTLSVersion: "VersionTLS12",
+			},
+			expect: `
 ---
 compactor:
   compaction:
@@ -1477,48 +1492,167 @@ ingester_client:
     tls_insecure_skip_verify: false
     tls_cipher_suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
     tls_min_version: VersionTLS12
-`
-	cfg, err := buildConfiguration(manifestutils.Params{
-		Tempo: v1alpha1.TempoStack{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test",
-				Namespace: "nstest",
+`,
+		},
+		{
+			name: "tls options no ciphers",
+			options: tlsprofile.TLSProfileOptions{
+				MinTLSVersion: "VersionTLS13",
 			},
-			Spec: v1alpha1.TempoStackSpec{
-				Storage: v1alpha1.ObjectStorageSpec{
-					Secret: v1alpha1.ObjectStorageSecretSpec{
-						Type: v1alpha1.ObjectStorageSecretS3,
+			expect: `
+---
+compactor:
+  compaction:
+    block_retention: 48h0m0s
+  ring:
+    kvstore:
+      store: memberlist
+distributor:
+  receivers:
+    jaeger:
+      protocols:
+        thrift_http:
+          endpoint: 0.0.0.0:14268
+        thrift_binary:
+          endpoint: 0.0.0.0:6832
+        thrift_compact:
+          endpoint: 0.0.0.0:6831
+        grpc:
+          endpoint: 0.0.0.0:14250
+    zipkin:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: "0.0.0.0:4317"
+        http:
+          endpoint: "0.0.0.0:4318"
+  ring:
+    kvstore:
+      store: memberlist
+ingester:
+  lifecycler:
+    ring:
+      kvstore:
+        store: memberlist
+      replication_factor: 1
+    tokens_file_path: /var/tempo/tokens.json
+  max_block_duration: 10m
+memberlist:
+  abort_if_cluster_join_fails: false
+  join_members:
+    - tempo-test-gossip-ring
+multitenancy_enabled: false
+querier:
+  max_concurrent_queries: 20
+  search:
+    external_hedge_requests_at: 8s
+    external_hedge_requests_up_to: 2
+  frontend_worker:
+    frontend_address: "tempo-test-query-frontend-discovery:9095"
+    grpc_client_config:
+      tls_enabled: true
+      tls_cert_path: /var/run/tls/server/tls.crt
+      tls_key_path: /var/run/tls/server/tls.key
+      tls_ca_path: /var/run/ca/service-ca.crt
+      tls_server_name: tempo-test-query-frontend.nstest.svc.cluster.local
+      tls_min_version: VersionTLS13
+internal_server:
+  enable: true
+  http_listen_address: ""
+  http_tls_config:
+    cert_file: /var/run/tls/server/tls.crt
+    key_file: /var/run/tls/server/tls.key
+  tls_min_version: VersionTLS13
+server:
+  grpc_server_max_recv_msg_size: 4194304
+  grpc_server_max_send_msg_size: 4194304
+  http_listen_port: 3200
+  http_server_read_timeout: 3m
+  http_server_write_timeout: 3m
+  log_format: logfmt
+  tls_min_version: VersionTLS13
+  grpc_tls_config:
+    cert_file: /var/run/tls/server/tls.crt
+    client_auth_type: RequireAndVerifyClientCert
+    client_ca_file: /var/run/ca/service-ca.crt
+    key_file: /var/run/tls/server/tls.key
+  http_tls_config:
+    cert_file: /var/run/tls/server/tls.crt
+    client_auth_type: RequireAndVerifyClientCert
+    client_ca_file: /var/run/ca/service-ca.crt
+    key_file: /var/run/tls/server/tls.key
+storage:
+  trace:
+    backend: s3
+    blocklist_poll: 5m
+    cache: none
+    local:
+      path: /var/tempo/traces
+    s3:
+      bucket: tempo
+      endpoint: "minio:9000"
+      insecure: true
+    wal:
+      path: /var/tempo/wal
+usage_report:
+  reporting_enabled: false
+query_frontend:
+  search:
+    concurrent_jobs: 2000
+    max_duration: 0s
+ingester_client:
+  grpc_client_config:
+    tls_enabled: true
+    tls_cert_path: /var/run/tls/server/tls.crt
+    tls_key_path: /var/run/tls/server/tls.key
+    tls_ca_path: /var/run/ca/service-ca.crt
+    tls_server_name: tempo-test-ingester.nstest.svc.cluster.local
+    tls_insecure_skip_verify: false
+    tls_min_version: VersionTLS13
+`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			cfg, err := buildConfiguration(manifestutils.Params{
+				Tempo: v1alpha1.TempoStack{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "nstest",
+					},
+					Spec: v1alpha1.TempoStackSpec{
+						Storage: v1alpha1.ObjectStorageSpec{
+							Secret: v1alpha1.ObjectStorageSecretSpec{
+								Type: v1alpha1.ObjectStorageSecretS3,
+							},
+						},
+						ReplicationFactor: 1,
+						Retention: v1alpha1.RetentionSpec{
+							Global: v1alpha1.RetentionConfig{
+								Traces: metav1.Duration{Duration: 48 * time.Hour},
+							},
+						},
 					},
 				},
-				ReplicationFactor: 1,
-				Retention: v1alpha1.RetentionSpec{
-					Global: v1alpha1.RetentionConfig{
-						Traces: metav1.Duration{Duration: 48 * time.Hour},
+				StorageParams: manifestutils.StorageParams{
+					S3: &manifestutils.S3{
+						Endpoint: "minio:9000",
+						Bucket:   "tempo",
+						Insecure: true,
 					},
 				},
-			},
-		},
-		StorageParams: manifestutils.StorageParams{
-			S3: &manifestutils.S3{
-				Endpoint: "minio:9000",
-				Bucket:   "tempo",
-				Insecure: true,
-			},
-		},
-		TLSProfile: tlsprofile.TLSProfileOptions{
-			Ciphers: []string{"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
-				"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
-				"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
-				"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384"},
-			MinTLSVersion: "VersionTLS12",
-		},
-		Gates: configv1alpha1.FeatureGates{
-			HTTPEncryption: true,
-			GRPCEncryption: true,
-		},
-	})
-	require.NoError(t, err)
-	require.YAMLEq(t, expCfg, string(cfg))
+				TLSProfile: tc.options,
+				Gates: configv1alpha1.FeatureGates{
+					HTTPEncryption: true,
+					GRPCEncryption: true,
+				},
+			})
+			require.NoError(t, err)
+			require.YAMLEq(t, tc.expect, string(cfg))
+		})
+	}
 }
 
 func TestBuildConfigurationTLSWithGateway(t *testing.T) {

--- a/internal/manifests/config/tempo-config.yaml
+++ b/internal/manifests/config/tempo-config.yaml
@@ -140,7 +140,9 @@ querier:
       tls_key_path: {{ .TLS.Paths.Key }}
       tls_ca_path: {{ .TLS.Paths.CA }}
       tls_server_name: {{ .TLS.ServerNames.QueryFrontend }}
+{{- if .TLS.Profile.Ciphers }}
       tls_cipher_suites: {{ .TLS.Profile.Ciphers }}
+{{- end }}
       tls_min_version: {{ .TLS.Profile.MinTLSVersion }}
 {{- end }}
   search:
@@ -157,7 +159,9 @@ querier:
 internal_server:
   enable: true
   http_listen_address: ""
+{{- if .TLS.Profile.Ciphers }}
   tls_cipher_suites: {{ .TLS.Profile.Ciphers }}
+{{- end }}
   tls_min_version: {{ .TLS.Profile.MinTLSVersion }}
   http_tls_config:
     cert_file: {{ .TLS.Paths.Certificate }}
@@ -171,7 +175,9 @@ server:
   http_server_write_timeout: 3m
   log_format: logfmt
 {{- if or .Gates.GRPCEncryption .Gates.HTTPEncryption }}
+{{- if .TLS.Profile.Ciphers }}
   tls_cipher_suites: {{ .TLS.Profile.Ciphers }}
+{{- end }}
   tls_min_version: {{ .TLS.Profile.MinTLSVersion }}
 {{- end }}
 {{- if .Gates.GRPCEncryption }}
@@ -239,6 +245,8 @@ ingester_client:
     tls_ca_path: {{ .TLS.Paths.CA }}
     tls_server_name: {{ .TLS.ServerNames.Ingester }}
     tls_insecure_skip_verify: false
+{{- if .TLS.Profile.Ciphers }}
     tls_cipher_suites: {{ .TLS.Profile.Ciphers }}
+{{- end }}
     tls_min_version: {{ .TLS.Profile.MinTLSVersion }}
 {{- end }}


### PR DESCRIPTION
After investigating this, the reason why` crypto.OpenSSLToIANACipherSuites(ciphers)` is returning empty is because in golang TLS1.3 ciphers are not configurable. https://github.com/golang/go/issues/29349

 

This is a golang design decision, so the library returns an empty string slice, as it is commented in their source code.https://github.com/openshift/library-go/blob/master/pkg/crypto/crypto.go#L152

 