### PR TITLE
Reduce log level of certrotation messages

### DIFF
--- a/.chloggen/reduce_certrotation_loglevel.yaml
+++ b/.chloggen/reduce_certrotation_loglevel.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, github action)
+component: operator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Reduce log level of certrotation messages
+
+# One or more tracking issues related to the change
+issues: [623]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/controllers/tempo/certrotation_controller.go
+++ b/controllers/tempo/certrotation_controller.go
@@ -56,7 +56,7 @@ func (r *CertRotationReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	checkExpiryAfter := expiryRetryAfter(rt.TargetCertRefresh)
-	log.Info("Checking if TempoStack certificates expired", "name", req.String(), "interval", checkExpiryAfter.String())
+	log.V(1).Info("Checking if TempoStack certificates expired", "name", req.String(), "interval", checkExpiryAfter.String())
 
 	var expired *certrotation.CertExpiredError
 
@@ -67,7 +67,7 @@ func (r *CertRotationReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	case err != nil:
 		return ctrl.Result{}, err
 	default:
-		log.Info("Skipping cert rotation, all TempoStack certificates still valid", "name", req.String())
+		log.V(1).Info("Skipping cert rotation, all TempoStack certificates still valid", "name", req.String())
 		return ctrl.Result{
 			RequeueAfter: checkExpiryAfter,
 		}, nil

--- a/internal/certrotation/handlers/rotate_certs.go
+++ b/internal/certrotation/handlers/rotate_certs.go
@@ -52,7 +52,7 @@ func CreateOrRotateCertificates(ctx context.Context, log logr.Logger,
 		return kverrors.Wrap(err, "failed to build certificate manifests", "name", req.String())
 	}
 
-	ll.Info("certificate manifests built", "count", len(objects))
+	ll.V(1).Info("certificate manifests built", "count", len(objects))
 
 	var errCount int32
 


### PR DESCRIPTION
Checking/skipping/building of certificate manifests is run for every reconciliation and is filling up the logs unnecessarily. For debugging purposes, the log level can be increased.

Resolves: #623