### PR TITLE
New Release Process (Semi automatic way)

### DIFF
--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -15,18 +15,12 @@ jobs:
         with:
           go-version: "1.20"
 
-      - name: Generate token
-        id: generate_token
-        uses: tibdex/github-app-token@v2
-        with:
-          app_id: ${{ secrets.PUBLISH_APP_ID }}
-          private_key: ${{ secrets.PUBLISH_APP_PRIVATE_KEY }}
-          installation_retrieval_payload:  ${{ secrets.PUBLISH_APP_INSTALLATION_ID }}
-          installation_retrieval_mode: id
-
       - uses: actions/checkout@v4
-        with:
-          token: ${{ steps.generate_token.outputs.token }}
+
+      - name: Update makefile
+        run: sed -i.bak "s/OPERATOR_VERSION ?= .*/OPERATOR_VERSION ?= $OPERATOR_VERSION/g" Makefile && rm Makefile.bak
+        env:
+          OPERATOR_VERSION: ${{inputs.version}}
 
       - name: Generate bundle
         run: make bundle
@@ -44,10 +38,10 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git checkout -b release/v${{ inputs.version }}
+          git checkout -b releases/${{ inputs.version }}
           git add -A
           git commit -m "Prepare Release ${{inputs.version}}" --author="${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>"
-          git push -f --set-upstream origin release/v${{ inputs.version }}
+          git push -f --set-upstream origin releases/${{ inputs.version }}
           gh pr create --title='Prepare release v${{ inputs.version }}' --assignee=${{ github.actor }} --reviewer=${{ github.actor }} --body='v${{ inputs.version }}'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,17 +1,42 @@
 name: "Release"
 on:
-  push:
-    tags: [ 'v*' ]
-
+  pull_request:
+    branches:
+      - main
+    types:
+      - closed
 jobs:
   release:
+    if: |
+        github.event.pull_request.merged == true && github.event.pull_request.head.repo.full_name == github.repository
+        && github.event.pull_request.user.login == 'github-actions[bot]' && github.event.pull_request.user.type == 'Bot'
     runs-on: ubuntu-22.04
     steps:
+    - name: Determine operator version to release
+      id: operator-version
+      run: echo "version=${BRANCH#"releases/"}" >> "$GITHUB_OUTPUT"
+      env:
+        BRANCH: ${{ github.event.pull_request.head.ref }}
+
+    - name: Determine repo
+      id: repo
+      run: echo "repo=${{ github.event.pull_request.base.repo.full_name }}"
+
+    - name: Determine user
+      id: user
+      run: echo "User=${{ github.event.pull_request.user.login }}"
+
+    - name: Actor user
+      id: acctor
+      run: echo "User=${{ github.actor }}"
+
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
         go-version: "1.20"
     - uses: actions/checkout@v4
+      with:
+        ref: main
 
     - name: "generate release resources"
       run: make release-artifacts
@@ -21,8 +46,8 @@ jobs:
     - name: "create the release in GitHub"
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        OPERATOR_VERSION: ${{ steps.operator-version.outputs.version }}
       run: |
-        OPERATOR_VERSION=$(git describe --tags | sed 's/^v//')
         awk '/^## / {v=$2} v == "'${OPERATOR_VERSION}'" && !/^## / {print}' CHANGELOG.md > RELEASE_NOTES.md
         gh release create \
             -t "Release v${OPERATOR_VERSION}" \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,22 +18,11 @@ jobs:
       env:
         BRANCH: ${{ github.event.pull_request.head.ref }}
 
-    - name: Determine repo
-      id: repo
-      run: echo "repo=${{ github.event.pull_request.base.repo.full_name }}"
-
-    - name: Determine user
-      id: user
-      run: echo "User=${{ github.event.pull_request.user.login }}"
-
-    - name: Actor user
-      id: acctor
-      run: echo "User=${{ github.actor }}"
-
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
         go-version: "1.20"
+
     - uses: actions/checkout@v4
       with:
         ref: main

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,7 @@ jobs:
     if: |
         github.event.pull_request.merged == true && github.event.pull_request.head.repo.full_name == github.repository
         && github.event.pull_request.user.login == 'github-actions[bot]' && github.event.pull_request.user.type == 'Bot'
+        && startsWith(github.event.pull_request.head.ref, 'releases/')
     runs-on: ubuntu-22.04
     steps:
     - name: Determine operator version to release

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,7 +6,7 @@ Steps to release a new version of the Tempo Operator:
 1. Go to GitHub Actions Tab, In the left sidebar, choose "Prepare Release" Workflow, then push in the "Run workflow" button , select the main branch and type the version of operator to release
 1. Push "Run workflow", this will trigger the process to generate the CHANGELOG and generate the bundle, this will create a PR with the title "Prepare Release vx.y.z`"
 1. Once the PR is created, use that branch to build, deploy and, run OpenShift tests against an OpenShift cluster (see below for instructions).
-1. Once the PR above are merged and available in the `main` branch, tag it with the desired version, prefixed with `v`: `vx.y.z` (e.g. `git tag v0.1.0 && git push origin v0.1.0`)
+1. Once the PR above are merged and available in the `main` branch, it will trigger the release workflow which will create the tag and the GitHub release.
 
 ## Running e2e tests on OpenShift
 A locally installed [CRC](https://github.com/crc-org/crc) cluster can be used for testing.


### PR DESCRIPTION
This new process is as follows:

 - Trigger "Prepare Release" GitHub action from the GitHub UI, you need to specify the new version.
 - This will create a new branch releases/x.y.z, where x.y.z is the new release
 - This also will create a new PR, witht he new bundle, the CHANGELOG, and all the neccesary modifications.
 - Once we test this on openshift and we are happy, we can merge the PR

The release GitHub action will take place

This GH action will be triggered only when the PR that gets merged is from releases/*., the source and destination are the the same repository, and the author of the PR is a GitHub action.

And this workflow follows the regular process, created release on GH and create the tag (we don't need to create the tag manually anymore)

Also this will trigger the OLM publish but that work is on another PR.  (https://github.com/grafana/tempo-operator/pull/583)

@andreasgerstmayr @pavolloffay @frzifus @iblancasa  Let me know what do you think. 

PS. I'll update the RELEASE.md once this is accepted.