### PR TITLE
drop bearerTokenSecret assert in e2e-openshift/monitoring test

### DIFF
--- a/tests/e2e-openshift/monitoring/02-assert.yaml
+++ b/tests/e2e-openshift/monitoring/02-assert.yaml
@@ -128,9 +128,7 @@ metadata:
   namespace: kuttl-monitoring
 spec:
   endpoints:
-  - bearerTokenSecret:
-      key: ""
-    path: /metrics
+  - path: /metrics
     port: http
     relabelings:
     - sourceLabels:
@@ -177,9 +175,7 @@ metadata:
   namespace: kuttl-monitoring
 spec:
   endpoints:
-  - bearerTokenSecret:
-      key: ""
-    path: /metrics
+  - path: /metrics
     port: http
     relabelings:
     - sourceLabels:
@@ -226,9 +222,7 @@ metadata:
   namespace: kuttl-monitoring
 spec:
   endpoints:
-  - bearerTokenSecret:
-      key: ""
-    path: /metrics
+  - path: /metrics
     port: http
     relabelings:
     - sourceLabels:
@@ -275,9 +269,7 @@ metadata:
   namespace: kuttl-monitoring
 spec:
   endpoints:
-  - bearerTokenSecret:
-      key: ""
-    path: /metrics
+  - path: /metrics
     port: http
     relabelings:
     - sourceLabels:
@@ -324,9 +316,7 @@ metadata:
   namespace: kuttl-monitoring
 spec:
   endpoints:
-  - bearerTokenSecret:
-      key: ""
-    path: /metrics
+  - path: /metrics
     port: http
     relabelings:
     - sourceLabels:


### PR DESCRIPTION
This assert is not required (please correct me if I'm missing something).
The test fails on CRC without this change.