### PR TITLE
Trigger publish images when release happens

### DIFF
--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -5,6 +5,9 @@ on:
     branches: [main]
     tags: ["v*"]
 
+  release:
+    types: [published]
+
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
It seems that even if creating a release creates a tag, The publish image was not triggered. it seems like you need to explicitly push the tag to trigger it.

In this PR I also add the release published event  (https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release) in order to trigger this workflow with the new approach.


I had to run manually for this release in order to have the image published.

@andreasgerstmayr  please review.