### PR TITLE
[Chore] Replace curl-jq image with multi-arch built image tempo-operator/test-utils:main

### DIFF
--- a/tests/e2e-openshift/monitoring/03-generate-traces.yaml
+++ b/tests/e2e-openshift/monitoring/03-generate-traces.yaml
@@ -14,4 +14,5 @@ spec:
         - --otlp-insecure
         - --duration=3m
         - --workers=1
+        - --span-duration=1s
       restartPolicy: Never

--- a/tests/e2e-openshift/multitenancy/04-verify-traces.yaml
+++ b/tests/e2e-openshift/multitenancy/04-verify-traces.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: verify-traces
-        image: registry.gitlab.com/gitlab-ci-utils/curl-jq:1.1.0
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
         command:
         - /bin/bash
         - -eux
@@ -41,7 +41,7 @@ spec:
     spec:
       containers:
         - name: verify-traces
-          image: registry.gitlab.com/gitlab-ci-utils/curl-jq:1.1.0
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
           command:
             - /bin/bash
             - -eux

--- a/tests/e2e-upgrade/upgrade/50-verify-traces.yaml
+++ b/tests/e2e-upgrade/upgrade/50-verify-traces.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
       - name: verify-traces
-        image: registry.gitlab.com/gitlab-ci-utils/curl-jq:1.1.0
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
         command:
         - /bin/bash
         - -eux

--- a/tests/e2e-upgrade/upgrade/70-verify-traces-after-upgrade.yaml
+++ b/tests/e2e-upgrade/upgrade/70-verify-traces-after-upgrade.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
       - name: verify-traces
-        image: registry.gitlab.com/gitlab-ci-utils/curl-jq:1.1.0
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
         command:
         - /bin/bash
         - -eux

--- a/tests/e2e/custom-ca/03-verify-traces.yaml
+++ b/tests/e2e/custom-ca/03-verify-traces.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
       - name: verify-traces
-        image: registry.gitlab.com/gitlab-ci-utils/curl-jq:1.1.0
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
         command:
         - /bin/bash
         - -eux

--- a/tests/e2e/receivers-mtls/04-verify-traces.yaml
+++ b/tests/e2e/receivers-mtls/04-verify-traces.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
       - name: verify-traces
-        image: registry.gitlab.com/gitlab-ci-utils/curl-jq:1.1.0
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
         command:
         - /bin/bash
         - -eux

--- a/tests/e2e/receivers-tls/04-verify-traces.yaml
+++ b/tests/e2e/receivers-tls/04-verify-traces.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
       - name: verify-traces
-        image: registry.gitlab.com/gitlab-ci-utils/curl-jq:1.1.0
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
         command:
         - /bin/bash
         - -eux

--- a/tests/e2e/smoketest-with-jaeger/04-verify-traces.yaml
+++ b/tests/e2e/smoketest-with-jaeger/04-verify-traces.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
       - name: verify-traces
-        image: registry.gitlab.com/gitlab-ci-utils/curl-jq:1.1.0
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
         command:
         - /bin/bash
         - -eux


### PR DESCRIPTION
* Replace test image curl-jq with [tempo-operator/test-utils:main](https://github.com/grafana/tempo-operator/pkgs/container/tempo-operator%2Ftest-utils) so that the tests can also be run on a non-amd64 Kubernetes/OpenShift cluster. 
* Fix monitoring test case failing with LIVE_TRACES_EXCEEDED issue. 

Tests passed on OpenShift 4.14 cluster:

PASS: kuttl (268.37s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/gateway (60.99s)
        --- PASS: kuttl/harness/generate (66.02s)
        --- PASS: kuttl/harness/reconcile (122.35s)
        --- PASS: kuttl/harness/route (148.60s)
        --- PASS: kuttl/harness/monitoring (148.91s)
        --- PASS: kuttl/harness/receivers-tls (156.43s)
        --- PASS: kuttl/harness/smoketest-with-jaeger (156.67s)
        --- PASS: kuttl/harness/red-metrics (160.08s)
        --- PASS: kuttl/harness/multitenancy (119.20s)
        --- PASS: kuttl/harness/receivers-mtls (150.21s)
        --- PASS: kuttl/harness/custom-ca (143.17s)
PASS