### PR TITLE
[Chore] Update e2e tests to use multiarch Telemetrygen v0.92.0

### DIFF
--- a/tests/e2e-openshift/monitoring/03-generate-traces.yaml
+++ b/tests/e2e-openshift/monitoring/03-generate-traces.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:latest
+        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
         args:
         - traces
         - --otlp-endpoint=tempo-tempostack-distributor.kuttl-monitoring.svc:4317

--- a/tests/e2e-openshift/multitenancy/03-generate-traces.yaml
+++ b/tests/e2e-openshift/multitenancy/03-generate-traces.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.75.0
+        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
         args:
         - traces
         - --otlp-endpoint=dev-collector:4317

--- a/tests/e2e-upgrade/upgrade/40-generate-traces.yaml
+++ b/tests/e2e-upgrade/upgrade/40-generate-traces.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.75.0
+        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
         args:
         - traces
         - --otlp-endpoint=tempo-simplest-distributor:4317

--- a/tests/e2e/compatibility/03-generate-traces.yaml
+++ b/tests/e2e/compatibility/03-generate-traces.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.75.0
+        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
         args:
         - traces
         - --otlp-endpoint=tempo-simplest-distributor:4317

--- a/tests/e2e/custom-ca/02-generate-traces.yaml
+++ b/tests/e2e/custom-ca/02-generate-traces.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.75.0
+        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
         args:
         - traces
         - --otlp-endpoint=tempo-simplest-distributor:4317

--- a/tests/e2e/receivers-mtls/03-generate-traces.yaml
+++ b/tests/e2e/receivers-mtls/03-generate-traces.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
         - name: telemetrygen
-          image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.75.0
+          image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
           args:
             - traces
             - --otlp-endpoint=opentelemetry-collector:4317

--- a/tests/e2e/receivers-tls/03-generate-traces.yaml
+++ b/tests/e2e/receivers-tls/03-generate-traces.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
         - name: telemetrygen
-          image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.75.0
+          image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
           args:
             - traces
             - --otlp-endpoint=opentelemetry-collector:4317


### PR DESCRIPTION
Multiarch image support for Telemetrygen is added by PR https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/29905 and the latest stable version of [Telemetrygen v0.92.0](https://github.com/open-telemetry/opentelemetry-collector-contrib/pkgs/container/opentelemetry-collector-contrib%2Ftelemetrygen/165347009?tag=v0.92.0 ) is released with the multiarch support. I have updated the e2e tests in this PR so that we can run them for different architectures without performing any additional steps.