### PR TITLE
[Chore] Test Span RED metrics and alerts.

### DIFF
--- a/tests/e2e-openshift/red-metrics/02-assert.yaml
+++ b/tests/e2e-openshift/red-metrics/02-assert.yaml
@@ -5,3 +5,22 @@ metadata:
 status:
   readyReplicas: 1
   replicas: 1
+
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: span-red
+spec:
+  groups:
+  - name: server-side-latency
+    rules:
+    - alert: SpanREDFrontendAPIRequestLatency
+      annotations:
+        description: '{{$labels.instance}} has 95th request latency above 2s (current
+          value: {{$value}}s)'
+        summary: High request latency on {{$labels.service_name}} and {{$labels.span_name}}
+      expr: histogram_quantile(0.95, sum(rate(duration_bucket{service_name="frontend",
+        span_kind="SPAN_KIND_SERVER"}[1m])) by (le, service_name, span_name)) > 1000
+      labels:
+        severity: Warning

--- a/tests/e2e-openshift/red-metrics/02-install-otel-collector.yaml
+++ b/tests/e2e-openshift/red-metrics/02-install-otel-collector.yaml
@@ -3,18 +3,17 @@ kind: OpenTelemetryCollector
 metadata:
   name: otel
 spec:
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.91.0
   mode: deployment
-  ports:
-    - name: promexporter
-      port: 8889
-      protocol: TCP
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.92.0
+  observability:
+    metrics:
+      enableMetrics: true
   config: |
     connectors:
       spanmetrics:
         histogram:
           explicit:
-            buckets: [100us, 1ms, 2ms, 6ms, 10ms, 100ms, 250ms]
+            buckets: [2ms, 4ms, 6ms, 8ms, 10ms, 50ms, 100ms, 200ms, 400ms, 800ms, 1s, 1400ms, 2s, 5s, 10s, 15s]
         dimensions:
         - name: http.method
           default: GET
@@ -35,7 +34,9 @@ spec:
         endpoint: 0.0.0.0:8889
         resource_to_telemetry_conversion: 
           enabled: true # by default resource attributes are dropped
+
       logging:
+
       otlp:
         endpoint: tempo-redmetrics-distributor:4317
         tls:
@@ -54,27 +55,20 @@ spec:
         metrics:
           receivers: [spanmetrics]
           exporters: [prometheus, logging]
+
 ---
 apiVersion: monitoring.coreos.com/v1
-kind: PodMonitor
+kind: PrometheusRule
 metadata:
-  name: otel-collector
+  name: span-red
 spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: otel-collector
-  podMetricsEndpoints:
-    - port: metrics
-    - port: promexporter
-      relabelings:
-        - action: labeldrop
-          regex: pod
-        - action: labeldrop
-          regex: container
-        - action: labeldrop
-          regex: endpoint
-      metricRelabelings:
-        - action: labeldrop
-          regex: instance
-        - action: labeldrop
-          regex: job
+  groups:
+  - name: server-side-latency
+    rules:
+    - alert: SpanREDFrontendAPIRequestLatency
+      expr: histogram_quantile(0.95, sum(rate(duration_bucket{service_name="frontend", span_kind="SPAN_KIND_SERVER"}[1m])) by (le, service_name, span_name)) > 1000
+      labels:
+        severity: Warning
+      annotations:
+        summary: "High request latency on {{$labels.service_name}} and {{$labels.span_name}}"
+        description: "{{$labels.instance}} has 95th request latency above 2s (current value: {{$value}}s)"

--- a/tests/e2e-openshift/red-metrics/03-assert.yaml
+++ b/tests/e2e-openshift/red-metrics/03-assert.yaml
@@ -50,3 +50,8 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: tempo-redmetrics
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- command: /bin/sh -c "kubectl get --namespace $NAMESPACE tempo redmetrics -o jsonpath='{.status.conditions[?(@.type==\"Ready\")].status}' | grep True"

--- a/tests/e2e-openshift/red-metrics/05-assert.yaml
+++ b/tests/e2e-openshift/red-metrics/05-assert.yaml
@@ -3,4 +3,4 @@ kind: Job
 metadata:
   name: hotrod-curl
 status:
-  succeeded: 1
+  active: 1

--- a/tests/e2e-openshift/red-metrics/05-install-generate-traces.yaml
+++ b/tests/e2e-openshift/red-metrics/05-install-generate-traces.yaml
@@ -3,8 +3,6 @@ kind: Job
 metadata:
   name: hotrod-curl
 spec:
-  completions: 1
-  parallelism: 1
   template:
     metadata:
       labels:
@@ -13,6 +11,7 @@ spec:
       containers:
         - name: hotrod-curl
           image: curlimages/curl
+          command: ["/bin/sh", "-c"]
           args:
-            - "http://hotrod:80/dispatch?customer=123"
+            - "for i in `seq 1 900`; do for j in `seq 1 10`; do curl http://hotrod:80/dispatch?customer=123 & done; wait; sleep 1; done"
       restartPolicy: Never

--- a/tests/e2e-openshift/red-metrics/06-assert.yaml
+++ b/tests/e2e-openshift/red-metrics/06-assert.yaml
@@ -6,3 +6,9 @@ status:
   conditions:
     - status: "True"
       type: Complete
+
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- script: ./tests/e2e-openshift/red-metrics/check_alert.sh

--- a/tests/e2e-openshift/red-metrics/07-assert.yaml
+++ b/tests/e2e-openshift/red-metrics/07-assert.yaml
@@ -1,0 +1,4 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- script: ./tests/e2e-openshift/red-metrics/check_metrics.sh

--- a/tests/e2e-openshift/red-metrics/check_alert.sh
+++ b/tests/e2e-openshift/red-metrics/check_alert.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Run the command and save its output
+output=$(oc -n openshift-monitoring exec alertmanager-main-0 -- amtool --alertmanager.url http://localhost:9093 alert query SpanREDFrontendAPIRequestLatency 2>&1)
+
+# Check if the command was successful
+if [ $? -ne 0 ]; then
+    echo "Error executing oc command: $output"
+    exit 1
+fi
+
+# Check if the alert is active
+if echo "$output" | grep -q "SpanREDFrontendAPIRequestLatency.*active"; then
+    echo "Alert SpanREDFrontendAPIRequestLatency is firing"
+    exit 0
+else
+    echo "Alert SpanREDFrontendAPIRequestLatency is not firing"
+    exit 1
+fi

--- a/tests/e2e-openshift/red-metrics/check_metrics.sh
+++ b/tests/e2e-openshift/red-metrics/check_metrics.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+SECRET=$(oc get secret -n openshift-user-workload-monitoring | grep prometheus-user-workload-token | head -n 1 | awk '{print $1}')
+TOKEN=$(echo $(oc get secret $SECRET -n openshift-user-workload-monitoring -o json | jq -r '.data.token') | base64 -d)
+THANOS_QUERIER_HOST=$(oc get route thanos-querier -n openshift-monitoring -o json | jq -r '.spec.host')
+
+#Check metrics used in the prometheus rules created for TempoStack. Refer issue https://issues.redhat.com/browse/TRACING-3399 for skipped metrics.
+metrics="duration_bucket duration_count duration_sum calls"
+
+for metric in $metrics; do
+  query="$metric"
+
+  response=$(curl -k -H "Authorization: Bearer $TOKEN" -H "Content-type: application/json" "https://$THANOS_QUERIER_HOST/api/v1/query?query=$query")
+
+  count=$(echo "$response" | jq -r '.data.result | length')
+
+  if [[ $count -eq 0 ]]; then
+    echo "No metric '$metric' with value present. Exiting with status 1."
+    exit 1
+  else
+    echo "Metric '$metric' with value is present."
+  fi
+done


### PR DESCRIPTION
The PR updates the red-metrics test case to test Span RED alerts using prometheusrule and verify the metrics generated. 

```
kuttl test --timeout=300 --test=red-metrics tests/e2e-openshift
2024/01/12 14:09:35 kutt-test config testdirs is overridden with args: [ tests/e2e-openshift ]
=== RUN   kuttl
    harness.go:462: starting setup
    harness.go:252: running tests using configured kubeconfig.
    harness.go:275: Successful connection to cluster at: https://api.REDACTED:6443
    harness.go:360: running tests
    harness.go:73: going to run test suite with timeout of 300 seconds for each step
    harness.go:372: testsuite: tests/e2e-openshift has 4 tests
=== RUN   kuttl/harness
=== RUN   kuttl/harness/red-metrics
=== PAUSE kuttl/harness/red-metrics
=== CONT  kuttl/harness/red-metrics
    logger.go:42: 14:09:42 | red-metrics | Ignoring check_alert.sh as it does not match file name regexp: ^(\d+)-(?:[^\.]+)(?:\.yaml)?$
    logger.go:42: 14:09:42 | red-metrics | Ignoring check_metrics.sh as it does not match file name regexp: ^(\d+)-(?:[^\.]+)(?:\.yaml)?$
    logger.go:42: 14:09:42 | red-metrics | Ignoring check_user_workload_monitoring.sh as it does not match file name regexp: ^(\d+)-(?:[^\.]+)(?:\.yaml)?$
    logger.go:42: 14:09:42 | red-metrics | Creating namespace: kuttl-test-bursting-penguin
    logger.go:42: 14:09:43 | red-metrics/0-install-storage | starting test step 0-install-storage
    logger.go:42: 14:09:44 | red-metrics/0-install-storage | PersistentVolumeClaim:kuttl-test-bursting-penguin/minio created
    logger.go:42: 14:09:45 | red-metrics/0-install-storage | Deployment:kuttl-test-bursting-penguin/minio created
    logger.go:42: 14:09:46 | red-metrics/0-install-storage | Service:kuttl-test-bursting-penguin/minio created
    logger.go:42: 14:09:58 | red-metrics/0-install-storage | test step completed 0-install-storage
    logger.go:42: 14:09:58 | red-metrics/1-install-workload-monitoring | starting test step 1-install-workload-monitoring
    logger.go:42: 14:10:01 | red-metrics/1-install-workload-monitoring | ConfigMap:openshift-monitoring/cluster-monitoring-config updated
    logger.go:42: 14:10:01 | red-metrics/1-install-workload-monitoring | running command: [sh -c ./tests/e2e-openshift/red-metrics/check_user_workload_monitoring.sh]
    logger.go:42: 14:10:05 | red-metrics/1-install-workload-monitoring | test step completed 1-install-workload-monitoring
    logger.go:42: 14:10:05 | red-metrics/2-install-otel-collector | starting test step 2-install-otel-collector
    logger.go:42: 14:10:07 | red-metrics/2-install-otel-collector | OpenTelemetryCollector:kuttl-test-bursting-penguin/otel created
    logger.go:42: 14:10:08 | red-metrics/2-install-otel-collector | PrometheusRule:kuttl-test-bursting-penguin/span-red created
    logger.go:42: 14:10:11 | red-metrics/2-install-otel-collector | test step completed 2-install-otel-collector
    logger.go:42: 14:10:11 | red-metrics/3-install-tempo | starting test step 3-install-tempo
    logger.go:42: 14:10:14 | red-metrics/3-install-tempo | Secret:kuttl-test-bursting-penguin/minio-test created
    logger.go:42: 14:10:14 | red-metrics/3-install-tempo | TempoStack:kuttl-test-bursting-penguin/redmetrics created
    logger.go:42: 14:10:17 | red-metrics/3-install-tempo | running command: [/bin/sh -c kubectl get --namespace kuttl-test-bursting-penguin tempo redmetrics -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' | grep True]
    logger.go:42: 14:10:20 | red-metrics/3-install-tempo | running command: [/bin/sh -c kubectl get --namespace kuttl-test-bursting-penguin tempo redmetrics -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' | grep True]
    logger.go:42: 14:10:23 | red-metrics/3-install-tempo | running command: [/bin/sh -c kubectl get --namespace kuttl-test-bursting-penguin tempo redmetrics -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' | grep True]
    logger.go:42: 14:10:26 | red-metrics/3-install-tempo | running command: [/bin/sh -c kubectl get --namespace kuttl-test-bursting-penguin tempo redmetrics -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' | grep True]
    logger.go:42: 14:10:30 | red-metrics/3-install-tempo | running command: [/bin/sh -c kubectl get --namespace kuttl-test-bursting-penguin tempo redmetrics -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' | grep True]
    logger.go:42: 14:10:33 | red-metrics/3-install-tempo | running command: [/bin/sh -c kubectl get --namespace kuttl-test-bursting-penguin tempo redmetrics -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' | grep True]
    logger.go:42: 14:10:36 | red-metrics/3-install-tempo | running command: [/bin/sh -c kubectl get --namespace kuttl-test-bursting-penguin tempo redmetrics -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' | grep True]
    logger.go:42: 14:10:37 | red-metrics/3-install-tempo | True
    logger.go:42: 14:10:40 | red-metrics/3-install-tempo | running command: [/bin/sh -c kubectl get --namespace kuttl-test-bursting-penguin tempo redmetrics -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' | grep True]
    logger.go:42: 14:10:41 | red-metrics/3-install-tempo | True
    logger.go:42: 14:10:43 | red-metrics/3-install-tempo | running command: [/bin/sh -c kubectl get --namespace kuttl-test-bursting-penguin tempo redmetrics -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' | grep True]
    logger.go:42: 14:10:44 | red-metrics/3-install-tempo | True
    logger.go:42: 14:10:46 | red-metrics/3-install-tempo | running command: [/bin/sh -c kubectl get --namespace kuttl-test-bursting-penguin tempo redmetrics -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' | grep True]
    logger.go:42: 14:10:47 | red-metrics/3-install-tempo | True
    logger.go:42: 14:10:50 | red-metrics/3-install-tempo | running command: [/bin/sh -c kubectl get --namespace kuttl-test-bursting-penguin tempo redmetrics -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' | grep True]
    logger.go:42: 14:10:51 | red-metrics/3-install-tempo | True
    logger.go:42: 14:10:53 | red-metrics/3-install-tempo | running command: [/bin/sh -c kubectl get --namespace kuttl-test-bursting-penguin tempo redmetrics -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' | grep True]
    logger.go:42: 14:10:54 | red-metrics/3-install-tempo | True
    logger.go:42: 14:10:56 | red-metrics/3-install-tempo | running command: [/bin/sh -c kubectl get --namespace kuttl-test-bursting-penguin tempo redmetrics -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' | grep True]
    logger.go:42: 14:10:57 | red-metrics/3-install-tempo | True
    logger.go:42: 14:10:59 | red-metrics/3-install-tempo | running command: [/bin/sh -c kubectl get --namespace kuttl-test-bursting-penguin tempo redmetrics -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' | grep True]
    logger.go:42: 14:11:00 | red-metrics/3-install-tempo | True
    logger.go:42: 14:11:02 | red-metrics/3-install-tempo | running command: [/bin/sh -c kubectl get --namespace kuttl-test-bursting-penguin tempo redmetrics -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' | grep True]
    logger.go:42: 14:11:03 | red-metrics/3-install-tempo | True
    logger.go:42: 14:11:06 | red-metrics/3-install-tempo | running command: [/bin/sh -c kubectl get --namespace kuttl-test-bursting-penguin tempo redmetrics -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' | grep True]
    logger.go:42: 14:11:07 | red-metrics/3-install-tempo | True
    logger.go:42: 14:11:09 | red-metrics/3-install-tempo | running command: [/bin/sh -c kubectl get --namespace kuttl-test-bursting-penguin tempo redmetrics -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' | grep True]
    logger.go:42: 14:11:10 | red-metrics/3-install-tempo | True
    logger.go:42: 14:11:12 | red-metrics/3-install-tempo | running command: [/bin/sh -c kubectl get --namespace kuttl-test-bursting-penguin tempo redmetrics -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' | grep True]
    logger.go:42: 14:11:13 | red-metrics/3-install-tempo | True
    logger.go:42: 14:11:16 | red-metrics/3-install-tempo | running command: [/bin/sh -c kubectl get --namespace kuttl-test-bursting-penguin tempo redmetrics -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' | grep True]
    logger.go:42: 14:11:17 | red-metrics/3-install-tempo | True
    logger.go:42: 14:11:19 | red-metrics/3-install-tempo | running command: [/bin/sh -c kubectl get --namespace kuttl-test-bursting-penguin tempo redmetrics -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' | grep True]
    logger.go:42: 14:11:20 | red-metrics/3-install-tempo | True
    logger.go:42: 14:11:22 | red-metrics/3-install-tempo | running command: [/bin/sh -c kubectl get --namespace kuttl-test-bursting-penguin tempo redmetrics -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' | grep True]
    logger.go:42: 14:11:23 | red-metrics/3-install-tempo | True
    logger.go:42: 14:11:25 | red-metrics/3-install-tempo | running command: [/bin/sh -c kubectl get --namespace kuttl-test-bursting-penguin tempo redmetrics -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' | grep True]
    logger.go:42: 14:11:26 | red-metrics/3-install-tempo | True
    logger.go:42: 14:11:29 | red-metrics/3-install-tempo | running command: [/bin/sh -c kubectl get --namespace kuttl-test-bursting-penguin tempo redmetrics -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' | grep True]
    logger.go:42: 14:11:30 | red-metrics/3-install-tempo | True
    logger.go:42: 14:11:30 | red-metrics/3-install-tempo | test step completed 3-install-tempo
    logger.go:42: 14:11:30 | red-metrics/4-install-hotrod | starting test step 4-install-hotrod
    logger.go:42: 14:11:32 | red-metrics/4-install-hotrod | Deployment:kuttl-test-bursting-penguin/hotrod created
    logger.go:42: 14:11:33 | red-metrics/4-install-hotrod | Service:kuttl-test-bursting-penguin/hotrod created
    logger.go:42: 14:11:36 | red-metrics/4-install-hotrod | test step completed 4-install-hotrod
    logger.go:42: 14:11:36 | red-metrics/5-install-generate-traces | starting test step 5-install-generate-traces
    logger.go:42: 14:11:38 | red-metrics/5-install-generate-traces | Job:kuttl-test-bursting-penguin/hotrod-curl created
    logger.go:42: 14:11:39 | red-metrics/5-install-generate-traces | test step completed 5-install-generate-traces
    logger.go:42: 14:11:39 | red-metrics/6-intall-assert-job | starting test step 6-intall-assert-job
    logger.go:42: 14:11:41 | red-metrics/6-intall-assert-job | Job:kuttl-test-bursting-penguin/verify-metrics created
    logger.go:42: 14:11:42 | red-metrics/6-intall-assert-job | running command: [sh -c ./tests/e2e-openshift/red-metrics/check_alert.sh]
    logger.go:42: 14:11:44 | red-metrics/6-intall-assert-job | Alert SpanREDFrontendAPIRequestLatency is not firing
    logger.go:42: 14:11:46 | red-metrics/6-intall-assert-job | running command: [sh -c ./tests/e2e-openshift/red-metrics/check_alert.sh]
    logger.go:42: 14:11:49 | red-metrics/6-intall-assert-job | Alert SpanREDFrontendAPIRequestLatency is not firing
    logger.go:42: 14:11:51 | red-metrics/6-intall-assert-job | running command: [sh -c ./tests/e2e-openshift/red-metrics/check_alert.sh]
    logger.go:42: 14:11:54 | red-metrics/6-intall-assert-job | Alert SpanREDFrontendAPIRequestLatency is not firing
    logger.go:42: 14:11:55 | red-metrics/6-intall-assert-job | running command: [sh -c ./tests/e2e-openshift/red-metrics/check_alert.sh]
    logger.go:42: 14:11:58 | red-metrics/6-intall-assert-job | Alert SpanREDFrontendAPIRequestLatency is not firing
    logger.go:42: 14:11:59 | red-metrics/6-intall-assert-job | running command: [sh -c ./tests/e2e-openshift/red-metrics/check_alert.sh]
    logger.go:42: 14:12:02 | red-metrics/6-intall-assert-job | Alert SpanREDFrontendAPIRequestLatency is not firing
    logger.go:42: 14:12:03 | red-metrics/6-intall-assert-job | running command: [sh -c ./tests/e2e-openshift/red-metrics/check_alert.sh]
    logger.go:42: 14:12:06 | red-metrics/6-intall-assert-job | Alert SpanREDFrontendAPIRequestLatency is not firing
    logger.go:42: 14:12:07 | red-metrics/6-intall-assert-job | running command: [sh -c ./tests/e2e-openshift/red-metrics/check_alert.sh]
    logger.go:42: 14:12:10 | red-metrics/6-intall-assert-job | Alert SpanREDFrontendAPIRequestLatency is not firing
    logger.go:42: 14:12:11 | red-metrics/6-intall-assert-job | running command: [sh -c ./tests/e2e-openshift/red-metrics/check_alert.sh]
    logger.go:42: 14:12:14 | red-metrics/6-intall-assert-job | Alert SpanREDFrontendAPIRequestLatency is not firing
    logger.go:42: 14:12:16 | red-metrics/6-intall-assert-job | running command: [sh -c ./tests/e2e-openshift/red-metrics/check_alert.sh]
    logger.go:42: 14:12:19 | red-metrics/6-intall-assert-job | Alert SpanREDFrontendAPIRequestLatency is not firing
    logger.go:42: 14:12:20 | red-metrics/6-intall-assert-job | running command: [sh -c ./tests/e2e-openshift/red-metrics/check_alert.sh]
    logger.go:42: 14:12:22 | red-metrics/6-intall-assert-job | Alert SpanREDFrontendAPIRequestLatency is not firing
    logger.go:42: 14:12:24 | red-metrics/6-intall-assert-job | running command: [sh -c ./tests/e2e-openshift/red-metrics/check_alert.sh]
    logger.go:42: 14:12:26 | red-metrics/6-intall-assert-job | Alert SpanREDFrontendAPIRequestLatency is not firing
    logger.go:42: 14:12:28 | red-metrics/6-intall-assert-job | running command: [sh -c ./tests/e2e-openshift/red-metrics/check_alert.sh]
    logger.go:42: 14:12:30 | red-metrics/6-intall-assert-job | Alert SpanREDFrontendAPIRequestLatency is not firing
    logger.go:42: 14:12:31 | red-metrics/6-intall-assert-job | running command: [sh -c ./tests/e2e-openshift/red-metrics/check_alert.sh]
    logger.go:42: 14:12:34 | red-metrics/6-intall-assert-job | Alert SpanREDFrontendAPIRequestLatency is not firing
    logger.go:42: 14:12:35 | red-metrics/6-intall-assert-job | running command: [sh -c ./tests/e2e-openshift/red-metrics/check_alert.sh]
    logger.go:42: 14:12:38 | red-metrics/6-intall-assert-job | Alert SpanREDFrontendAPIRequestLatency is not firing
    logger.go:42: 14:12:40 | red-metrics/6-intall-assert-job | running command: [sh -c ./tests/e2e-openshift/red-metrics/check_alert.sh]
    logger.go:42: 14:12:42 | red-metrics/6-intall-assert-job | Alert SpanREDFrontendAPIRequestLatency is not firing
    logger.go:42: 14:12:44 | red-metrics/6-intall-assert-job | running command: [sh -c ./tests/e2e-openshift/red-metrics/check_alert.sh]
    logger.go:42: 14:12:47 | red-metrics/6-intall-assert-job | Alert SpanREDFrontendAPIRequestLatency is not firing
    logger.go:42: 14:12:48 | red-metrics/6-intall-assert-job | running command: [sh -c ./tests/e2e-openshift/red-metrics/check_alert.sh]
    logger.go:42: 14:12:51 | red-metrics/6-intall-assert-job | Alert SpanREDFrontendAPIRequestLatency is not firing
    logger.go:42: 14:12:52 | red-metrics/6-intall-assert-job | running command: [sh -c ./tests/e2e-openshift/red-metrics/check_alert.sh]
    logger.go:42: 14:12:55 | red-metrics/6-intall-assert-job | Alert SpanREDFrontendAPIRequestLatency is not firing
    logger.go:42: 14:12:56 | red-metrics/6-intall-assert-job | running command: [sh -c ./tests/e2e-openshift/red-metrics/check_alert.sh]
    logger.go:42: 14:12:59 | red-metrics/6-intall-assert-job | Alert SpanREDFrontendAPIRequestLatency is not firing
    logger.go:42: 14:13:00 | red-metrics/6-intall-assert-job | running command: [sh -c ./tests/e2e-openshift/red-metrics/check_alert.sh]
    logger.go:42: 14:13:03 | red-metrics/6-intall-assert-job | Alert SpanREDFrontendAPIRequestLatency is not firing
    logger.go:42: 14:13:04 | red-metrics/6-intall-assert-job | running command: [sh -c ./tests/e2e-openshift/red-metrics/check_alert.sh]
    logger.go:42: 14:13:07 | red-metrics/6-intall-assert-job | Alert SpanREDFrontendAPIRequestLatency is not firing
    logger.go:42: 14:13:09 | red-metrics/6-intall-assert-job | running command: [sh -c ./tests/e2e-openshift/red-metrics/check_alert.sh]
    logger.go:42: 14:13:12 | red-metrics/6-intall-assert-job | Alert SpanREDFrontendAPIRequestLatency is not firing
    logger.go:42: 14:13:13 | red-metrics/6-intall-assert-job | running command: [sh -c ./tests/e2e-openshift/red-metrics/check_alert.sh]
    logger.go:42: 14:13:16 | red-metrics/6-intall-assert-job | Alert SpanREDFrontendAPIRequestLatency is firing
    logger.go:42: 14:13:16 | red-metrics/6-intall-assert-job | test step completed 6-intall-assert-job
    logger.go:42: 14:13:16 | red-metrics/7- | starting test step 7-
    logger.go:42: 14:13:19 | red-metrics/7- | running command: [sh -c ./tests/e2e-openshift/red-metrics/check_metrics.sh]
    logger.go:42: 14:13:22 | red-metrics/7- |   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
    logger.go:42: 14:13:22 | red-metrics/7- |                                  Dload  Upload   Total   Spent    Left  Speed
100  217k    0  217k    0     0   104k      0 --:--:--  0:00:02 --:--:--  104k
    logger.go:42: 14:13:24 | red-metrics/7- | Metric 'duration_bucket' with value is present.
    logger.go:42: 14:13:24 | red-metrics/7- |   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
    logger.go:42: 14:13:24 | red-metrics/7- |                                  Dload  Upload   Total   Spent    Left  Speed
100 12897    0 12897    0     0  14021      0 --:--:-- --:--:-- --:--:-- 14033
    logger.go:42: 14:13:25 | red-metrics/7- | Metric 'duration_count' with value is present.
    logger.go:42: 14:13:25 | red-metrics/7- |   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
    logger.go:42: 14:13:25 | red-metrics/7- |                                  Dload  Upload   Total   Spent    Left  Speed
100 13178    0 13178    0     0  11355      0 --:--:--  0:00:01 --:--:-- 11350
    logger.go:42: 14:13:26 | red-metrics/7- | Metric 'duration_sum' with value is present.
    logger.go:42: 14:13:26 | red-metrics/7- |   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
    logger.go:42: 14:13:26 | red-metrics/7- |                                  Dload  Upload   Total   Spent    Left  Speed
100 12681    0 12681    0     0  12269      0 --:--:--  0:00:01 --:--:-- 12275
    logger.go:42: 14:13:27 | red-metrics/7- | Metric 'calls' with value is present.
    logger.go:42: 14:13:27 | red-metrics/7- | test step completed 7-
    logger.go:42: 14:13:28 | red-metrics | red-metrics events from ns kuttl-test-bursting-penguin:
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:09:44 +0530 IST	Normal	PersistentVolumeClaim minio		WaitForFirstConsumer	waiting for first consumer to be created before binding	persistentvolume-controller	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:09:45 +0530 IST	Normal	ReplicaSet.apps minio-5c87b5b89d	SuccessfulCreate	Created pod: minio-5c87b5b89d-wsm7j	replicaset-controller	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:09:45 +0530 IST	Normal	Deployment.apps minio		ScalingReplicaSet	Scaled up replica set minio-5c87b5b89d to 1	deployment-controller	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:09:45 +0530 IST	Normal	PersistentVolumeClaim minio		Provisioning	External provisioner is provisioning volume for claim "kuttl-test-bursting-penguin/minio"		
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:09:45 +0530 IST	Normal	PersistentVolumeClaim minio		ExternalProvisioning	waiting for a volume to be created, either by external provisioner "ebs.csi.aws.com" or manually created by system administrator	persistentvolume-controller	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:09:48 +0530 IST	Normal	PersistentVolumeClaim minio		ProvisioningSucceeded	Successfully provisioned volume pvc-06ae4146-cd8a-4352-8aaf-c752ef7c51aa		
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:09:49 +0530 IST	Normal	Pod minio-5c87b5b89d-wsm7j		Scheduled	Successfully assigned kuttl-test-bursting-penguin/minio-5c87b5b89d-wsm7j to ip-10-0-8-162.us-east-2.compute.internal	default-scheduler	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:09:51 +0530 IST	Normal	Pod minio-5c87b5b89d-wsm7j		SuccessfulAttachVolume	AttachVolume.Attach succeeded for volume "pvc-06ae4146-cd8a-4352-8aaf-c752ef7c51aa" 	attachdetach-controller	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:09:55 +0530 IST	Normal	Pod minio-5c87b5b89d-wsm7j		AddedInterface	Add eth0 [10.129.2.62/23] from openshift-sdn		
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:09:55 +0530 IST	Normal	Pod minio-5c87b5b89d-wsm7j.spec.containers{minio}		Pulling	Pulling image "minio/minio"	kubelet	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:09:55 +0530 IST	Normal	Pod minio-5c87b5b89d-wsm7j.spec.containers{minio}		Pulled	Successfully pulled image "minio/minio" in 303.389657ms (303.402188ms including waiting)	kubelet	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:09:56 +0530 IST	Normal	Pod minio-5c87b5b89d-wsm7j.spec.containers{minio}		Created	Created container minio	kubelet	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:09:56 +0530 IST	Normal	Pod minio-5c87b5b89d-wsm7j.spec.containers{minio}		Started	Started container minio	kubelet	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:10:07 +0530 IST	Normal	Pod otel-collector-769b7b7bd8-cthx8	Scheduled	Successfully assigned kuttl-test-bursting-penguin/otel-collector-769b7b7bd8-cthx8 to ip-10-0-87-245.us-east-2.compute.internal	default-scheduler	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:10:07 +0530 IST	Warning	ReplicaSet.apps otel-collector-769b7b7bd8		FailedCreate	Error creating: pods "otel-collector-769b7b7bd8-" is forbidden: error looking up service account kuttl-test-bursting-penguin/otel-collector: serviceaccount "otel-collector" not found	replicaset-controller	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:10:07 +0530 IST	Normal	ReplicaSet.apps otel-collector-769b7b7bd8		SuccessfulCreate	Created pod: otel-collector-769b7b7bd8-cthx8	replicaset-controller	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:10:07 +0530 IST	Normal	PodDisruptionBudget.policy otel-collector		NoPods	No matching pods found	controllermanager	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:10:07 +0530 IST	Normal	Deployment.apps otel-collector		ScalingReplicaSet	Scaled up replica set otel-collector-769b7b7bd8 to 1	deployment-controller	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:10:07 +0530 IST	Normal	OpenTelemetryCollector.opentelemetry.io otel		Info	applied status changes	opentelemetry-operator	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:10:10 +0530 IST	Normal	Pod otel-collector-769b7b7bd8-cthx8	AddedInterface	Add eth0 [10.128.2.46/23] from openshift-sdn		
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:10:10 +0530 IST	Normal	Pod otel-collector-769b7b7bd8-cthx8.spec.containers{otc-container}		Pulled	Container image "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.92.0" already present on machine	kubelet	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:10:10 +0530 IST	Normal	Pod otel-collector-769b7b7bd8-cthx8.spec.containers{otc-container}		Created	Created container otc-container	kubelet	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:10:10 +0530 IST	Normal	Pod otel-collector-769b7b7bd8-cthx8.spec.containers{otc-container}		Started	Started container otc-container	kubelet	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:10:15 +0530 IST	Normal	PersistentVolumeClaim data-tempo-redmetrics-ingester-0		WaitForFirstConsumer	waiting for first consumer to be created before binding	persistentvolume-controller	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:10:15 +0530 IST	Normal	Pod tempo-redmetrics-distributor-77c9ddb9c7-9fdrb		Scheduled	Successfully assigned kuttl-test-bursting-penguin/tempo-redmetrics-distributor-77c9ddb9c7-9fdrb to ip-10-0-40-46.us-east-2.compute.internal	default-scheduler	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:10:15 +0530 IST	Normal	ReplicaSet.apps tempo-redmetrics-distributor-77c9ddb9c7		SuccessfulCreate	Created pod: tempo-redmetrics-distributor-77c9ddb9c7-9fdrb	replicaset-controller	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:10:15 +0530 IST	Normal	Deployment.apps tempo-redmetrics-distributor		ScalingReplicaSet	Scaled up replica set tempo-redmetrics-distributor-77c9ddb9c7 to 1	deployment-controller	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:10:15 +0530 IST	Normal	StatefulSet.apps tempo-redmetrics-ingester		SuccessfulCreate	create Claim data-tempo-redmetrics-ingester-0 Pod tempo-redmetrics-ingester-0 in StatefulSet tempo-redmetrics-ingester success	statefulset-controller	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:10:15 +0530 IST	Normal	StatefulSet.apps tempo-redmetrics-ingester		SuccessfulCreate	create Pod tempo-redmetrics-ingester-0 in StatefulSet tempo-redmetrics-ingester successful	statefulset-controller	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:10:15 +0530 IST	Normal	Deployment.apps tempo-redmetrics-query-frontend		ScalingReplicaSet	Scaled up replica set tempo-redmetrics-query-frontend-84f87dd6f to 1	deployment-controller	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:10:16 +0530 IST	Normal	PersistentVolumeClaim data-tempo-redmetrics-ingester-0		Provisioning	External provisioner is provisioning volume for claim "kuttl-test-bursting-penguin/data-tempo-redmetrics-ingester-0"		
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:10:16 +0530 IST	Normal	PersistentVolumeClaim data-tempo-redmetrics-ingester-0		ExternalProvisioning	waiting for a volume to be created, either by external provisioner "ebs.csi.aws.com" or manually created by system administrator	persistentvolume-controller	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:10:16 +0530 IST	Normal	Pod tempo-redmetrics-compactor-54db6cb8f7-vsgzs		Scheduled	Successfully assigned kuttl-test-bursting-penguin/tempo-redmetrics-compactor-54db6cb8f7-vsgzs to ip-10-0-8-162.us-east-2.compute.internal	default-scheduler	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:10:16 +0530 IST	Normal	ReplicaSet.apps tempo-redmetrics-compactor-54db6cb8f7		SuccessfulCreate	Created pod: tempo-redmetrics-compactor-54db6cb8f7-vsgzs	replicaset-controller	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:10:16 +0530 IST	Normal	Deployment.apps tempo-redmetrics-compactor		ScalingReplicaSet	Scaled up replica set tempo-redmetrics-compactor-54db6cb8f7 to 1	deployment-controller	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:10:16 +0530 IST	Normal	Pod tempo-redmetrics-querier-676d8c644b-26b4s		Scheduled	Successfully assigned kuttl-test-bursting-penguin/tempo-redmetrics-querier-676d8c644b-26b4s to ip-10-0-87-245.us-east-2.compute.internal	default-scheduler	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:10:16 +0530 IST	Normal	ReplicaSet.apps tempo-redmetrics-querier-676d8c644b		SuccessfulCreate	Created pod: tempo-redmetrics-querier-676d8c644b-26b4s	replicaset-controller	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:10:16 +0530 IST	Normal	Deployment.apps tempo-redmetrics-querieScalingReplicaSet	Scaled up replica set tempo-redmetrics-querier-676d8c644b to 1	deployment-controller	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:10:16 +0530 IST	Normal	Pod tempo-redmetrics-query-frontend-84f87dd6f-5thhw		Scheduled	Successfully assigned kuttl-test-bursting-penguin/tempo-redmetrics-query-frontend-84f87dd6f-5thhw to ip-10-0-40-46.us-east-2.compute.internal	default-scheduler	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:10:16 +0530 IST	Normal	ReplicaSet.apps tempo-redmetrics-query-frontend-84f87dd6f		SuccessfulCreate	Created pod: tempo-redmetrics-query-frontend-84f87dd6f-5thhw	replicaset-controller	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:10:17 +0530 IST	Normal	Pod tempo-redmetrics-compactor-54db6cb8f7-vsgzs		AddedInterface	Add eth0 [10.129.2.63/23] from openshift-sdn		
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:10:17 +0530 IST	Normal	Pod tempo-redmetrics-compactor-54db6cb8f7-vsgzs.spec.containers{tempo}		Pulled	Container image "registry.redhat.io/rhosdt/tempo-rhel8@sha256:d0a526c0721596880eef4f38ef772ec7a914364cdc7165eaa35f6ba4068a5e7a" already present on machine	kubelet	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:10:17 +0530 IST	Normal	Pod tempo-redmetrics-distributor-77c9ddb9c7-9fdrb		AddedInterface	Add eth0 [10.131.0.51/23] from openshift-sdn		
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:10:17 +0530 IST	Normal	Pod tempo-redmetrics-distributor-77c9ddb9c7-9fdrb.spec.containers{tempo}		Pulled	Container image "registry.redhat.io/rhosdt/tempo-rhel8@sha256:d0a526c0721596880eef4f38ef772ec7a914364cdc7165eaa35f6ba4068a5e7a" already present on machine	kubelet	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:10:17 +0530 IST	Normal	Pod tempo-redmetrics-distributor-77c9ddb9c7-9fdrb.spec.containers{tempo}		Created	Created container tempo	kubelet	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:10:17 +0530 IST	Normal	Pod tempo-redmetrics-distributor-77c9ddb9c7-9fdrb.spec.containers{tempo}		Started	Started container tempo	kubelet	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:10:18 +0530 IST	Normal	Pod tempo-redmetrics-compactor-54db6cb8f7-vsgzs.spec.containers{tempo}		Created	Created container tempo	kubelet	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:10:18 +0530 IST	Normal	Pod tempo-redmetrics-compactor-54db6cb8f7-vsgzs.spec.containers{tempo}		Started	Started container tempo	kubelet	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:10:18 +0530 IST	Normal	Pod tempo-redmetrics-querier-676d8c644b-26b4s		AddedInterface	Add eth0 [10.128.2.47/23] from openshift-sdn		
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:10:18 +0530 IST	Normal	Pod tempo-redmetrics-querier-676d8c644b-26b4s.spec.containers{tempo}		Pulled	Container image "registry.redhat.io/rhosdt/tempo-rhel8@sha256:d0a526c0721596880eef4f38ef772ec7a914364cdc7165eaa35f6ba4068a5e7a" already present on machine	kubelet	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:10:18 +0530 IST	Normal	Pod tempo-redmetrics-querier-676d8c644b-26b4s.spec.containers{tempo}		Created	Created container tempo	kubelet	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:10:18 +0530 IST	Normal	Pod tempo-redmetrics-querier-676d8c644b-26b4s.spec.containers{tempo}		Started	Started container tempo	kubelet	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:10:18 +0530 IST	Normal	Pod tempo-redmetrics-query-frontend-84f87dd6f-5thhw		AddedInterface	Add eth0 [10.131.0.52/23] from openshift-sdn		
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:10:18 +0530 IST	Normal	Pod tempo-redmetrics-query-frontend-84f87dd6f-5thhw.spec.containers{tempo}		Pulled	Container image "registry.redhat.io/rhosdt/tempo-rhel8@sha256:d0a526c0721596880eef4f38ef772ec7a914364cdc7165eaa35f6ba4068a5e7a" already present on machine	kubelet	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:10:18 +0530 IST	Normal	Pod tempo-redmetrics-query-frontend-84f87dd6f-5thhw.spec.containers{tempo}		Created	Created container tempo	kubelet	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:10:18 +0530 IST	Normal	Pod tempo-redmetrics-query-frontend-84f87dd6f-5thhw.spec.containers{tempo}		Started	Started container tempo	kubelet	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:10:18 +0530 IST	Normal	Pod tempo-redmetrics-query-frontend-84f87dd6f-5thhw.spec.containers{tempo-query}		Pulled	Container image "registry.redhat.io/rhosdt/tempo-query-rhel8@sha256:5402f3af7bdee45bb3d514ed1054cdc2fb9475f6ca33ab513d226a3bd1bc46b9" already present on machine	kubelet	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:10:18 +0530 IST	Normal	Pod tempo-redmetrics-query-frontend-84f87dd6f-5thhw.spec.containers{tempo-query}		Created	Created container tempo-query	kubelet	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:10:18 +0530 IST	Normal	Pod tempo-redmetrics-query-frontend-84f87dd6f-5thhw.spec.containers{tempo-query}		Started	Started container tempo-query	kubelet	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:10:19 +0530 IST	Normal	PersistentVolumeClaim data-tempo-redmetrics-ingester-0		ProvisioningSucceeded	Successfully provisioned volume pvc-067b3508-59b3-4c15-989c-ae6e79b4ea73	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:10:20 +0530 IST	Normal	Pod tempo-redmetrics-ingester-0		Scheduled	Successfully assigned kuttl-test-bursting-penguin/tempo-redmetrics-ingester-0 to ip-10-0-8-162.us-east-2.compute.internal	default-scheduler	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:10:22 +0530 IST	Normal	Pod tempo-redmetrics-ingester-0		SuccessfulAttachVolume	AttachVolume.Attach succeeded for volume "pvc-067b3508-59b3-4c15-989c-ae6e79b4ea73" 	attachdetach-controller	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:10:25 +0530 IST	Normal	Pod tempo-redmetrics-ingester-0		AddedInterface	Add eth0 [10.129.2.64/23] from openshift-sdn		
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:10:26 +0530 IST	Normal	Pod tempo-redmetrics-ingester-0.spec.containers{tempo}		Pulled	Container image "registry.redhat.io/rhosdt/tempo-rhel8@sha256:d0a526c0721596880eef4f38ef772ec7a914364cdc7165eaa35f6ba4068a5e7a" already present on machine	kubelet	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:10:26 +0530 IST	Normal	Pod tempo-redmetrics-ingester-0.spec.containers{tempo}		Created	Created container tempo	kubelet	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:10:26 +0530 IST	Normal	Pod tempo-redmetrics-ingester-0.spec.containers{tempo}		Started	Started container tempo	kubelet	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:10:36 +0530 IST	Warning	Pod tempo-redmetrics-compactor-54db6cb8f7-vsgzs.spec.containers{tempo}		Unhealthy	Readiness probe failed: HTTP probe failed with statuscode: 503	kubelet
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:10:44 +0530 IST	Warning	Pod tempo-redmetrics-ingester-0.spec.containers{tempo}		Unhealthy	Readiness probe failed: HTTP probe failed with statuscode: 503	kubelet	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:11:32 +0530 IST	Normal	Pod hotrod-57d4948b8f-p8w4k		Scheduled	Successfully assigned kuttl-test-bursting-penguin/hotrod-57d4948b8f-p8w4k to ip-10-0-87-245.us-east-2.compute.internal	default-scheduler	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:11:32 +0530 IST	Normal	ReplicaSet.apps hotrod-57d4948b8f	SuccessfulCreate	Created pod: hotrod-57d4948b8f-p8w4k	replicaset-controller	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:11:32 +0530 IST	Normal	Deployment.apps hotrod		ScalingReplicaSet	Scaled up replica set hotrod-57d4948b8f to 1	deployment-controller	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:11:34 +0530 IST	Normal	Pod hotrod-57d4948b8f-p8w4k		AddedInterface	Add eth0 [10.128.2.48/23] from openshift-sdn		
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:11:34 +0530 IST	Normal	Pod hotrod-57d4948b8f-p8w4k.spec.containers{hotrod}		Pulled	Container image "jaegertracing/example-hotrod:1.46.0" already present on machine	kubelet
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:11:34 +0530 IST	Normal	Pod hotrod-57d4948b8f-p8w4k.spec.containers{hotrod}		Created	Created container hotrod	kubelet	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:11:34 +0530 IST	Normal	Pod hotrod-57d4948b8f-p8w4k.spec.containers{hotrod}		Started	Started container hotrod	kubelet	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:11:38 +0530 IST	Normal	Pod hotrod-curl-fmmlz		Scheduled	Successfully assigned kuttl-test-bursting-penguin/hotrod-curl-fmmlz to ip-10-0-8-162.us-east-2.compute.internal	default-scheduler	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:11:38 +0530 IST	Normal	Job.batch hotrod-curl		SuccessfulCreate	Created pod: hotrod-curl-fmmlz	job-controller	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:11:40 +0530 IST	Normal	Pod hotrod-curl-fmmlz		AddedInterface	Add eth0 [10.129.2.65/23] from openshift-sdn		
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:11:40 +0530 IST	Normal	Pod hotrod-curl-fmmlz.spec.containers{hotrod-curl}		Pulling	Pulling image "curlimages/curl"	kubelet	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:11:40 +0530 IST	Normal	Pod hotrod-curl-fmmlz.spec.containers{hotrod-curl}		Pulled	Successfully pulled image "curlimages/curl" in 321.427838ms (321.440452ms including waiting)	kubelet	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:11:40 +0530 IST	Normal	Pod hotrod-curl-fmmlz.spec.containers{hotrod-curl}		Created	Created container hotrod-curl	kubelet	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:11:40 +0530 IST	Normal	Pod hotrod-curl-fmmlz.spec.containers{hotrod-curl}		Started	Started container hotrod-curl	kubelet	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:11:41 +0530 IST	Normal	Pod verify-metrics-dtxfl		Scheduled	Successfully assigned kuttl-test-bursting-penguin/verify-metrics-dtxfl to ip-10-0-40-46.us-east-2.compute.internal	default-scheduler	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:11:41 +0530 IST	Normal	Job.batch verify-metrics		SuccessfulCreate	Created pod: verify-metrics-dtxfl	job-controller	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:11:43 +0530 IST	Normal	Pod verify-metrics-dtxfl		AddedInterface	Add eth0 [10.131.0.53/23] from openshift-sdn		
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:11:43 +0530 IST	Normal	Pod verify-metrics-dtxfl.spec.containers{verify-metrics}		Pulled	Container image "registry.access.redhat.com/ubi9/ubi:9.1" already present on machine	kubelet	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:11:43 +0530 IST	Normal	Pod verify-metrics-dtxfl.spec.containers{verify-metrics}		Created	Created container verify-metrics	kubelet	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:11:43 +0530 IST	Normal	Pod verify-metrics-dtxfl.spec.containers{verify-metrics}		Started	Started container verify-metrics	kubelet	
    logger.go:42: 14:13:28 | red-metrics | 2024-01-12 14:11:46 +0530 IST	Normal	Job.batch verify-metrics		Completed	Job completed	job-controller	
    logger.go:42: 14:13:31 | red-metrics | Deleting namespace: kuttl-test-bursting-penguin
=== CONT  kuttl
    harness.go:405: run tests finished
    harness.go:513: cleaning up
    harness.go:570: removing temp folder: ""
--- PASS: kuttl (273.91s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/red-metrics (267.14s)
PASS
```
