### PR TITLE
Fix validating spec.observability.grafana in the validating webhook

### DIFF
--- a/apis/tempo/v1alpha1/tempostack_webhook.go
+++ b/apis/tempo/v1alpha1/tempostack_webhook.go
@@ -293,9 +293,8 @@ func (v *validator) validateGateway(tempo TempoStack) field.ErrorList {
 
 func (v *validator) validateObservability(tempo TempoStack) field.ErrorList {
 	observabilityBase := field.NewPath("spec").Child("observability")
-	metricsBase := observabilityBase.Child("metrics")
-	grafanaBase := observabilityBase.Child("grafana")
 
+	metricsBase := observabilityBase.Child("metrics")
 	if tempo.Spec.Observability.Metrics.CreateServiceMonitors && !v.ctrlConfig.Gates.PrometheusOperator {
 		return field.ErrorList{
 			field.Invalid(metricsBase.Child("createServiceMonitors"), tempo.Spec.Observability.Metrics.CreateServiceMonitors,
@@ -318,16 +317,15 @@ func (v *validator) validateObservability(tempo TempoStack) field.ErrorList {
 	}
 
 	tracingBase := observabilityBase.Child("tracing")
-	if tempo.Spec.Observability.Tracing.SamplingFraction == "" {
-		return nil
-	}
-	if _, err := strconv.ParseFloat(tempo.Spec.Observability.Tracing.SamplingFraction, 64); err != nil {
-		return field.ErrorList{
-			field.Invalid(
-				tracingBase.Child("sampling_fraction"),
-				tempo.Spec.Observability.Tracing.SamplingFraction,
-				err.Error(),
-			)}
+	if tempo.Spec.Observability.Tracing.SamplingFraction != "" {
+		if _, err := strconv.ParseFloat(tempo.Spec.Observability.Tracing.SamplingFraction, 64); err != nil {
+			return field.ErrorList{
+				field.Invalid(
+					tracingBase.Child("sampling_fraction"),
+					tempo.Spec.Observability.Tracing.SamplingFraction,
+					err.Error(),
+				)}
+		}
 	}
 
 	if tempo.Spec.Observability.Tracing.JaegerAgentEndpoint != "" {
@@ -342,6 +340,7 @@ func (v *validator) validateObservability(tempo TempoStack) field.ErrorList {
 		}
 	}
 
+	grafanaBase := observabilityBase.Child("grafana")
 	if tempo.Spec.Observability.Grafana.CreateDatasource && !v.ctrlConfig.Gates.GrafanaOperator {
 		return field.ErrorList{
 			field.Invalid(grafanaBase.Child("createDatasource"), tempo.Spec.Observability.Grafana.CreateDatasource,

--- a/apis/tempo/v1alpha1/tempostack_webhook_test.go
+++ b/apis/tempo/v1alpha1/tempostack_webhook_test.go
@@ -1251,6 +1251,72 @@ func TestValidatorObservabilityTracingConfig(t *testing.T) {
 	}
 }
 
+func TestValidatorObservabilityGrafana(t *testing.T) {
+	tt := []struct {
+		name       string
+		input      TempoStack
+		ctrlConfig v1alpha1.ProjectConfig
+		expected   field.ErrorList
+	}{
+		{
+			name: "datasource not enabled",
+			input: TempoStack{
+				Spec: TempoStackSpec{},
+			},
+			expected: nil,
+		},
+		{
+			name: "datasource enabled, feature gate not set",
+			input: TempoStack{
+				Spec: TempoStackSpec{
+					Observability: ObservabilitySpec{
+						Grafana: GrafanaConfigSpec{
+							CreateDatasource: true,
+						},
+					},
+				},
+			},
+			ctrlConfig: v1alpha1.ProjectConfig{
+				Gates: v1alpha1.FeatureGates{
+					GrafanaOperator: false,
+				},
+			},
+			expected: field.ErrorList{
+				field.Invalid(
+					field.NewPath("spec").Child("observability").Child("grafana").Child("createDatasource"),
+					true,
+					"the grafanaOperator feature gate must be enabled to create a Datasource for Tempo",
+				),
+			},
+		},
+		{
+			name: "datasource enabled, feature gate set",
+			input: TempoStack{
+				Spec: TempoStackSpec{
+					Observability: ObservabilitySpec{
+						Grafana: GrafanaConfigSpec{
+							CreateDatasource: true,
+						},
+					},
+				},
+			},
+			ctrlConfig: v1alpha1.ProjectConfig{
+				Gates: v1alpha1.FeatureGates{
+					GrafanaOperator: true,
+				},
+			},
+			expected: nil,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			v := &validator{ctrlConfig: tc.ctrlConfig}
+			assert.Equal(t, tc.expected, v.validateObservability(tc.input))
+		})
+	}
+}
+
 func TestValidatorValidate(t *testing.T) {
 
 	gvType := metav1.TypeMeta{

--- a/bundle/community/manifests/tempo-operator-manager-config_v1_configmap.yaml
+++ b/bundle/community/manifests/tempo-operator-manager-config_v1_configmap.yaml
@@ -46,8 +46,6 @@ data:
         metrics:
           createServiceMonitors: false
           createPrometheusRules: false
-        grafana:
-          createDatasource: false
 kind: ConfigMap
 metadata:
   labels:

--- a/bundle/openshift/manifests/tempo-operator-manager-config_v1_configmap.yaml
+++ b/bundle/openshift/manifests/tempo-operator-manager-config_v1_configmap.yaml
@@ -46,8 +46,6 @@ data:
         metrics:
           createServiceMonitors: true
           createPrometheusRules: true
-        grafana:
-          createDatasource: false
 kind: ConfigMap
 metadata:
   labels:

--- a/config/overlays/community/controller_manager_config.yaml
+++ b/config/overlays/community/controller_manager_config.yaml
@@ -43,5 +43,3 @@ featureGates:
     metrics:
       createServiceMonitors: false
       createPrometheusRules: false
-    grafana:
-      createDatasource: false

--- a/config/overlays/openshift/controller_manager_config.yaml
+++ b/config/overlays/openshift/controller_manager_config.yaml
@@ -43,5 +43,3 @@ featureGates:
     metrics:
       createServiceMonitors: true
       createPrometheusRules: true
-    grafana:
-      createDatasource: false


### PR DESCRIPTION
The webhook had a `return nil` in the middle, resulting in skipping the Grafana validation.