### PR TITLE
Use a percentage of query-frontend resources for jaeger UI

### DIFF
--- a/.chloggen/fix_double_resources_query.yaml
+++ b/.chloggen/fix_double_resources_query.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, github action)
+component: operator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: fix double allocation of query-frontend resources
+
+# One or more tracking issues related to the change
+issues: [727]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
The approach I took to this was to use a percentage of the resources assigned to the query-frontend.


```
OriginalQueryFrontEndResouces = X

jaegerUIAssigned = PERCENTAGE*OriginalQueryFrontEndResouces
NewQueryFrontEndResources = OriginalQueryFrontEndResouces - jaegerUIAssigned.

```

PERCENTAGE = 0.1 I think 10% is reasonable for an static UI. 

 Other approach would be to have another table with new global percentages

But I don't think that is a good idea, that will lead us to an explotion of combinations, where we will need a table when jaegerUI is enabled but not gateway, of when both are enabled, or when jaegerUI is not enabled but gateway yes and so on..

Still need to test this..