### PR TITLE
Unify TLS paths and key names

### DIFF
--- a/controllers/tempo/storage.go
+++ b/controllers/tempo/storage.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"path"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -32,7 +33,7 @@ func GetS3Params(tempo v1alpha1.TempoStack, storageSecret *corev1.Secret) *manif
 
 	caPath := ""
 	if tempo.Spec.Storage.TLS.CA != "" {
-		caPath = manifestutils.TempoStorageTLSCAPath()
+		caPath = path.Join(manifestutils.StorageTLSCADir, manifestutils.StorageTLSCAFilename)
 	}
 
 	return &manifestutils.S3{

--- a/internal/manifests/config/build.go
+++ b/internal/manifests/config/build.go
@@ -112,7 +112,7 @@ func buildReceiverTLSConfig(tempo v1alpha1.TempoStack) receiverTLSOptions {
 		Enabled:         tempo.Spec.Template.Distributor.TLS.Enabled,
 		ClientCAEnabled: tempo.Spec.Template.Distributor.TLS.CA != "",
 		Paths: tlsFilePaths{
-			CA:          path.Join(manifestutils.CAReceiver, manifestutils.TLSCAFilename),
+			CA:          path.Join(manifestutils.ReceiverTLSCADir, manifestutils.TLSCAFilename),
 			Key:         path.Join(manifestutils.ReceiverTLSCertDir, manifestutils.TLSKeyFilename),
 			Certificate: path.Join(manifestutils.ReceiverTLSCertDir, manifestutils.TLSCertFilename),
 		},
@@ -128,7 +128,7 @@ func buildTLSConfig(params manifestutils.Params) (tlsOptions, error) {
 	}
 	return tlsOptions{
 		Paths: tlsFilePaths{
-			CA:          path.Join(manifestutils.CABundleDir, manifestutils.TLSCAFilename),
+			CA:          path.Join(manifestutils.TempoInternalTLSCADir, manifestutils.TLSCAFilename),
 			Key:         path.Join(manifestutils.TempoInternalTLSCertDir, manifestutils.TLSKeyFilename),
 			Certificate: path.Join(manifestutils.TempoInternalTLSCertDir, manifestutils.TLSCertFilename),
 		},

--- a/internal/manifests/config/build.go
+++ b/internal/manifests/config/build.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"html/template"
 	"io"
+	"path"
 
 	"k8s.io/utils/ptr"
 
@@ -111,9 +112,9 @@ func buildReceiverTLSConfig(tempo v1alpha1.TempoStack) receiverTLSOptions {
 		Enabled:         tempo.Spec.Template.Distributor.TLS.Enabled,
 		ClientCAEnabled: tempo.Spec.Template.Distributor.TLS.CA != "",
 		Paths: tlsFilePaths{
-			CA:          fmt.Sprintf("%s/%s", manifestutils.CAReceiver, manifestutils.TLSCAFilename),
-			Key:         fmt.Sprintf("%s/%s", manifestutils.ReceiverTLSCertDir, manifestutils.TLSKeyFilename),
-			Certificate: fmt.Sprintf("%s/%s", manifestutils.ReceiverTLSCertDir, manifestutils.TLSCertFilename),
+			CA:          path.Join(manifestutils.CAReceiver, manifestutils.TLSCAFilename),
+			Key:         path.Join(manifestutils.ReceiverTLSCertDir, manifestutils.TLSKeyFilename),
+			Certificate: path.Join(manifestutils.ReceiverTLSCertDir, manifestutils.TLSCertFilename),
 		},
 		MinTLSVersion: tempo.Spec.Template.Distributor.TLS.MinVersion,
 	}
@@ -127,9 +128,9 @@ func buildTLSConfig(params manifestutils.Params) (tlsOptions, error) {
 	}
 	return tlsOptions{
 		Paths: tlsFilePaths{
-			CA:          fmt.Sprintf("%s/%s", manifestutils.CABundleDir, manifestutils.TLSCAFilename),
-			Key:         fmt.Sprintf("%s/%s", manifestutils.TempoInternalTLSCertDir, manifestutils.TLSKeyFilename),
-			Certificate: fmt.Sprintf("%s/%s", manifestutils.TempoInternalTLSCertDir, manifestutils.TLSCertFilename),
+			CA:          path.Join(manifestutils.CABundleDir, manifestutils.TLSCAFilename),
+			Key:         path.Join(manifestutils.TempoInternalTLSCertDir, manifestutils.TLSKeyFilename),
+			Certificate: path.Join(manifestutils.TempoInternalTLSCertDir, manifestutils.TLSCertFilename),
 		},
 		ServerNames: serverNames{
 			QueryFrontend: naming.ServiceFqdn(tempo.Namespace, tempo.Name, manifestutils.QueryFrontendComponentName),

--- a/internal/manifests/config/build.go
+++ b/internal/manifests/config/build.go
@@ -111,9 +111,9 @@ func buildReceiverTLSConfig(tempo v1alpha1.TempoStack) receiverTLSOptions {
 		Enabled:         tempo.Spec.Template.Distributor.TLS.Enabled,
 		ClientCAEnabled: tempo.Spec.Template.Distributor.TLS.CA != "",
 		Paths: tlsFilePaths{
-			CA:          fmt.Sprintf("%s/%s", manifestutils.CAReceiver, manifestutils.ReceiverCAKey),
-			Key:         fmt.Sprintf("%s/%s", manifestutils.TempoReceiverTLSDir(), manifestutils.ReceiverPrivateKey),
-			Certificate: fmt.Sprintf("%s/%s", manifestutils.TempoReceiverTLSDir(), manifestutils.ReceiverPublicKey),
+			CA:          fmt.Sprintf("%s/%s", manifestutils.CAReceiver, manifestutils.TLSCAFilename),
+			Key:         fmt.Sprintf("%s/%s", manifestutils.ReceiverTLSCertDir, manifestutils.TLSKeyFilename),
+			Certificate: fmt.Sprintf("%s/%s", manifestutils.ReceiverTLSCertDir, manifestutils.TLSCertFilename),
 		},
 		MinTLSVersion: tempo.Spec.Template.Distributor.TLS.MinVersion,
 	}
@@ -127,9 +127,9 @@ func buildTLSConfig(params manifestutils.Params) (tlsOptions, error) {
 	}
 	return tlsOptions{
 		Paths: tlsFilePaths{
-			CA:          fmt.Sprintf("%s/service-ca.crt", manifestutils.CABundleDir),
-			Key:         fmt.Sprintf("%s/tls.key", manifestutils.TempoServerTLSDir()),
-			Certificate: fmt.Sprintf("%s/tls.crt", manifestutils.TempoServerTLSDir()),
+			CA:          fmt.Sprintf("%s/%s", manifestutils.CABundleDir, manifestutils.TLSCAFilename),
+			Key:         fmt.Sprintf("%s/%s", manifestutils.TempoInternalTLSCertDir, manifestutils.TLSKeyFilename),
+			Certificate: fmt.Sprintf("%s/%s", manifestutils.TempoInternalTLSCertDir, manifestutils.TLSCertFilename),
 		},
 		ServerNames: serverNames{
 			QueryFrontend: naming.ServiceFqdn(tempo.Namespace, tempo.Name, manifestutils.QueryFrontendComponentName),

--- a/internal/manifests/distributor/distributor.go
+++ b/internal/manifests/distributor/distributor.go
@@ -104,7 +104,7 @@ func configureReceiversTLS(dep *v1.Deployment, tempo v1alpha1.TempoStack) error 
 			{
 				Name:      certSecretName,
 				ReadOnly:  true,
-				MountPath: manifestutils.TempoReceiverTLSDir(),
+				MountPath: manifestutils.ReceiverTLSCertDir,
 			},
 		},
 	}

--- a/internal/manifests/distributor/distributor.go
+++ b/internal/manifests/distributor/distributor.go
@@ -74,7 +74,7 @@ func configureReceiversTLS(dep *v1.Deployment, tempo v1alpha1.TempoStack) error 
 				{
 					Name:      caSecretName,
 					ReadOnly:  true,
-					MountPath: manifestutils.CAReceiver,
+					MountPath: manifestutils.ReceiverTLSCADir,
 				},
 			},
 		}

--- a/internal/manifests/distributor/distributor_test.go
+++ b/internal/manifests/distributor/distributor_test.go
@@ -334,7 +334,7 @@ func TestBuildDistributor(t *testing.T) {
 				},
 				{
 					Name:      "cert-custom",
-					MountPath: manifestutils.TempoReceiverTLSDir(),
+					MountPath: manifestutils.ReceiverTLSCertDir,
 					ReadOnly:  true,
 				},
 			},

--- a/internal/manifests/distributor/distributor_test.go
+++ b/internal/manifests/distributor/distributor_test.go
@@ -329,7 +329,7 @@ func TestBuildDistributor(t *testing.T) {
 				},
 				{
 					Name:      "ca-custom",
-					MountPath: manifestutils.CAReceiver,
+					MountPath: manifestutils.ReceiverTLSCADir,
 					ReadOnly:  true,
 				},
 				{

--- a/internal/manifests/gateway/gateway.go
+++ b/internal/manifests/gateway/gateway.go
@@ -143,7 +143,7 @@ func deployment(params manifestutils.Params, rbacCfgHash string, tenantsCfgHash 
 			fmt.Sprintf("--tls.internal.server.cert-file=%s", path.Join(manifestutils.TempoInternalTLSCertDir, manifestutils.TLSCertFilename)),
 			fmt.Sprintf("--traces.tls.key-file=%s", path.Join(manifestutils.TempoInternalTLSCertDir, manifestutils.TLSKeyFilename)),
 			fmt.Sprintf("--traces.tls.cert-file=%s", path.Join(manifestutils.TempoInternalTLSCertDir, manifestutils.TLSCertFilename)),
-			fmt.Sprintf("--traces.tls.ca-file=%s", path.Join(manifestutils.CABundleDir, manifestutils.TLSCAFilename)),
+			fmt.Sprintf("--traces.tls.ca-file=%s", path.Join(manifestutils.TempoInternalTLSCADir, manifestutils.TLSCAFilename)),
 		}
 	}
 

--- a/internal/manifests/gateway/gateway.go
+++ b/internal/manifests/gateway/gateway.go
@@ -139,11 +139,11 @@ func deployment(params manifestutils.Params, rbacCfgHash string, tenantsCfgHash 
 	if params.CtrlConfig.Gates.HTTPEncryption {
 		internalServerScheme = corev1.URISchemeHTTPS
 		tlsArgs = []string{
-			fmt.Sprintf("--tls.internal.server.key-file=%s/tls.key", manifestutils.TempoServerTLSDir()),
-			fmt.Sprintf("--tls.internal.server.cert-file=%s/tls.crt", manifestutils.TempoServerTLSDir()),
-			fmt.Sprintf("--traces.tls.key-file=%s/tls.key", manifestutils.TempoServerTLSDir()),
-			fmt.Sprintf("--traces.tls.cert-file=%s/tls.crt", manifestutils.TempoServerTLSDir()),
-			fmt.Sprintf("--traces.tls.ca-file=%s/service-ca.crt", manifestutils.CABundleDir),
+			fmt.Sprintf("--tls.internal.server.key-file=%s/%s", manifestutils.TempoInternalTLSCertDir, manifestutils.TLSKeyFilename),
+			fmt.Sprintf("--tls.internal.server.cert-file=%s/%s", manifestutils.TempoInternalTLSCertDir, manifestutils.TLSCertFilename),
+			fmt.Sprintf("--traces.tls.key-file=%s/%s", manifestutils.TempoInternalTLSCertDir, manifestutils.TLSKeyFilename),
+			fmt.Sprintf("--traces.tls.cert-file=%s/%s", manifestutils.TempoInternalTLSCertDir, manifestutils.TLSCertFilename),
+			fmt.Sprintf("--traces.tls.ca-file=%s/%s", manifestutils.CABundleDir, manifestutils.TLSCAFilename),
 		}
 	}
 

--- a/internal/manifests/gateway/gateway.go
+++ b/internal/manifests/gateway/gateway.go
@@ -139,11 +139,11 @@ func deployment(params manifestutils.Params, rbacCfgHash string, tenantsCfgHash 
 	if params.CtrlConfig.Gates.HTTPEncryption {
 		internalServerScheme = corev1.URISchemeHTTPS
 		tlsArgs = []string{
-			fmt.Sprintf("--tls.internal.server.key-file=%s/%s", manifestutils.TempoInternalTLSCertDir, manifestutils.TLSKeyFilename),
-			fmt.Sprintf("--tls.internal.server.cert-file=%s/%s", manifestutils.TempoInternalTLSCertDir, manifestutils.TLSCertFilename),
-			fmt.Sprintf("--traces.tls.key-file=%s/%s", manifestutils.TempoInternalTLSCertDir, manifestutils.TLSKeyFilename),
-			fmt.Sprintf("--traces.tls.cert-file=%s/%s", manifestutils.TempoInternalTLSCertDir, manifestutils.TLSCertFilename),
-			fmt.Sprintf("--traces.tls.ca-file=%s/%s", manifestutils.CABundleDir, manifestutils.TLSCAFilename),
+			fmt.Sprintf("--tls.internal.server.key-file=%s", path.Join(manifestutils.TempoInternalTLSCertDir, manifestutils.TLSKeyFilename)),
+			fmt.Sprintf("--tls.internal.server.cert-file=%s", path.Join(manifestutils.TempoInternalTLSCertDir, manifestutils.TLSCertFilename)),
+			fmt.Sprintf("--traces.tls.key-file=%s", path.Join(manifestutils.TempoInternalTLSCertDir, manifestutils.TLSKeyFilename)),
+			fmt.Sprintf("--traces.tls.cert-file=%s", path.Join(manifestutils.TempoInternalTLSCertDir, manifestutils.TLSCertFilename)),
+			fmt.Sprintf("--traces.tls.ca-file=%s", path.Join(manifestutils.CABundleDir, manifestutils.TLSCAFilename)),
 		}
 	}
 

--- a/internal/manifests/gateway/gateway_test.go
+++ b/internal/manifests/gateway/gateway_test.go
@@ -564,10 +564,10 @@ func TestTLSParameters(t *testing.T) {
 	require.True(t, ok)
 
 	args := dep.Spec.Template.Spec.Containers[0].Args
-	assert.Contains(t, args, fmt.Sprintf("--tls.internal.server.key-file=%s/tls.key", manifestutils.TempoServerTLSDir()))
-	assert.Contains(t, args, fmt.Sprintf("--tls.internal.server.cert-file=%s/tls.crt", manifestutils.TempoServerTLSDir()))
-	assert.Contains(t, args, fmt.Sprintf("--traces.tls.key-file=%s/tls.key", manifestutils.TempoServerTLSDir()))
-	assert.Contains(t, args, fmt.Sprintf("--traces.tls.cert-file=%s/tls.crt", manifestutils.TempoServerTLSDir()))
+	assert.Contains(t, args, fmt.Sprintf("--tls.internal.server.key-file=%s/tls.key", manifestutils.TempoInternalTLSCertDir))
+	assert.Contains(t, args, fmt.Sprintf("--tls.internal.server.cert-file=%s/tls.crt", manifestutils.TempoInternalTLSCertDir))
+	assert.Contains(t, args, fmt.Sprintf("--traces.tls.key-file=%s/tls.key", manifestutils.TempoInternalTLSCertDir))
+	assert.Contains(t, args, fmt.Sprintf("--traces.tls.cert-file=%s/tls.crt", manifestutils.TempoInternalTLSCertDir))
 	assert.Contains(t, args, fmt.Sprintf("--traces.tls.ca-file=%s/service-ca.crt", manifestutils.CABundleDir))
 	assert.Contains(t, args, fmt.Sprintf("--traces.tempo.endpoint=https://%s:%d",
 		naming.ServiceFqdn(tempo.Namespace, tempo.Name, manifestutils.QueryFrontendComponentName), manifestutils.PortHTTPServer))
@@ -594,10 +594,10 @@ func TestTLSParameters(t *testing.T) {
 	require.True(t, ok)
 
 	args = dep.Spec.Template.Spec.Containers[0].Args
-	assert.NotContains(t, args, fmt.Sprintf("--tls.internal.server.key-file=%s/tls.key", manifestutils.TempoServerTLSDir()))
-	assert.NotContains(t, args, fmt.Sprintf("--tls.internal.server.cert-file=%s/tls.crt", manifestutils.TempoServerTLSDir()))
-	assert.NotContains(t, args, fmt.Sprintf("--traces.tls.key-file=%s/tls.key", manifestutils.TempoServerTLSDir()))
-	assert.NotContains(t, args, fmt.Sprintf("--traces.tls.cert-file=%s/tls.crt", manifestutils.TempoServerTLSDir()))
+	assert.NotContains(t, args, fmt.Sprintf("--tls.internal.server.key-file=%s/tls.key", manifestutils.TempoInternalTLSCertDir))
+	assert.NotContains(t, args, fmt.Sprintf("--tls.internal.server.cert-file=%s/tls.crt", manifestutils.TempoInternalTLSCertDir))
+	assert.NotContains(t, args, fmt.Sprintf("--traces.tls.key-file=%s/tls.key", manifestutils.TempoInternalTLSCertDir))
+	assert.NotContains(t, args, fmt.Sprintf("--traces.tls.cert-file=%s/tls.crt", manifestutils.TempoInternalTLSCertDir))
 	assert.NotContains(t, args, fmt.Sprintf("--traces.tls.ca-file=%s/service-ca.crt", manifestutils.CABundleDir))
 	assert.Contains(t, args, fmt.Sprintf("--traces.read.endpoint=http://%s:16686",
 		naming.ServiceFqdn(tempo.Namespace, tempo.Name, manifestutils.QueryFrontendComponentName)))

--- a/internal/manifests/gateway/gateway_test.go
+++ b/internal/manifests/gateway/gateway_test.go
@@ -568,7 +568,7 @@ func TestTLSParameters(t *testing.T) {
 	assert.Contains(t, args, fmt.Sprintf("--tls.internal.server.cert-file=%s/tls.crt", manifestutils.TempoInternalTLSCertDir))
 	assert.Contains(t, args, fmt.Sprintf("--traces.tls.key-file=%s/tls.key", manifestutils.TempoInternalTLSCertDir))
 	assert.Contains(t, args, fmt.Sprintf("--traces.tls.cert-file=%s/tls.crt", manifestutils.TempoInternalTLSCertDir))
-	assert.Contains(t, args, fmt.Sprintf("--traces.tls.ca-file=%s/service-ca.crt", manifestutils.CABundleDir))
+	assert.Contains(t, args, fmt.Sprintf("--traces.tls.ca-file=%s/service-ca.crt", manifestutils.TempoInternalTLSCADir))
 	assert.Contains(t, args, fmt.Sprintf("--traces.tempo.endpoint=https://%s:%d",
 		naming.ServiceFqdn(tempo.Namespace, tempo.Name, manifestutils.QueryFrontendComponentName), manifestutils.PortHTTPServer))
 	assert.Equal(t, corev1.URISchemeHTTPS, dep.Spec.Template.Spec.Containers[0].ReadinessProbe.HTTPGet.Scheme)
@@ -598,7 +598,7 @@ func TestTLSParameters(t *testing.T) {
 	assert.NotContains(t, args, fmt.Sprintf("--tls.internal.server.cert-file=%s/tls.crt", manifestutils.TempoInternalTLSCertDir))
 	assert.NotContains(t, args, fmt.Sprintf("--traces.tls.key-file=%s/tls.key", manifestutils.TempoInternalTLSCertDir))
 	assert.NotContains(t, args, fmt.Sprintf("--traces.tls.cert-file=%s/tls.crt", manifestutils.TempoInternalTLSCertDir))
-	assert.NotContains(t, args, fmt.Sprintf("--traces.tls.ca-file=%s/service-ca.crt", manifestutils.CABundleDir))
+	assert.NotContains(t, args, fmt.Sprintf("--traces.tls.ca-file=%s/service-ca.crt", manifestutils.TempoInternalTLSCADir))
 	assert.Contains(t, args, fmt.Sprintf("--traces.read.endpoint=http://%s:16686",
 		naming.ServiceFqdn(tempo.Namespace, tempo.Name, manifestutils.QueryFrontendComponentName)))
 	assert.Equal(t, corev1.URISchemeHTTP, dep.Spec.Template.Spec.Containers[0].ReadinessProbe.HTTPGet.Scheme)

--- a/internal/manifests/manifestutils/constants.go
+++ b/internal/manifests/manifestutils/constants.go
@@ -92,10 +92,13 @@ const (
 	// TenantHeader is the header name that contains tenant name.
 	TenantHeader = "x-scope-orgid"
 
-	// ReceiverCAKey is the key name of the CA file in the configmap.
-	ReceiverCAKey = "service-ca.crt"
-	// ReceiverPublicKey is the key name of the public key file in the configmap.
-	ReceiverPublicKey = "tls.crt"
-	// ReceiverPrivateKey is the key name of the private key file in the configmap.
-	ReceiverPrivateKey = "tls.key"
+	// TLSCAFilename is the key name of the CA file in the ConfigMap.
+	TLSCAFilename = "service-ca.crt"
+	// TLSCertFilename is the key name of the certificate file in the Secret.
+	TLSCertFilename = "tls.crt"
+	// TLSKeyFilename is the key name of the private key file in the Secret.
+	TLSKeyFilename = "tls.key"
+
+	// StorageTLSCAFilename is the key name of the CA file in the ConfigMap for accessing object storage.
+	StorageTLSCAFilename = "ca.crt"
 )

--- a/internal/manifests/manifestutils/params.go
+++ b/internal/manifests/manifestutils/params.go
@@ -17,7 +17,7 @@ type Params struct {
 	GatewayTenantsData  []*GatewayTenantsData
 }
 
-// StorageParams holds storage configuration.
+// StorageParams holds storage configuration from the storage secret, except the credentials.
 type StorageParams struct {
 	AzureStorage *AzureStorage
 	GCS          *GCS

--- a/internal/manifests/manifestutils/paths.go
+++ b/internal/manifests/manifestutils/paths.go
@@ -3,14 +3,14 @@ package manifestutils
 const (
 	// TLSDir is the path that is mounted from the secret for TLS.
 	TLSDir = "/var/run/tls"
-	// CABundleDir is the path that is mounted from the configmap for TLS.
-	CABundleDir = "/var/run/ca"
-	// CAReceiver is the path that is mounted from the configmap for TLS for receiver.
-	CAReceiver = "/var/run/ca-receiver"
 
+	// TempoInternalTLSCADir is the path that is mounted from the configmap for TLS.
+	TempoInternalTLSCADir = "/var/run/ca"
 	// TempoInternalTLSCertDir returns the mount path of the HTTP service certificates for communication between Tempo components.
 	TempoInternalTLSCertDir = TLSDir + "/server"
 
+	// ReceiverTLSCADir is the path that is mounted from the configmap for TLS for receiver.
+	ReceiverTLSCADir = "/var/run/ca-receiver"
 	// ReceiverTLSCertDir returns the mount path of the receivers certificates (for ingesting traces).
 	ReceiverTLSCertDir = TLSDir + "/receiver"
 

--- a/internal/manifests/manifestutils/paths.go
+++ b/internal/manifests/manifestutils/paths.go
@@ -7,4 +7,15 @@ const (
 	CABundleDir = "/var/run/ca"
 	// CAReceiver is the path that is mounted from the configmap for TLS for receiver.
 	CAReceiver = "/var/run/ca-receiver"
+
+	// TempoInternalTLSCertDir returns the mount path of the HTTP service certificates for communication between Tempo components.
+	TempoInternalTLSCertDir = TLSDir + "/server"
+
+	// ReceiverTLSCertDir returns the mount path of the receivers certificates (for ingesting traces).
+	ReceiverTLSCertDir = TLSDir + "/receiver"
+
+	// StorageTLSCADir contains the CA file for accessing object storage.
+	StorageTLSCADir = TLSDir + "/storage/ca"
+	// StorageTLSCertDir contains the certificate and key file for accessing object storage.
+	StorageTLSCertDir = TLSDir + "/storage/cert"
 )

--- a/internal/manifests/manifestutils/service.go
+++ b/internal/manifests/manifestutils/service.go
@@ -1,24 +1,12 @@
 package manifestutils
 
 import (
-	"path"
-
 	"github.com/ViaQ/logerr/v2/kverrors"
 	"github.com/imdario/mergo"
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/grafana/tempo-operator/internal/manifests/naming"
 )
-
-// TempoServerTLSDir returns the mount path of the HTTP service certificates.
-func TempoServerTLSDir() string {
-	return path.Join(TLSDir, "server")
-}
-
-// TempoReceiverTLSDir returns the mount path of the receivers certificates.
-func TempoReceiverTLSDir() string {
-	return path.Join(TLSDir, "receiver")
-}
 
 // ConfigureServiceCA modify the PodSpec adding the volumes and volumeMounts to the specified containers.
 func ConfigureServiceCA(podSpec *corev1.PodSpec, caBundleName string, containers ...int) error {
@@ -90,7 +78,7 @@ func ConfigureServicePKI(tempoStackName string, component string, podSpec *corev
 			{
 				Name:      serviceName,
 				ReadOnly:  false,
-				MountPath: TempoServerTLSDir(),
+				MountPath: TempoInternalTLSCertDir,
 			},
 		},
 	}

--- a/internal/manifests/manifestutils/service.go
+++ b/internal/manifests/manifestutils/service.go
@@ -30,7 +30,7 @@ func ConfigureServiceCA(podSpec *corev1.PodSpec, caBundleName string, containers
 			{
 				Name:      caBundleName,
 				ReadOnly:  false,
-				MountPath: CABundleDir,
+				MountPath: TempoInternalTLSCADir,
 			},
 		},
 	}

--- a/internal/manifests/manifestutils/storage.go
+++ b/internal/manifests/manifestutils/storage.go
@@ -14,16 +14,6 @@ const (
 	storageCAVolumeName = "storage-ca"
 )
 
-// TempoStorageTLSDir returns the mount path of certificates for connecting to object storage.
-func TempoStorageTLSDir() string {
-	return path.Join(TLSDir, "storage")
-}
-
-// TempoStorageTLSCAPath returns the path of the CA certificate for connecting to object storage.
-func TempoStorageTLSCAPath() string {
-	return path.Join(TempoStorageTLSDir(), "ca.crt")
-}
-
 func configureAzureStorage(tempo *v1alpha1.TempoStack, pod *corev1.PodSpec) error {
 	var envVars []corev1.EnvVar = []corev1.EnvVar{
 		{
@@ -141,7 +131,7 @@ func configureS3Storage(tempo *v1alpha1.TempoStack, pod *corev1.PodSpec) error {
 	if tempo.Spec.Storage.TLS.CA != "" {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      storageCAVolumeName,
-			MountPath: TempoStorageTLSDir(),
+			MountPath: StorageTLSCADir,
 			ReadOnly:  true,
 		})
 		volumes = append(volumes, corev1.Volume{

--- a/internal/manifests/manifestutils/storage_test.go
+++ b/internal/manifests/manifestutils/storage_test.go
@@ -147,7 +147,7 @@ func TestGetS3StorageWithCA(t *testing.T) {
 	assert.Equal(t, []corev1.VolumeMount{
 		{
 			Name:      storageCAVolumeName,
-			MountPath: TempoStorageTLSDir(),
+			MountPath: StorageTLSCADir,
 			ReadOnly:  true,
 		},
 	}, pod.Containers[0].VolumeMounts)

--- a/internal/manifests/queryfrontend/query_frontend.go
+++ b/internal/manifests/queryfrontend/query_frontend.go
@@ -2,6 +2,7 @@ package queryfrontend
 
 import (
 	"fmt"
+	"path"
 	"strings"
 
 	"github.com/imdario/mergo"
@@ -251,18 +252,18 @@ func deployment(params manifestutils.Params) (*appsv1.Deployment, error) {
 		if params.CtrlConfig.Gates.HTTPEncryption && tempo.Spec.Template.Gateway.Enabled {
 			jaegerQueryContainer.Args = append(jaegerQueryContainer.Args,
 				"--query.http.tls.enabled=true",
-				fmt.Sprintf("--query.http.tls.key=%s/%s", manifestutils.TempoInternalTLSCertDir, manifestutils.TLSKeyFilename),
-				fmt.Sprintf("--query.http.tls.cert=%s/%s", manifestutils.TempoInternalTLSCertDir, manifestutils.TLSCertFilename),
-				fmt.Sprintf("--query.http.tls.client-ca=%s/%s", manifestutils.CABundleDir, manifestutils.TLSCAFilename),
+				fmt.Sprintf("--query.http.tls.key=%s", path.Join(manifestutils.TempoInternalTLSCertDir, manifestutils.TLSKeyFilename)),
+				fmt.Sprintf("--query.http.tls.cert=%s", path.Join(manifestutils.TempoInternalTLSCertDir, manifestutils.TLSCertFilename)),
+				fmt.Sprintf("--query.http.tls.client-ca=%s", path.Join(manifestutils.CABundleDir, manifestutils.TLSCAFilename)),
 			)
 		}
 
 		if params.CtrlConfig.Gates.GRPCEncryption && tempo.Spec.Template.Gateway.Enabled {
 			jaegerQueryContainer.Args = append(jaegerQueryContainer.Args,
 				"--query.grpc.tls.enabled=true",
-				fmt.Sprintf("--query.grpc.tls.key=%s/%s", manifestutils.TempoInternalTLSCertDir, manifestutils.TLSKeyFilename),
-				fmt.Sprintf("--query.grpc.tls.cert=%s/%s", manifestutils.TempoInternalTLSCertDir, manifestutils.TLSCertFilename),
-				fmt.Sprintf("--query.grpc.tls.client-ca=%s/%s", manifestutils.CABundleDir, manifestutils.TLSCAFilename),
+				fmt.Sprintf("--query.grpc.tls.key=%s", path.Join(manifestutils.TempoInternalTLSCertDir, manifestutils.TLSKeyFilename)),
+				fmt.Sprintf("--query.grpc.tls.cert=%s", path.Join(manifestutils.TempoInternalTLSCertDir, manifestutils.TLSCertFilename)),
+				fmt.Sprintf("--query.grpc.tls.client-ca=%s", path.Join(manifestutils.CABundleDir, manifestutils.TLSCAFilename)),
 			)
 		}
 

--- a/internal/manifests/queryfrontend/query_frontend.go
+++ b/internal/manifests/queryfrontend/query_frontend.go
@@ -251,18 +251,18 @@ func deployment(params manifestutils.Params) (*appsv1.Deployment, error) {
 		if params.CtrlConfig.Gates.HTTPEncryption && tempo.Spec.Template.Gateway.Enabled {
 			jaegerQueryContainer.Args = append(jaegerQueryContainer.Args,
 				"--query.http.tls.enabled=true",
-				fmt.Sprintf("--query.http.tls.key=%s/tls.key", manifestutils.TempoServerTLSDir()),
-				fmt.Sprintf("--query.http.tls.cert=%s/tls.crt", manifestutils.TempoServerTLSDir()),
-				fmt.Sprintf("--query.http.tls.client-ca=%s/service-ca.crt", manifestutils.CABundleDir),
+				fmt.Sprintf("--query.http.tls.key=%s/%s", manifestutils.TempoInternalTLSCertDir, manifestutils.TLSKeyFilename),
+				fmt.Sprintf("--query.http.tls.cert=%s/%s", manifestutils.TempoInternalTLSCertDir, manifestutils.TLSCertFilename),
+				fmt.Sprintf("--query.http.tls.client-ca=%s/%s", manifestutils.CABundleDir, manifestutils.TLSCAFilename),
 			)
 		}
 
 		if params.CtrlConfig.Gates.GRPCEncryption && tempo.Spec.Template.Gateway.Enabled {
 			jaegerQueryContainer.Args = append(jaegerQueryContainer.Args,
 				"--query.grpc.tls.enabled=true",
-				fmt.Sprintf("--query.grpc.tls.key=%s/tls.key", manifestutils.TempoServerTLSDir()),
-				fmt.Sprintf("--query.grpc.tls.cert=%s/tls.crt", manifestutils.TempoServerTLSDir()),
-				fmt.Sprintf("--query.grpc.tls.client-ca=%s/service-ca.crt", manifestutils.CABundleDir),
+				fmt.Sprintf("--query.grpc.tls.key=%s/%s", manifestutils.TempoInternalTLSCertDir, manifestutils.TLSKeyFilename),
+				fmt.Sprintf("--query.grpc.tls.cert=%s/%s", manifestutils.TempoInternalTLSCertDir, manifestutils.TLSCertFilename),
+				fmt.Sprintf("--query.grpc.tls.client-ca=%s/%s", manifestutils.CABundleDir, manifestutils.TLSCAFilename),
 			)
 		}
 

--- a/internal/manifests/queryfrontend/query_frontend.go
+++ b/internal/manifests/queryfrontend/query_frontend.go
@@ -254,7 +254,7 @@ func deployment(params manifestutils.Params) (*appsv1.Deployment, error) {
 				"--query.http.tls.enabled=true",
 				fmt.Sprintf("--query.http.tls.key=%s", path.Join(manifestutils.TempoInternalTLSCertDir, manifestutils.TLSKeyFilename)),
 				fmt.Sprintf("--query.http.tls.cert=%s", path.Join(manifestutils.TempoInternalTLSCertDir, manifestutils.TLSCertFilename)),
-				fmt.Sprintf("--query.http.tls.client-ca=%s", path.Join(manifestutils.CABundleDir, manifestutils.TLSCAFilename)),
+				fmt.Sprintf("--query.http.tls.client-ca=%s", path.Join(manifestutils.TempoInternalTLSCADir, manifestutils.TLSCAFilename)),
 			)
 		}
 
@@ -263,7 +263,7 @@ func deployment(params manifestutils.Params) (*appsv1.Deployment, error) {
 				"--query.grpc.tls.enabled=true",
 				fmt.Sprintf("--query.grpc.tls.key=%s", path.Join(manifestutils.TempoInternalTLSCertDir, manifestutils.TLSKeyFilename)),
 				fmt.Sprintf("--query.grpc.tls.cert=%s", path.Join(manifestutils.TempoInternalTLSCertDir, manifestutils.TLSCertFilename)),
-				fmt.Sprintf("--query.grpc.tls.client-ca=%s", path.Join(manifestutils.CABundleDir, manifestutils.TLSCAFilename)),
+				fmt.Sprintf("--query.grpc.tls.client-ca=%s", path.Join(manifestutils.TempoInternalTLSCADir, manifestutils.TLSCAFilename)),
 			)
 		}
 

--- a/internal/manifests/queryfrontend/query_frontend_test.go
+++ b/internal/manifests/queryfrontend/query_frontend_test.go
@@ -528,12 +528,12 @@ func TestQueryFrontendJaegerTLS(t *testing.T) {
 	assert.Contains(t, args, "--query.http.tls.enabled=true")
 	assert.Contains(t, args, fmt.Sprintf("--query.http.tls.key=%s/tls.key", manifestutils.TempoInternalTLSCertDir))
 	assert.Contains(t, args, fmt.Sprintf("--query.http.tls.cert=%s/tls.crt", manifestutils.TempoInternalTLSCertDir))
-	assert.Contains(t, args, fmt.Sprintf("--query.http.tls.client-ca=%s/service-ca.crt", manifestutils.CABundleDir))
+	assert.Contains(t, args, fmt.Sprintf("--query.http.tls.client-ca=%s/service-ca.crt", manifestutils.TempoInternalTLSCADir))
 
 	assert.Contains(t, args, "--query.grpc.tls.enabled=true")
 	assert.Contains(t, args, fmt.Sprintf("--query.grpc.tls.key=%s/tls.key", manifestutils.TempoInternalTLSCertDir))
 	assert.Contains(t, args, fmt.Sprintf("--query.grpc.tls.cert=%s/tls.crt", manifestutils.TempoInternalTLSCertDir))
-	assert.Contains(t, args, fmt.Sprintf("--query.grpc.tls.client-ca=%s/service-ca.crt", manifestutils.CABundleDir))
+	assert.Contains(t, args, fmt.Sprintf("--query.grpc.tls.client-ca=%s/service-ca.crt", manifestutils.TempoInternalTLSCADir))
 }
 
 func TestBuildQueryFrontendWithJaegerMonitorTab(t *testing.T) {

--- a/internal/manifests/queryfrontend/query_frontend_test.go
+++ b/internal/manifests/queryfrontend/query_frontend_test.go
@@ -526,13 +526,13 @@ func TestQueryFrontendJaegerTLS(t *testing.T) {
 	jaegerContainer := deployment.Spec.Template.Spec.Containers[1]
 	args := jaegerContainer.Args
 	assert.Contains(t, args, "--query.http.tls.enabled=true")
-	assert.Contains(t, args, fmt.Sprintf("--query.http.tls.key=%s/tls.key", manifestutils.TempoServerTLSDir()))
-	assert.Contains(t, args, fmt.Sprintf("--query.http.tls.cert=%s/tls.crt", manifestutils.TempoServerTLSDir()))
+	assert.Contains(t, args, fmt.Sprintf("--query.http.tls.key=%s/tls.key", manifestutils.TempoInternalTLSCertDir))
+	assert.Contains(t, args, fmt.Sprintf("--query.http.tls.cert=%s/tls.crt", manifestutils.TempoInternalTLSCertDir))
 	assert.Contains(t, args, fmt.Sprintf("--query.http.tls.client-ca=%s/service-ca.crt", manifestutils.CABundleDir))
 
 	assert.Contains(t, args, "--query.grpc.tls.enabled=true")
-	assert.Contains(t, args, fmt.Sprintf("--query.grpc.tls.key=%s/tls.key", manifestutils.TempoServerTLSDir()))
-	assert.Contains(t, args, fmt.Sprintf("--query.grpc.tls.cert=%s/tls.crt", manifestutils.TempoServerTLSDir()))
+	assert.Contains(t, args, fmt.Sprintf("--query.grpc.tls.key=%s/tls.key", manifestutils.TempoInternalTLSCertDir))
+	assert.Contains(t, args, fmt.Sprintf("--query.grpc.tls.cert=%s/tls.crt", manifestutils.TempoInternalTLSCertDir))
 	assert.Contains(t, args, fmt.Sprintf("--query.grpc.tls.client-ca=%s/service-ca.crt", manifestutils.CABundleDir))
 }
 

--- a/tests/e2e/custom-ca/01-assert.yaml
+++ b/tests/e2e/custom-ca/01-assert.yaml
@@ -40,7 +40,7 @@ spec:
           readOnly: true
         - mountPath: /var/tempo
           name: data
-        - mountPath: /var/run/tls/storage
+        - mountPath: /var/run/tls/storage/ca
           name: storage-ca
           readOnly: true
         - mountPath: /var/run/ca

--- a/tests/e2e/custom-ca/01-install-tempo.yaml
+++ b/tests/e2e/custom-ca/01-install-tempo.yaml
@@ -33,7 +33,6 @@ data:
     xtdKFBv1LLup2pr/hbmbP+0XHNFuUK36I7oantHhagXL/pGO3vcugppAd+YNzOW9
     Qr67VgKeixOrNiK6W9FzuaWYadv0XOgrJbFhsvmtYqpEMDGZzfdb5dAzdA==
     -----END CERTIFICATE-----
-
 ---
 apiVersion: tempo.grafana.com/v1alpha1
 kind: TempoStack


### PR DESCRIPTION
We're currently managing three different sets of certificates:
* internal communication between components
* receiver TLS
* storage TLS

Let's unify them with common paths and key names in the ConfigMap/Secrets.


Except for changing the storage CA mountpoint from `/var/run/tls/storage` to `/var/run/tls/storage/ca`, all other manifests should be unmodified.