### PR TITLE
[Chore] Fix red-metrics test case

### DIFF
--- a/tests/e2e-openshift/red-metrics/06-assert.yaml
+++ b/tests/e2e-openshift/red-metrics/06-assert.yaml
@@ -1,3 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kuttl-cluster-monitoring-view
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-monitoring-view
+subjects:
+- kind: ServiceAccount
+  name: prometheus-user-workload
+  namespace: openshift-user-workload-monitoring
+
+---
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/tests/e2e-openshift/red-metrics/06-intall-assert-job.yaml
+++ b/tests/e2e-openshift/red-metrics/06-intall-assert-job.yaml
@@ -1,3 +1,20 @@
+# Add the cluter role binding required for fetching metrics from Thanos querier. Refer https://issues.redhat.com/browse/MON-3379
+# The ClusterRoleBinding step is not a Tempo requirement and is used only by the test case to check the metrics using the check_metrics.sh script.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kuttl-cluster-monitoring-view
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-monitoring-view
+subjects:
+- kind: ServiceAccount
+  name: prometheus-user-workload
+  namespace: openshift-user-workload-monitoring
+
+---
 apiVersion: batch/v1
 kind: Job
 metadata:


### PR DESCRIPTION
Sets the required clusterrolebinding cluster-monitoring-view to query the metrics from Thanos querier. 

```
--- PASS: kuttl (238.99s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/red-metrics (236.12s)
PASS
```