### PR TITLE
[Chore] Update tests to use multiarch images.

### DIFF
--- a/tests/e2e/monolithic-memory/03-generate-traces.yaml
+++ b/tests/e2e/monolithic-memory/03-generate-traces.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.75.0
+        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
         args:
         - traces
         - --otlp-endpoint=tempo-simplest:4317

--- a/tests/e2e/monolithic-memory/05-verify-traces-grafana.yaml
+++ b/tests/e2e/monolithic-memory/05-verify-traces-grafana.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: verify-traces-grafana
-        image: registry.gitlab.com/gitlab-ci-utils/curl-jq:1.1.0
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
         command:
         - /bin/bash
         - -eux

--- a/tests/e2e/monolithic-pv/03-generate-traces.yaml
+++ b/tests/e2e/monolithic-pv/03-generate-traces.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.75.0
+        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
         args:
         - traces
         - --otlp-endpoint=tempo-simplest:4317

--- a/tests/e2e/monolithic-s3-tls/03-generate-traces.yaml
+++ b/tests/e2e/monolithic-s3-tls/03-generate-traces.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.75.0
+        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
         args:
         - traces
         - --otlp-endpoint=tempo-simplest:4317


### PR DESCRIPTION
Updates tests to use multiarch images so that we can run them on ARM and IBM P and Z clusters.

Tested on ARM cluster:
```
--- PASS: kuttl (640.49s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/monolithic-ingestion-mtls (99.97s)
        --- PASS: kuttl/harness/multitenancy (129.50s)
        --- PASS: kuttl/harness/compatibility (156.81s)
        --- PASS: kuttl/harness/receivers-mtls (157.96s)
        --- PASS: kuttl/harness/monolithic-s3-tls (116.83s)
        --- PASS: kuttl/harness/monolithic-pv (107.96s)
        --- PASS: kuttl/harness/monolithic-memory (104.70s)
        --- PASS: kuttl/harness/reconcile (129.98s)
        --- PASS: kuttl/harness/gateway (61.34s)
        --- PASS: kuttl/harness/generate (62.52s)
        --- PASS: kuttl/harness/monitoring (147.11s)
        --- PASS: kuttl/harness/route (44.64s)
        --- PASS: kuttl/harness/receivers-tls (163.48s)
        --- PASS: kuttl/harness/custom-ca (141.57s)
        --- PASS: kuttl/harness/red-metrics (284.57s)
PASS
```