### PR TITLE
Kubernetes 1.29 enablement

### DIFF
--- a/.chloggen/enable-129.yaml
+++ b/.chloggen/enable-129.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, github action)
+component: operator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Kubernetes 1.29 enablement
+
+# One or more tracking issues related to the change
+issues: [735]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -21,7 +21,7 @@ jobs:
        # should be compatible with them.
        kube-version:
        - "1.21"
-       - "1.28"
+       - "1.29"
 
     steps:
     - name: Set up Go
@@ -46,7 +46,7 @@ jobs:
     strategy:
       matrix:
         kube-version:
-          - "1.28"
+          - "1.29"
 
     steps:
     - name: Set up Go

--- a/kind-1.29.yaml
+++ b/kind-1.29.yaml
@@ -1,0 +1,18 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+    image: kindest/node:v1.29.2@sha256:acc9e82a5a5bd3dfccfd03117e9ef5f96b46108b55cd647fb5e7d0d1a35c9c6f
+    kubeadmConfigPatches:
+      - |
+        kind: InitConfiguration
+        nodeRegistration:
+          kubeletExtraArgs:
+            node-labels: "ingress-ready=true"
+    extraPortMappings:
+      - containerPort: 80
+        hostPort: 80
+        protocol: TCP
+      - containerPort: 443
+        hostPort: 443
+        protocol: TCP


### PR DESCRIPTION
Enabling operator tests to run on Kubernetes 1.29.

Resolves #735