### PR TITLE
fix golint

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -62,11 +62,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-
       - name: Lint
         uses: golangci/golangci-lint-action@v4
         with:


### PR DESCRIPTION
Fixes:
```
  /usr/bin/tar -xf /home/runner/work/_temp/ab5fc90b-99a4-43c1-8181-4d8960a26ad0/cache.tzst -P -C /home/runner/work/tempo-operator/tempo-operator --use-compress-program unzstd
  Received 223785415 of 223785415 (100.0%), 106.6 MBs/sec
  /usr/bin/tar: ../../../go/pkg/mod/google.golang.org/protobuf@v1.32.0/README.md: Cannot open: File exists
  Error: /usr/bin/tar: ../../../go/pkg/mod/google.golang.org/protobuf@v1.32.0/integration_test.go: Cannot open: File exists
  Error: /usr/bin/tar: ../../../go/pkg/mod/google.golang.org/protobuf@v1.32.0/protoadapt/convert.go: Cannot open: File exists
  /usr/bin/tar: ../../../go/pkg/mod/google.golang.org/protobuf@v1.32.0/PATENTS: Cannot open: File exists
  Error: /usr/bin/tar: ../../../go/pkg/mod/google.golang.org/protobuf@v1.32.0/encoding/bench_test.go: Cannot open: File exists
  Error: /usr/bin/tar: ../../../go/pkg/mod/google.golang.org/protobuf@v1.32.0/encoding/prototext/decode.go: Cannot open: File exists
  Error: /usr/bin/tar: ../../../go/pkg/mod/google.golang.org/protobuf@v1.32.0/encoding/prototext/other_test.go: Cannot open: File exists
  Error: /usr/bin/tar: ../../../go/pkg/mod/google.golang.org/protobuf@v1.32.0/encoding/prototext/encode.go: Cannot open: File exists
  Error: /usr/bin/tar: ../../../go/pkg/mod/google.golang.org/protobuf@v1.32.0/encoding/prototext/decode_test.go: Cannot open: File exists
  Error: /usr/bin/tar: ../../../go/pkg/mod/google.golang.org/protobuf@v1.32.0/encoding/prototext/doc.go: Cannot open: File exists
  Error: /usr/bin/tar: ../../../go/pkg/mod/google.golang.org/protobuf@v1.32.0/encoding/prototext/encode_test.go: Cannot open: File exists
  Error: /usr/bin/tar: ../../../go/pkg/mod/google.golang.org/protobuf@v1.32.0/encoding/protojson/bench_test.go: Cannot open: File exists
[...]
```

as seen in https://github.com/grafana/tempo-operator/actions/runs/8140953755/job/22248111854?pr=826