### PR TITLE
Support Grafana instances in a different namespace

### DIFF
--- a/.chloggen/grafana_cross_namespace.yaml
+++ b/.chloggen/grafana_cross_namespace.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, github action)
+component: operator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Support Grafana instances in a different namespace
+
+# One or more tracking issues related to the change
+issues: [840]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/internal/manifests/grafana/datasource.go
+++ b/internal/manifests/grafana/datasource.go
@@ -6,6 +6,7 @@ import (
 	grafanav1 "github.com/grafana/grafana-operator/v5/api/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/utils/ptr"
 
 	"github.com/grafana/tempo-operator/internal/manifests/manifestutils"
 	"github.com/grafana/tempo-operator/internal/manifests/naming"
@@ -51,8 +52,12 @@ func NewGrafanaDatasource(
 				Access: "proxy",
 				URL:    url,
 			},
+
 			// InstanceSelector is a required field in the spec
 			InstanceSelector: &instanceSelector,
+
+			// Allow using this datasource from Grafana instances in other namespaces
+			AllowCrossNamespaceImport: ptr.To(true),
 		},
 	}
 }

--- a/internal/manifests/grafana/datasource_test.go
+++ b/internal/manifests/grafana/datasource_test.go
@@ -6,6 +6,7 @@ import (
 	grafanav1 "github.com/grafana/grafana-operator/v5/api/v1beta1"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	"github.com/grafana/tempo-operator/apis/tempo/v1alpha1"
 	"github.com/grafana/tempo-operator/internal/manifests/manifestutils"
@@ -39,7 +40,8 @@ func TestBuildGrafanaDatasource(t *testing.T) {
 				Type:   "tempo",
 				URL:    "http://tempo-test-query-frontend.tempo.svc.cluster.local:3200",
 			},
-			InstanceSelector: &metav1.LabelSelector{},
+			InstanceSelector:          &metav1.LabelSelector{},
+			AllowCrossNamespaceImport: ptr.To(true),
 		},
 	}, datasource)
 }

--- a/internal/manifests/monolithic/grafana_datasource_test.go
+++ b/internal/manifests/monolithic/grafana_datasource_test.go
@@ -6,6 +6,7 @@ import (
 	grafanav1 "github.com/grafana/grafana-operator/v5/api/v1beta1"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	"github.com/grafana/tempo-operator/apis/tempo/v1alpha1"
 )
@@ -54,6 +55,7 @@ func TestBuildGrafanaDatasource(t *testing.T) {
 			InstanceSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{"key": "value"},
 			},
+			AllowCrossNamespaceImport: ptr.To(true),
 		},
 	}, datasource)
 }


### PR DESCRIPTION
Support Grafana instances in a different namespace

Otherwise the `Grafana` CR must be in the same namespace as the `TempoStack` CR.