### PR TITLE
Disable Grafana data source creation if gateway is enabled

### DIFF
--- a/internal/manifests/grafana/datasource.go
+++ b/internal/manifests/grafana/datasource.go
@@ -15,14 +15,7 @@ import (
 func BuildGrafanaDatasource(params manifestutils.Params) *grafanav1.GrafanaDatasource {
 	tempo := params.Tempo
 	labels := manifestutils.CommonLabels(tempo.Name)
-	var url string
-
-	if tempo.Spec.Template.Gateway.Enabled {
-		url = fmt.Sprintf("http://%s:%d", naming.ServiceFqdn(tempo.Namespace, tempo.Name, manifestutils.GatewayComponentName), manifestutils.PortHTTPServer)
-	} else {
-		url = fmt.Sprintf("http://%s:%d", naming.ServiceFqdn(tempo.Namespace, tempo.Name, manifestutils.QueryFrontendComponentName), manifestutils.PortHTTPServer)
-	}
-
+	url := fmt.Sprintf("http://%s:%d", naming.ServiceFqdn(tempo.Namespace, tempo.Name, manifestutils.QueryFrontendComponentName), manifestutils.PortHTTPServer)
 	return NewGrafanaDatasource(tempo.Namespace, tempo.Name, labels, url, tempo.Spec.Observability.Grafana.InstanceSelector)
 }
 

--- a/internal/webhooks/tempostack_webhook.go
+++ b/internal/webhooks/tempostack_webhook.go
@@ -340,6 +340,14 @@ func (v *validator) validateObservability(tempo v1alpha1.TempoStack) field.Error
 			)}
 	}
 
+	if tempo.Spec.Observability.Grafana.CreateDatasource && tempo.Spec.Template.Gateway.Enabled {
+		return field.ErrorList{field.Invalid(
+			grafanaBase.Child("createDatasource"),
+			tempo.Spec.Observability.Grafana.CreateDatasource,
+			"creating a data source for Tempo is not support if the gateway is enabled",
+		)}
+	}
+
 	return nil
 }
 

--- a/internal/webhooks/tempostack_webhook_test.go
+++ b/internal/webhooks/tempostack_webhook_test.go
@@ -1399,6 +1399,35 @@ func TestValidatorObservabilityGrafana(t *testing.T) {
 			},
 			expected: nil,
 		},
+		{
+			name: "datasource enabled, feature gate set, gateway enabled",
+			input: v1alpha1.TempoStack{
+				Spec: v1alpha1.TempoStackSpec{
+					Observability: v1alpha1.ObservabilitySpec{
+						Grafana: v1alpha1.GrafanaConfigSpec{
+							CreateDatasource: true,
+						},
+					},
+					Template: v1alpha1.TempoTemplateSpec{
+						Gateway: v1alpha1.TempoGatewaySpec{
+							Enabled: true,
+						},
+					},
+				},
+			},
+			ctrlConfig: configv1alpha1.ProjectConfig{
+				Gates: configv1alpha1.FeatureGates{
+					GrafanaOperator: true,
+				},
+			},
+			expected: field.ErrorList{
+				field.Invalid(
+					field.NewPath("spec").Child("observability").Child("grafana").Child("createDatasource"),
+					true,
+					"creating a data source for Tempo is not support if the gateway is enabled",
+				),
+			},
+		},
 	}
 
 	for _, tc := range tt {


### PR DESCRIPTION
It is broken when the gateway is enabled due to missing authentication.