### PR TITLE
Monolithic: support multiple annotations (multiple config file checksums)

### DIFF
--- a/internal/manifests/monolithic/configmap_test.go
+++ b/internal/manifests/monolithic/configmap_test.go
@@ -43,11 +43,13 @@ func TestBuildConfigMap(t *testing.T) {
 		},
 	}
 
-	cm, checksum, err := BuildConfigMap(opts)
+	cm, annotations, err := BuildConfigMap(opts)
 	require.NoError(t, err)
 	require.NotNil(t, cm.Data)
 	require.NotNil(t, cm.Data["tempo.yaml"])
-	require.Equal(t, fmt.Sprintf("%x", sha256.Sum256([]byte(cm.Data["tempo.yaml"]))), checksum)
+	require.Equal(t, map[string]string{
+		"tempo.grafana.com/tempoConfig.hash": fmt.Sprintf("%x", sha256.Sum256([]byte(cm.Data["tempo.yaml"]))),
+	}, annotations)
 }
 
 func TestBuildConfig(t *testing.T) {

--- a/internal/manifests/monolithic/statefulset.go
+++ b/internal/manifests/monolithic/statefulset.go
@@ -22,10 +22,9 @@ var (
 )
 
 // BuildTempoStatefulset creates the Tempo statefulset for a monolithic deployment.
-func BuildTempoStatefulset(opts Options) (*appsv1.StatefulSet, error) {
+func BuildTempoStatefulset(opts Options, extraAnnotations map[string]string) (*appsv1.StatefulSet, error) {
 	tempo := opts.Tempo
 	labels := ComponentLabels(manifestutils.TempoMonolithComponentName, tempo.Name)
-	annotations := manifestutils.CommonAnnotations(opts.ConfigChecksum)
 
 	sts := &appsv1.StatefulSet{
 		TypeMeta: metav1.TypeMeta{
@@ -52,7 +51,7 @@ func BuildTempoStatefulset(opts Options) (*appsv1.StatefulSet, error) {
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:      labels,
-					Annotations: annotations,
+					Annotations: extraAnnotations,
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: serviceAccountName(tempo),
@@ -88,7 +87,7 @@ func BuildTempoStatefulset(opts Options) (*appsv1.StatefulSet, error) {
 							VolumeSource: corev1.VolumeSource{
 								ConfigMap: &corev1.ConfigMapVolumeSource{
 									LocalObjectReference: corev1.LocalObjectReference{
-										Name: naming.Name(manifestutils.TempoMonolithComponentName, tempo.Name),
+										Name: naming.Name(manifestutils.TempoConfigName, tempo.Name),
 									},
 								},
 							},

--- a/internal/manifests/monolithic/statefulset_test.go
+++ b/internal/manifests/monolithic/statefulset_test.go
@@ -54,11 +54,10 @@ func TestStatefulsetMemoryStorage(t *testing.T) {
 			},
 		},
 	}
-	sts, err := BuildTempoStatefulset(opts)
+	sts, err := BuildTempoStatefulset(opts, map[string]string{"tempo.grafana.com/tempoConfig.hash": "abc"})
 	require.NoError(t, err)
 
 	labels := ComponentLabels(manifestutils.TempoMonolithComponentName, "sample")
-	annotations := manifestutils.CommonAnnotations("")
 	require.Equal(t, &appsv1.StatefulSet{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "apps/v1",
@@ -76,8 +75,10 @@ func TestStatefulsetMemoryStorage(t *testing.T) {
 			PodManagementPolicy: appsv1.ParallelPodManagement,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels:      labels,
-					Annotations: annotations,
+					Labels: labels,
+					Annotations: map[string]string{
+						"tempo.grafana.com/tempoConfig.hash": "abc",
+					},
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: "tempo-sample",
@@ -135,7 +136,7 @@ func TestStatefulsetMemoryStorage(t *testing.T) {
 							VolumeSource: corev1.VolumeSource{
 								ConfigMap: &corev1.ConfigMapVolumeSource{
 									LocalObjectReference: corev1.LocalObjectReference{
-										Name: "tempo-sample",
+										Name: "tempo-sample-config",
 									},
 								},
 							},
@@ -177,7 +178,7 @@ func TestStatefulsetPVStorage(t *testing.T) {
 			},
 		},
 	}
-	sts, err := BuildTempoStatefulset(opts)
+	sts, err := BuildTempoStatefulset(opts, map[string]string{})
 	require.NoError(t, err)
 
 	require.Equal(t, []corev1.VolumeMount{
@@ -198,7 +199,7 @@ func TestStatefulsetPVStorage(t *testing.T) {
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
 					LocalObjectReference: corev1.LocalObjectReference{
-						Name: "tempo-sample",
+						Name: "tempo-sample-config",
 					},
 				},
 			},
@@ -255,7 +256,7 @@ func TestStatefulsetS3TLSStorage(t *testing.T) {
 			},
 		},
 	}
-	sts, err := BuildTempoStatefulset(opts)
+	sts, err := BuildTempoStatefulset(opts, map[string]string{})
 	require.NoError(t, err)
 
 	require.Equal(t, []corev1.VolumeMount{
@@ -319,7 +320,7 @@ func TestStatefulsetS3TLSStorage(t *testing.T) {
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
 					LocalObjectReference: corev1.LocalObjectReference{
-						Name: "tempo-sample",
+						Name: "tempo-sample-config",
 					},
 				},
 			},
@@ -395,7 +396,7 @@ func TestStatefulsetReceiverTLS(t *testing.T) {
 			},
 		},
 	}
-	sts, err := BuildTempoStatefulset(opts)
+	sts, err := BuildTempoStatefulset(opts, map[string]string{})
 	require.NoError(t, err)
 
 	require.Equal(t, []corev1.VolumeMount{
@@ -426,7 +427,7 @@ func TestStatefulsetReceiverTLS(t *testing.T) {
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
 					LocalObjectReference: corev1.LocalObjectReference{
-						Name: "tempo-sample",
+						Name: "tempo-sample-config",
 					},
 				},
 			},
@@ -547,7 +548,7 @@ func TestStatefulsetPorts(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			opts.Tempo.Spec.Ingestion = test.input
-			sts, err := BuildTempoStatefulset(opts)
+			sts, err := BuildTempoStatefulset(opts, map[string]string{})
 			require.NoError(t, err)
 			require.Equal(t, test.expected, sts.Spec.Template.Spec.Containers[0].Ports)
 		})
@@ -601,7 +602,7 @@ func TestStatefulsetSchedulingRules(t *testing.T) {
 			},
 		},
 	}
-	sts, err := BuildTempoStatefulset(opts)
+	sts, err := BuildTempoStatefulset(opts, map[string]string{})
 	require.NoError(t, err)
 
 	require.Equal(t, map[string]string{
@@ -674,7 +675,7 @@ func TestStatefulsetCustomServiceAccount(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			opts.Tempo.Spec.ServiceAccount = test.input
-			sts, err := BuildTempoStatefulset(opts)
+			sts, err := BuildTempoStatefulset(opts, map[string]string{})
 			require.NoError(t, err)
 			require.Equal(t, test.expected, sts.Spec.Template.Spec.ServiceAccountName)
 		})


### PR DESCRIPTION
When the gateway is enabled, we need to add additional annotations with file checksums to the tempo statefulset.