### PR TITLE
[Chore] Fix multitenancy test

### DIFF
--- a/tests/e2e-openshift/multitenancy/01-assert.yaml
+++ b/tests/e2e-openshift/multitenancy/01-assert.yaml
@@ -175,7 +175,7 @@ spec:
           failureThreshold: 10
           httpGet:
             path: /live
-            port: 8081
+            port: internal
             scheme: HTTPS
           periodSeconds: 30
           successThreshold: 1
@@ -195,7 +195,7 @@ spec:
           failureThreshold: 12
           httpGet:
             path: /ready
-            port: 8081
+            port: internal
             scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1
@@ -252,7 +252,7 @@ spec:
           periodSeconds: 30
           successThreshold: 1
           timeoutSeconds: 2
-        name: opa
+        name: tempo-gateway-opa
         ports:
         - containerPort: 8082
           name: public
@@ -357,18 +357,18 @@ metadata:
       name: simplest
 spec:
   ports:
-    - name: grpc-public
-      port: 8090
-      protocol: TCP
-      targetPort: 8090
-    - name: internal
-      port: 8081
-      protocol: TCP
-      targetPort: 8081
-    - name: public
-      port: 8080
-      protocol: TCP
-      targetPort: 8080
+  - name: grpc-public
+    port: 8090
+    protocol: TCP
+    targetPort: grpc-public
+  - name: internal
+    port: 8081
+    protocol: TCP
+    targetPort: internal
+  - name: public
+    port: 8080
+    protocol: TCP
+    targetPort: public
   selector:
     app.kubernetes.io/component: gateway
     app.kubernetes.io/instance: simplest


### PR DESCRIPTION
The test is failing in OCP CI. Refer https://github.com/openshift/grafana-tempo-operator/pull/25 
The PR fixes the asserts to use the named ports. 