### PR TITLE
[Chore] Add interoperability e2e tests for Tempo and OpenShift Service Mesh

### DIFF
--- a/tests/e2e-openshift-ossm/ossm-monolithic-otel/apply-telemetry-cr-assert.yaml
+++ b/tests/e2e-openshift-ossm/ossm-monolithic-otel/apply-telemetry-cr-assert.yaml
@@ -1,0 +1,27 @@
+apiVersion: telemetry.istio.io/v1alpha1
+kind: Telemetry
+metadata:
+  name: mesh-default
+  namespace: istio-system
+spec:
+  tracing:
+  - providers:
+    - name: tempo
+    randomSamplingPercentage: 100
+
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: kiali
+    app.kubernetes.io/instance: kiali
+    app.kubernetes.io/name: kiali
+    app.kubernetes.io/part-of: kiali
+  namespace: istio-system
+status:
+  containerStatuses:
+  - name: kiali
+    ready: true
+    started: true
+  phase: Running

--- a/tests/e2e-openshift-ossm/ossm-monolithic-otel/apply-telemetry-cr.yaml
+++ b/tests/e2e-openshift-ossm/ossm-monolithic-otel/apply-telemetry-cr.yaml
@@ -1,0 +1,10 @@
+apiVersion: telemetry.istio.io/v1alpha1
+kind: Telemetry
+metadata:
+  name: mesh-default
+  namespace: istio-system
+spec:
+  tracing:
+  - providers:
+    - name: tempo
+    randomSamplingPercentage: 100

--- a/tests/e2e-openshift-ossm/ossm-monolithic-otel/chainsaw-test.yaml
+++ b/tests/e2e-openshift-ossm/ossm-monolithic-otel/chainsaw-test.yaml
@@ -1,0 +1,75 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: ossm-monolithic-otel
+spec:
+  # Avoid running this test case in parallel as it uses high resources and uses static namespaces. 
+  concurrent: false
+  steps:
+  - name: Install OSSM
+    try:
+    - apply:
+        file: install-ossm.yaml
+    - assert:
+        file: install-ossm-assert.yaml
+  - name: Install TempoStack
+    try:
+    - apply:
+        file: install-tempo.yaml
+    - assert:
+        file: install-tempo-assert.yaml
+  - name: Update Kiali config
+    try:
+    - patch:
+        file: update-kiali.yaml
+    - sleep:
+        duration: 10s
+    - assert:
+        file: update-kiali-assert.yaml
+  - name: Install OTEL collector
+    try:
+    - apply: 
+        file: install-otel-collector.yaml
+    - assert:
+        file: install-otel-collector-assert.yaml
+  - name: Enable OSSM Tempo provider
+    try:
+    - apply:
+        file: apply-telemetry-cr.yaml
+    - sleep:
+        duration: 10s
+    - assert:
+        file: apply-telemetry-cr-assert.yaml
+  - name: Install Bookinfo app
+    try:
+    - apply:
+        file: install-bookinfo.yaml
+    - assert:
+        file: install-bookinfo-assert.yaml
+  - name: Generate traces from the bookinfo app
+    try:
+    - script:
+        content: |
+            for i in {1..20}
+            do
+                curl http://$(oc -n istio-system get route istio-ingressgateway -o jsonpath='{.spec.host}')/productpage
+                sleep 1
+            done
+  - name: Check traces in Kiali
+    try:
+    - apply:
+        file: verify-traces.yaml
+    - assert:
+        file: verify-traces-assert.yaml
+  - name: Generate traces and send it to OTEL collector via OTLP GRPC and HTTP
+    try:
+    - apply:
+        file: generate-traces-otel.yaml
+    - assert:
+        file: generate-traces-otel-assert.yaml
+  - name: Verify the traces sent to OTEL collector in Tempo Monolithic instance.
+    try:
+    - apply: 
+        file: verify-traces-otel.yaml
+    - assert:
+        file: verify-traces-otel-assert.yaml

--- a/tests/e2e-openshift-ossm/ossm-monolithic-otel/generate-traces-otel-assert.yaml
+++ b/tests/e2e-openshift-ossm/ossm-monolithic-otel/generate-traces-otel-assert.yaml
@@ -1,0 +1,16 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: generate-traces-grpc
+  namespace: otlp-app
+status:
+  succeeded: 1
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: generate-traces-http
+  namespace: otlp-app
+status:
+  succeeded: 1

--- a/tests/e2e-openshift-ossm/ossm-monolithic-otel/generate-traces-otel.yaml
+++ b/tests/e2e-openshift-ossm/ossm-monolithic-otel/generate-traces-otel.yaml
@@ -1,0 +1,41 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: generate-traces-http
+  namespace: otlp-app
+spec:
+  template:
+    spec:
+      containers:
+      - name: telemetrygen
+        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
+        args:
+        - traces
+        - --otlp-endpoint=simplest-collector.tracing-system.svc.cluster.local:4318
+        - --traces=10
+        - --otlp-http
+        - --otlp-insecure=true
+        - --service=telemetrygen-http
+        - --otlp-attributes=protocol="http"
+      restartPolicy: Never
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: generate-traces-grpc
+  namespace: otlp-app
+spec:
+  template:
+    spec:
+      containers:
+      - name: telemetrygen
+        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
+        args:
+        - traces
+        - --otlp-endpoint=simplest-collector.tracing-system.svc.cluster.local:4317
+        - --traces=10
+        - --otlp-insecure=true
+        - --service=telemetrygen-grpc
+        - --otlp-attributes=protocol="grpc"
+      restartPolicy: Never

--- a/tests/e2e-openshift-ossm/ossm-monolithic-otel/install-bookinfo-assert.yaml
+++ b/tests/e2e-openshift-ossm/ossm-monolithic-otel/install-bookinfo-assert.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: details-v1
+  namespace: bookinfo
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: productpage-v1
+  namespace: bookinfo
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ratings-v1
+  namespace: bookinfo
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: reviews-v1
+  namespace: bookinfo
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: reviews-v2
+  namespace: bookinfo
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: reviews-v3
+  namespace: bookinfo
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+

--- a/tests/e2e-openshift-ossm/ossm-monolithic-otel/install-bookinfo.yaml
+++ b/tests/e2e-openshift-ossm/ossm-monolithic-otel/install-bookinfo.yaml
@@ -1,0 +1,473 @@
+# Copyright Istio Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+##################################################################################################
+# This file defines the services, service accounts, and deployments for the Bookinfo sample.
+#
+# To apply all 4 Bookinfo services, their corresponding service accounts, and deployments:
+#
+#   kubectl apply -f samples/bookinfo/platform/kube/bookinfo.yaml
+#
+# Alternatively, you can deploy any resource separately:
+#
+#   kubectl apply -f samples/bookinfo/platform/kube/bookinfo.yaml -l service=reviews # reviews Service
+#   kubectl apply -f samples/bookinfo/platform/kube/bookinfo.yaml -l account=reviews # reviews ServiceAccount
+#   kubectl apply -f samples/bookinfo/platform/kube/bookinfo.yaml -l app=reviews,version=v3 # reviews-v3 Deployment
+##################################################################################################
+
+##################################################################################################
+# Details service
+##################################################################################################
+apiVersion: v1
+kind: Service
+metadata:
+  name: details
+  labels:
+    app: details
+    service: details
+  namespace: bookinfo
+spec:
+  ports:
+  - port: 9080
+    name: http
+  selector:
+    app: details
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: bookinfo-details
+  namespace: bookinfo
+  labels:
+    account: details
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: details-v1
+  namespace: bookinfo
+  labels:
+    app: details
+    version: v1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: details
+      version: v1
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "true"
+      labels:
+        app: details
+        version: v1
+    spec:
+      serviceAccountName: bookinfo-details
+      containers:
+      - name: details
+        image: quay.io/maistra/examples-bookinfo-details-v1:2.4.0
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 9080
+---
+##################################################################################################
+# Ratings service
+##################################################################################################
+apiVersion: v1
+kind: Service
+metadata:
+  name: ratings
+  namespace: bookinfo
+  labels:
+    app: ratings
+    service: ratings
+spec:
+  ports:
+  - port: 9080
+    name: http
+  selector:
+    app: ratings
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: bookinfo-ratings
+  namespace: bookinfo
+  labels:
+    account: ratings
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ratings-v1
+  namespace: bookinfo
+  labels:
+    app: ratings
+    version: v1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ratings
+      version: v1
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "true"
+      labels:
+        app: ratings
+        version: v1
+    spec:
+      serviceAccountName: bookinfo-ratings
+      containers:
+      - name: ratings
+        image: quay.io/maistra/examples-bookinfo-ratings-v1:2.4.0
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 9080
+---
+##################################################################################################
+# Reviews service
+##################################################################################################
+apiVersion: v1
+kind: Service
+metadata:
+  name: reviews
+  namespace: bookinfo
+  labels:
+    app: reviews
+    service: reviews
+spec:
+  ports:
+  - port: 9080
+    name: http
+  selector:
+    app: reviews
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: bookinfo-reviews
+  namespace: bookinfo
+  labels:
+    account: reviews
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: reviews-v1
+  namespace: bookinfo
+  labels:
+    app: reviews
+    version: v1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: reviews
+      version: v1
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "true"
+      labels:
+        app: reviews
+        version: v1
+    spec:
+      serviceAccountName: bookinfo-reviews
+      containers:
+      - name: reviews
+        image: quay.io/maistra/examples-bookinfo-reviews-v1:2.4.0
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: LOG_DIR
+          value: "/tmp/logs"
+        ports:
+        - containerPort: 9080
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        - name: wlp-output
+          mountPath: /opt/ibm/wlp/output
+      volumes:
+      - name: wlp-output
+        emptyDir: {}
+      - name: tmp
+        emptyDir: {}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: reviews-v2
+  namespace: bookinfo
+  labels:
+    app: reviews
+    version: v2
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: reviews
+      version: v2
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "true"
+      labels:
+        app: reviews
+        version: v2
+    spec:
+      serviceAccountName: bookinfo-reviews
+      containers:
+      - name: reviews
+        image: quay.io/maistra/examples-bookinfo-reviews-v2:2.4.0
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: LOG_DIR
+          value: "/tmp/logs"
+        ports:
+        - containerPort: 9080
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        - name: wlp-output
+          mountPath: /opt/ibm/wlp/output
+      volumes:
+      - name: wlp-output
+        emptyDir: {}
+      - name: tmp
+        emptyDir: {}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: reviews-v3
+  namespace: bookinfo
+  labels:
+    app: reviews
+    version: v3
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: reviews
+      version: v3
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "true"
+      labels:
+        app: reviews
+        version: v3
+    spec:
+      serviceAccountName: bookinfo-reviews
+      containers:
+      - name: reviews
+        image: quay.io/maistra/examples-bookinfo-reviews-v3:2.4.0
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: LOG_DIR
+          value: "/tmp/logs"
+        ports:
+        - containerPort: 9080
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        - name: wlp-output
+          mountPath: /opt/ibm/wlp/output
+      volumes:
+      - name: wlp-output
+        emptyDir: {}
+      - name: tmp
+        emptyDir: {}
+---
+##################################################################################################
+# Productpage services
+##################################################################################################
+apiVersion: v1
+kind: Service
+metadata:
+  name: productpage
+  namespace: bookinfo
+  labels:
+    app: productpage
+    service: productpage
+spec:
+  ports:
+  - port: 9080
+    name: http
+  selector:
+    app: productpage
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: bookinfo-productpage
+  namespace: bookinfo
+  labels:
+    account: productpage
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: productpage-v1
+  namespace: bookinfo
+  labels:
+    app: productpage
+    version: v1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: productpage
+      version: v1
+  template:
+    metadata:
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9080"
+        prometheus.io/path: "/metrics"
+        sidecar.istio.io/inject: "true"
+      labels:
+        app: productpage
+        version: v1
+    spec:
+      serviceAccountName: bookinfo-productpage
+      containers:
+      - name: productpage
+        image: quay.io/maistra/examples-bookinfo-productpage-v1:2.4.0
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 9080
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: bookinfo-gateway
+  namespace: bookinfo
+spec:
+  # The selector matches the ingress gateway pod labels.
+  # If you installed Istio using Helm following the standard documentation, this would be "istio=ingress"
+  selector:
+    istio: ingressgateway # use istio default controller
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts:
+    - "*"
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: bookinfo
+  namespace: bookinfo
+spec:
+  hosts:
+  - "*"
+  gateways:
+  - bookinfo-gateway
+  http:
+  - match:
+    - uri:
+        exact: /productpage
+    - uri:
+        prefix: /static
+    - uri:
+        exact: /login
+    - uri:
+        exact: /logout
+    - uri:
+        prefix: /api/v1/products
+    route:
+    - destination:
+        host: productpage
+        port:
+          number: 9080
+
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: productpage
+  namespace: bookinfo
+spec:
+  host: productpage
+  subsets:
+  - name: v1
+    labels:
+      version: v1
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: reviews
+  namespace: bookinfo
+spec:
+  host: reviews
+  subsets:
+  - name: v1
+    labels:
+      version: v1
+  - name: v2
+    labels:
+      version: v2
+  - name: v3
+    labels:
+      version: v3
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: ratings
+  namespace: bookinfo
+spec:
+  host: ratings
+  subsets:
+  - name: v1
+    labels:
+      version: v1
+  - name: v2
+    labels:
+      version: v2
+  - name: v2-mysql
+    labels:
+      version: v2-mysql
+  - name: v2-mysql-vm
+    labels:
+      version: v2-mysql-vm
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: details
+  namespace: bookinfo
+spec:
+  host: details
+  subsets:
+  - name: v1
+    labels:
+      version: v1
+  - name: v2
+    labels:
+      version: v2
+---

--- a/tests/e2e-openshift-ossm/ossm-monolithic-otel/install-ossm-assert.yaml
+++ b/tests/e2e-openshift-ossm/ossm-monolithic-otel/install-ossm-assert.yaml
@@ -1,0 +1,101 @@
+apiVersion: project.openshift.io/v1
+kind: Project
+metadata:
+  name: istio-system
+spec:
+  finalizers:
+  - kubernetes
+status:
+  phase: Active
+
+---
+apiVersion: project.openshift.io/v1
+kind: Project
+metadata:
+  name: tracing-system
+spec:
+  finalizers:
+  - kubernetes
+status:
+  phase: Active
+
+---
+apiVersion: project.openshift.io/v1
+kind: Project
+metadata:
+  name: bookinfo
+spec:
+  finalizers:
+  - kubernetes
+status:
+  phase: Active
+
+---
+apiVersion: project.openshift.io/v1
+kind: Project
+metadata:
+  name: otlp-app
+spec:
+  finalizers:
+  - kubernetes
+status:
+  phase: Active
+
+---
+apiVersion: maistra.io/v2
+kind: ServiceMeshControlPlane
+metadata:
+  name: istio-system
+  namespace: istio-system
+status:
+  readiness:
+    components:
+      pending: []
+      ready:
+      - grafana
+      - istio-discovery
+      - istio-egress
+      - istio-ingress
+      - kiali
+      - mesh-config
+      - prometheus
+      - telemetry-common
+      unready: []
+
+---
+apiVersion: maistra.io/v1
+kind: ServiceMeshMemberRoll
+metadata:
+  name: default
+  namespace: istio-system
+spec:
+  members:
+  - tracing-system
+  - bookinfo
+  - otlp-app
+status:
+  configuredMembers:
+  - bookinfo
+  - otlp-app
+  - tracing-system
+  members:
+  - bookinfo
+  - otlp-app
+  - tracing-system
+
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: kiali
+    app.kubernetes.io/instance: kiali
+    app.kubernetes.io/name: kiali
+    app.kubernetes.io/part-of: kiali
+  namespace: istio-system
+status:
+  containerStatuses:
+  - name: kiali
+    ready: true
+    started: true
+  phase: Running

--- a/tests/e2e-openshift-ossm/ossm-monolithic-otel/install-ossm.yaml
+++ b/tests/e2e-openshift-ossm/ossm-monolithic-otel/install-ossm.yaml
@@ -1,0 +1,58 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: istio-system
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tracing-system
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: bookinfo
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: otlp-app
+
+---
+apiVersion: maistra.io/v2
+kind: ServiceMeshControlPlane
+metadata:
+  name: istio-system
+  namespace: istio-system
+spec:
+  version: v2.5
+  tracing:
+    type: None
+    sampling: 10000
+  meshConfig:
+    extensionProviders:
+      - name: tempo
+        zipkin:
+          service: simplest-collector.tracing-system.svc.cluster.local
+          port: 9411
+  addons:
+    kiali:
+      enabled: true
+      name: kiali
+    grafana:
+      enabled: true
+
+---
+kind: ServiceMeshMemberRoll
+apiVersion: maistra.io/v1
+metadata:
+  name: default
+  namespace: istio-system
+spec:
+  members:
+    - tracing-system
+    - bookinfo
+    - otlp-app

--- a/tests/e2e-openshift-ossm/ossm-monolithic-otel/install-otel-collector-assert.yaml
+++ b/tests/e2e-openshift-ossm/ossm-monolithic-otel/install-otel-collector-assert.yaml
@@ -1,0 +1,9 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simplest-collector
+  namespace: tracing-system
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1

--- a/tests/e2e-openshift-ossm/ossm-monolithic-otel/install-otel-collector.yaml
+++ b/tests/e2e-openshift-ossm/ossm-monolithic-otel/install-otel-collector.yaml
@@ -1,0 +1,28 @@
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: simplest
+  namespace: tracing-system
+spec:
+  config: |
+    receivers:
+      zipkin:
+      otlp:
+        protocols:
+          grpc:
+          http:
+      
+    processors:
+
+    exporters:
+        otlp:
+          endpoint: tempo-simplest.tracing-system.svc.cluster.local:4317
+          tls:
+            insecure: true
+
+    service:
+      pipelines:
+        traces:
+          receivers: [zipkin, otlp]
+          processors: []
+          exporters: [otlp]

--- a/tests/e2e-openshift-ossm/ossm-monolithic-otel/install-tempo-assert.yaml
+++ b/tests/e2e-openshift-ossm/ossm-monolithic-otel/install-tempo-assert.yaml
@@ -1,0 +1,76 @@
+apiVersion: tempo.grafana.com/v1alpha1
+kind: TempoMonolithic
+metadata:
+  name: simplest
+  namespace: tracing-system
+  
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: tempo-simplest
+  namespace: tracing-system
+status:
+  readyReplicas: 1
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: tempo
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo-monolithic
+  name: tempo-simplest
+  namespace: tracing-system
+spec:
+  ports:
+  - name: http
+    port: 3200
+    protocol: TCP
+    targetPort: http
+  - name: otlp-grpc
+    port: 4317
+    protocol: TCP
+    targetPort: otlp-grpc
+  - name: otlp-http
+    port: 4318
+    protocol: TCP
+    targetPort: otlp-http
+  selector:
+    app.kubernetes.io/component: tempo
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo-monolithic
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: jaegerui
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo-monolithic
+  name: tempo-simplest-jaegerui
+  namespace: tracing-system
+spec:
+  ports:
+  - name: jaeger-grpc
+    port: 16685
+    protocol: TCP
+    targetPort: jaeger-grpc
+  - name: jaeger-ui
+    port: 16686
+    protocol: TCP
+    targetPort: jaeger-ui
+  - name: jaeger-metrics
+    port: 16687
+    protocol: TCP
+    targetPort: jaeger-metrics
+  selector:
+    app.kubernetes.io/component: tempo
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo-monolithic

--- a/tests/e2e-openshift-ossm/ossm-monolithic-otel/install-tempo.yaml
+++ b/tests/e2e-openshift-ossm/ossm-monolithic-otel/install-tempo.yaml
@@ -1,0 +1,8 @@
+apiVersion: tempo.grafana.com/v1alpha1
+kind: TempoMonolithic
+metadata:
+  name: simplest
+  namespace: tracing-system
+spec:
+  jaegerui:
+    enabled: true

--- a/tests/e2e-openshift-ossm/ossm-monolithic-otel/update-kiali-assert.yaml
+++ b/tests/e2e-openshift-ossm/ossm-monolithic-otel/update-kiali-assert.yaml
@@ -1,0 +1,30 @@
+apiVersion: kiali.io/v1alpha1
+kind: Kiali
+metadata:
+  name: kiali
+  namespace: istio-system
+spec:
+  external_services:
+    tracing:
+      query_timeout: 30
+      enabled: true
+      in_cluster_url: 'http://tempo-simplest-jaegerui.tracing-system.svc.cluster.local:16686'
+      url: '[Tempo query frontend Route url]'
+      use_grpc: false
+
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: kiali
+    app.kubernetes.io/instance: kiali
+    app.kubernetes.io/name: kiali
+    app.kubernetes.io/part-of: kiali
+  namespace: istio-system
+status:
+  containerStatuses:
+  - name: kiali
+    ready: true
+    started: true
+  phase: Running

--- a/tests/e2e-openshift-ossm/ossm-monolithic-otel/update-kiali.yaml
+++ b/tests/e2e-openshift-ossm/ossm-monolithic-otel/update-kiali.yaml
@@ -1,0 +1,13 @@
+apiVersion: kiali.io/v1alpha1
+kind: Kiali
+metadata:
+  name: kiali
+  namespace: istio-system
+spec:
+  external_services:
+    tracing:
+      query_timeout: 30
+      enabled: true
+      in_cluster_url: 'http://tempo-simplest-jaegerui.tracing-system.svc.cluster.local:16686'
+      url: '[Tempo query frontend Route url]'
+      use_grpc: false

--- a/tests/e2e-openshift-ossm/ossm-monolithic-otel/verify-traces-assert.yaml
+++ b/tests/e2e-openshift-ossm/ossm-monolithic-otel/verify-traces-assert.yaml
@@ -1,0 +1,7 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify-traces
+  namespace: istio-system
+status:
+  succeeded: 1

--- a/tests/e2e-openshift-ossm/ossm-monolithic-otel/verify-traces-otel-assert.yaml
+++ b/tests/e2e-openshift-ossm/ossm-monolithic-otel/verify-traces-otel-assert.yaml
@@ -1,0 +1,7 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify-traces-otel
+  namespace: otlp-app
+status:
+  succeeded: 1

--- a/tests/e2e-openshift-ossm/ossm-monolithic-otel/verify-traces-otel.yaml
+++ b/tests/e2e-openshift-ossm/ossm-monolithic-otel/verify-traces-otel.yaml
@@ -1,0 +1,33 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify-traces-otel
+  namespace: otlp-app
+spec:
+  template:
+    spec:
+      containers:
+      - name: verify-traces-otel
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - /bin/bash
+        - -eux
+        - -c
+        args:
+        - |
+          # Check for service telemetrygen-http
+          curl -v -G http://tempo-simplest-jaegerui.tracing-system.svc.cluster.local:16686/api/traces --data-urlencode "service=telemetrygen-http" | tee /tmp/jaeger-http.out
+          num_traces_http=$(jq ".data | length" /tmp/jaeger-http.out)
+          if [[ "$num_traces_http" -ne 10 ]]; then
+            echo && echo "The TempoQuery API for telemetrygen-http returned $num_traces_http instead of 10 traces."
+            exit 1
+          fi
+
+          # Check for service telemetrygen-grpc
+          curl -v -G http://tempo-simplest-jaegerui.tracing-system.svc.cluster.local:16686/api/traces --data-urlencode "service=telemetrygen-grpc" | tee /tmp/jaeger-grpc.out
+          num_traces_grpc=$(jq ".data | length" /tmp/jaeger-grpc.out)
+          if [[ "$num_traces_grpc" -ne 10 ]]; then
+            echo && echo "The TempoQuery API for telemetrygen-grpc returned $num_traces_grpc instead of 10 traces."
+            exit 1
+          fi
+      restartPolicy: Never

--- a/tests/e2e-openshift-ossm/ossm-monolithic-otel/verify-traces.yaml
+++ b/tests/e2e-openshift-ossm/ossm-monolithic-otel/verify-traces.yaml
@@ -1,0 +1,25 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify-traces
+  namespace: istio-system
+spec:
+  template:
+    spec:
+      serviceAccountName: kiali-service-account
+      containers:
+      - name: verify-traces
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command: ["/bin/bash", "-eux", "-c"]
+        args:
+        - |
+            TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+            KIALI_URL=https://kiali.istio-system.svc.cluster.local:20001
+            START_MICROS=1712566368978000
+            OUTPUT=$(curl -k -H "Authorization: Bearer $TOKEN" "$KIALI_URL/api/namespaces/bookinfo/services/productpage/traces?startMicros=$START_MICROS&tags=&limit=100")
+            if echo "$OUTPUT" | grep -q '"serviceName":"productpage.bookinfo"'; then
+              exit 0
+            else
+              exit 1
+            fi
+      restartPolicy: Never

--- a/tests/e2e-openshift-ossm/ossm-tempostack-otel/apply-telemetry-cr-assert.yaml
+++ b/tests/e2e-openshift-ossm/ossm-tempostack-otel/apply-telemetry-cr-assert.yaml
@@ -1,0 +1,27 @@
+apiVersion: telemetry.istio.io/v1alpha1
+kind: Telemetry
+metadata:
+  name: mesh-default
+  namespace: istio-system
+spec:
+  tracing:
+  - providers:
+    - name: tempo
+    randomSamplingPercentage: 100
+
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: kiali
+    app.kubernetes.io/instance: kiali
+    app.kubernetes.io/name: kiali
+    app.kubernetes.io/part-of: kiali
+  namespace: istio-system
+status:
+  containerStatuses:
+  - name: kiali
+    ready: true
+    started: true
+  phase: Running

--- a/tests/e2e-openshift-ossm/ossm-tempostack-otel/apply-telemetry-cr.yaml
+++ b/tests/e2e-openshift-ossm/ossm-tempostack-otel/apply-telemetry-cr.yaml
@@ -1,0 +1,10 @@
+apiVersion: telemetry.istio.io/v1alpha1
+kind: Telemetry
+metadata:
+  name: mesh-default
+  namespace: istio-system
+spec:
+  tracing:
+  - providers:
+    - name: tempo
+    randomSamplingPercentage: 100

--- a/tests/e2e-openshift-ossm/ossm-tempostack-otel/chainsaw-test.yaml
+++ b/tests/e2e-openshift-ossm/ossm-tempostack-otel/chainsaw-test.yaml
@@ -1,0 +1,81 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: ossm-tempostack-otel
+spec:
+  # Avoid running this test case in parallel as it uses high resources and uses static namespaces. 
+  concurrent: false
+  steps:
+  - name: Install OSSM
+    try:
+    - apply:
+        file: install-ossm.yaml
+    - assert:
+        file: install-ossm-assert.yaml
+  - name: Install Minio object store
+    try:
+    - apply:
+        file: install-minio.yaml
+    - assert:
+        file: install-minio-assert.yaml
+  - name: Install TempoStack
+    try:
+    - apply:
+        file: install-tempo.yaml
+    - assert:
+        file: install-tempo-assert.yaml
+  - name: Update Kiali config
+    try:
+    - patch:
+        file: update-kiali.yaml
+    - sleep:
+        duration: 10s
+    - assert:
+        file: update-kiali-assert.yaml
+  - name: Install OTEL collector
+    try:
+    - apply: 
+        file: install-otel-collector.yaml
+    - assert:
+        file: install-otel-collector-assert.yaml
+  - name: Enable OSSM Tempo provider
+    try:
+    - apply:
+        file: apply-telemetry-cr.yaml
+    - sleep:
+        duration: 10s
+    - assert:
+        file: apply-telemetry-cr-assert.yaml
+  - name: Install Bookinfo app
+    try:
+    - apply:
+        file: install-bookinfo.yaml
+    - assert:
+        file: install-bookinfo-assert.yaml
+  - name: Generate traces from the bookinfo app
+    try:
+    - script:
+        content: |
+            for i in {1..20}
+            do
+                curl http://$(oc -n istio-system get route istio-ingressgateway -o jsonpath='{.spec.host}')/productpage
+                sleep 1
+            done
+  - name: Check traces in Kiali
+    try:
+    - apply:
+        file: verify-traces.yaml
+    - assert:
+        file: verify-traces-assert.yaml
+  - name: Generate traces and send it to OTEL collector via OTLP GRPC and HTTP
+    try:
+    - apply:
+        file: generate-traces-otel.yaml
+    - assert:
+        file: generate-traces-otel-assert.yaml
+  - name: Verify the traces sent to OTEL collector in TempoStack instance.
+    try:
+    - apply: 
+        file: verify-traces-otel.yaml
+    - assert:
+        file: verify-traces-otel-assert.yaml

--- a/tests/e2e-openshift-ossm/ossm-tempostack-otel/generate-traces-otel-assert.yaml
+++ b/tests/e2e-openshift-ossm/ossm-tempostack-otel/generate-traces-otel-assert.yaml
@@ -1,0 +1,16 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: generate-traces-grpc
+  namespace: otlp-app
+status:
+  succeeded: 1
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: generate-traces-http
+  namespace: otlp-app
+status:
+  succeeded: 1

--- a/tests/e2e-openshift-ossm/ossm-tempostack-otel/generate-traces-otel.yaml
+++ b/tests/e2e-openshift-ossm/ossm-tempostack-otel/generate-traces-otel.yaml
@@ -1,0 +1,41 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: generate-traces-http
+  namespace: otlp-app
+spec:
+  template:
+    spec:
+      containers:
+      - name: telemetrygen
+        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
+        args:
+        - traces
+        - --otlp-endpoint=simplest-collector.tracing-system.svc.cluster.local:4318
+        - --traces=10
+        - --otlp-http
+        - --otlp-insecure=true
+        - --service=telemetrygen-http
+        - --otlp-attributes=protocol="http"
+      restartPolicy: Never
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: generate-traces-grpc
+  namespace: otlp-app
+spec:
+  template:
+    spec:
+      containers:
+      - name: telemetrygen
+        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
+        args:
+        - traces
+        - --otlp-endpoint=simplest-collector.tracing-system.svc.cluster.local:4317
+        - --traces=10
+        - --otlp-insecure=true
+        - --service=telemetrygen-grpc
+        - --otlp-attributes=protocol="grpc"
+      restartPolicy: Never

--- a/tests/e2e-openshift-ossm/ossm-tempostack-otel/install-bookinfo-assert.yaml
+++ b/tests/e2e-openshift-ossm/ossm-tempostack-otel/install-bookinfo-assert.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: details-v1
+  namespace: bookinfo
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: productpage-v1
+  namespace: bookinfo
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ratings-v1
+  namespace: bookinfo
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: reviews-v1
+  namespace: bookinfo
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: reviews-v2
+  namespace: bookinfo
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: reviews-v3
+  namespace: bookinfo
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+

--- a/tests/e2e-openshift-ossm/ossm-tempostack-otel/install-bookinfo.yaml
+++ b/tests/e2e-openshift-ossm/ossm-tempostack-otel/install-bookinfo.yaml
@@ -1,0 +1,473 @@
+# Copyright Istio Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+##################################################################################################
+# This file defines the services, service accounts, and deployments for the Bookinfo sample.
+#
+# To apply all 4 Bookinfo services, their corresponding service accounts, and deployments:
+#
+#   kubectl apply -f samples/bookinfo/platform/kube/bookinfo.yaml
+#
+# Alternatively, you can deploy any resource separately:
+#
+#   kubectl apply -f samples/bookinfo/platform/kube/bookinfo.yaml -l service=reviews # reviews Service
+#   kubectl apply -f samples/bookinfo/platform/kube/bookinfo.yaml -l account=reviews # reviews ServiceAccount
+#   kubectl apply -f samples/bookinfo/platform/kube/bookinfo.yaml -l app=reviews,version=v3 # reviews-v3 Deployment
+##################################################################################################
+
+##################################################################################################
+# Details service
+##################################################################################################
+apiVersion: v1
+kind: Service
+metadata:
+  name: details
+  labels:
+    app: details
+    service: details
+  namespace: bookinfo
+spec:
+  ports:
+  - port: 9080
+    name: http
+  selector:
+    app: details
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: bookinfo-details
+  namespace: bookinfo
+  labels:
+    account: details
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: details-v1
+  namespace: bookinfo
+  labels:
+    app: details
+    version: v1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: details
+      version: v1
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "true"
+      labels:
+        app: details
+        version: v1
+    spec:
+      serviceAccountName: bookinfo-details
+      containers:
+      - name: details
+        image: quay.io/maistra/examples-bookinfo-details-v1:2.4.0
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 9080
+---
+##################################################################################################
+# Ratings service
+##################################################################################################
+apiVersion: v1
+kind: Service
+metadata:
+  name: ratings
+  namespace: bookinfo
+  labels:
+    app: ratings
+    service: ratings
+spec:
+  ports:
+  - port: 9080
+    name: http
+  selector:
+    app: ratings
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: bookinfo-ratings
+  namespace: bookinfo
+  labels:
+    account: ratings
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ratings-v1
+  namespace: bookinfo
+  labels:
+    app: ratings
+    version: v1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ratings
+      version: v1
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "true"
+      labels:
+        app: ratings
+        version: v1
+    spec:
+      serviceAccountName: bookinfo-ratings
+      containers:
+      - name: ratings
+        image: quay.io/maistra/examples-bookinfo-ratings-v1:2.4.0
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 9080
+---
+##################################################################################################
+# Reviews service
+##################################################################################################
+apiVersion: v1
+kind: Service
+metadata:
+  name: reviews
+  namespace: bookinfo
+  labels:
+    app: reviews
+    service: reviews
+spec:
+  ports:
+  - port: 9080
+    name: http
+  selector:
+    app: reviews
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: bookinfo-reviews
+  namespace: bookinfo
+  labels:
+    account: reviews
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: reviews-v1
+  namespace: bookinfo
+  labels:
+    app: reviews
+    version: v1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: reviews
+      version: v1
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "true"
+      labels:
+        app: reviews
+        version: v1
+    spec:
+      serviceAccountName: bookinfo-reviews
+      containers:
+      - name: reviews
+        image: quay.io/maistra/examples-bookinfo-reviews-v1:2.4.0
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: LOG_DIR
+          value: "/tmp/logs"
+        ports:
+        - containerPort: 9080
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        - name: wlp-output
+          mountPath: /opt/ibm/wlp/output
+      volumes:
+      - name: wlp-output
+        emptyDir: {}
+      - name: tmp
+        emptyDir: {}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: reviews-v2
+  namespace: bookinfo
+  labels:
+    app: reviews
+    version: v2
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: reviews
+      version: v2
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "true"
+      labels:
+        app: reviews
+        version: v2
+    spec:
+      serviceAccountName: bookinfo-reviews
+      containers:
+      - name: reviews
+        image: quay.io/maistra/examples-bookinfo-reviews-v2:2.4.0
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: LOG_DIR
+          value: "/tmp/logs"
+        ports:
+        - containerPort: 9080
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        - name: wlp-output
+          mountPath: /opt/ibm/wlp/output
+      volumes:
+      - name: wlp-output
+        emptyDir: {}
+      - name: tmp
+        emptyDir: {}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: reviews-v3
+  namespace: bookinfo
+  labels:
+    app: reviews
+    version: v3
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: reviews
+      version: v3
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "true"
+      labels:
+        app: reviews
+        version: v3
+    spec:
+      serviceAccountName: bookinfo-reviews
+      containers:
+      - name: reviews
+        image: quay.io/maistra/examples-bookinfo-reviews-v3:2.4.0
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: LOG_DIR
+          value: "/tmp/logs"
+        ports:
+        - containerPort: 9080
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        - name: wlp-output
+          mountPath: /opt/ibm/wlp/output
+      volumes:
+      - name: wlp-output
+        emptyDir: {}
+      - name: tmp
+        emptyDir: {}
+---
+##################################################################################################
+# Productpage services
+##################################################################################################
+apiVersion: v1
+kind: Service
+metadata:
+  name: productpage
+  namespace: bookinfo
+  labels:
+    app: productpage
+    service: productpage
+spec:
+  ports:
+  - port: 9080
+    name: http
+  selector:
+    app: productpage
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: bookinfo-productpage
+  namespace: bookinfo
+  labels:
+    account: productpage
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: productpage-v1
+  namespace: bookinfo
+  labels:
+    app: productpage
+    version: v1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: productpage
+      version: v1
+  template:
+    metadata:
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9080"
+        prometheus.io/path: "/metrics"
+        sidecar.istio.io/inject: "true"
+      labels:
+        app: productpage
+        version: v1
+    spec:
+      serviceAccountName: bookinfo-productpage
+      containers:
+      - name: productpage
+        image: quay.io/maistra/examples-bookinfo-productpage-v1:2.4.0
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 9080
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: bookinfo-gateway
+  namespace: bookinfo
+spec:
+  # The selector matches the ingress gateway pod labels.
+  # If you installed Istio using Helm following the standard documentation, this would be "istio=ingress"
+  selector:
+    istio: ingressgateway # use istio default controller
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts:
+    - "*"
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: bookinfo
+  namespace: bookinfo
+spec:
+  hosts:
+  - "*"
+  gateways:
+  - bookinfo-gateway
+  http:
+  - match:
+    - uri:
+        exact: /productpage
+    - uri:
+        prefix: /static
+    - uri:
+        exact: /login
+    - uri:
+        exact: /logout
+    - uri:
+        prefix: /api/v1/products
+    route:
+    - destination:
+        host: productpage
+        port:
+          number: 9080
+
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: productpage
+  namespace: bookinfo
+spec:
+  host: productpage
+  subsets:
+  - name: v1
+    labels:
+      version: v1
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: reviews
+  namespace: bookinfo
+spec:
+  host: reviews
+  subsets:
+  - name: v1
+    labels:
+      version: v1
+  - name: v2
+    labels:
+      version: v2
+  - name: v3
+    labels:
+      version: v3
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: ratings
+  namespace: bookinfo
+spec:
+  host: ratings
+  subsets:
+  - name: v1
+    labels:
+      version: v1
+  - name: v2
+    labels:
+      version: v2
+  - name: v2-mysql
+    labels:
+      version: v2-mysql
+  - name: v2-mysql-vm
+    labels:
+      version: v2-mysql-vm
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: details
+  namespace: bookinfo
+spec:
+  host: details
+  subsets:
+  - name: v1
+    labels:
+      version: v1
+  - name: v2
+    labels:
+      version: v2
+---

--- a/tests/e2e-openshift-ossm/ossm-tempostack-otel/install-minio-assert.yaml
+++ b/tests/e2e-openshift-ossm/ossm-tempostack-otel/install-minio-assert.yaml
@@ -1,0 +1,7 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+  namespace: tracing-system
+status:
+  readyReplicas: 1

--- a/tests/e2e-openshift-ossm/ossm-tempostack-otel/install-minio.yaml
+++ b/tests/e2e-openshift-ossm/ossm-tempostack-otel/install-minio.yaml
@@ -1,0 +1,79 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app.kubernetes.io/name: minio
+  name: minio
+  namespace: tracing-system
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+  namespace: tracing-system
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: minio
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: minio
+    spec:
+      containers:
+        - command:
+            - /bin/sh
+            - -c
+            - |
+              mkdir -p /storage/tempo && \
+              minio server /storage
+          env:
+            - name: MINIO_ACCESS_KEY
+              value: tempo
+            - name: MINIO_SECRET_KEY
+              value: supersecret
+          image: minio/minio
+          name: minio
+          ports:
+            - containerPort: 9000
+          volumeMounts:
+            - mountPath: /storage
+              name: storage
+      volumes:
+        - name: storage
+          persistentVolumeClaim:
+            claimName: minio
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+  namespace: tracing-system
+spec:
+  ports:
+    - port: 9000
+      protocol: TCP
+      targetPort: 9000
+  selector:
+    app.kubernetes.io/name: minio
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio
+  namespace: tracing-system
+stringData:
+  endpoint: http://minio.tracing-system.svc.cluster.local:9000
+  bucket: tempo
+  access_key_id: tempo
+  access_key_secret: supersecret
+type: Opaque

--- a/tests/e2e-openshift-ossm/ossm-tempostack-otel/install-ossm-assert.yaml
+++ b/tests/e2e-openshift-ossm/ossm-tempostack-otel/install-ossm-assert.yaml
@@ -1,0 +1,90 @@
+apiVersion: project.openshift.io/v1
+kind: Project
+metadata:
+  name: istio-system
+spec:
+  finalizers:
+  - kubernetes
+status:
+  phase: Active
+
+---
+apiVersion: project.openshift.io/v1
+kind: Project
+metadata:
+  name: tracing-system
+spec:
+  finalizers:
+  - kubernetes
+status:
+  phase: Active
+
+---
+apiVersion: project.openshift.io/v1
+kind: Project
+metadata:
+  name: otlp-app
+spec:
+  finalizers:
+  - kubernetes
+status:
+  phase: Active
+
+---
+apiVersion: maistra.io/v2
+kind: ServiceMeshControlPlane
+metadata:
+  name: istio-system
+  namespace: istio-system
+status:
+  readiness:
+    components:
+      pending: []
+      ready:
+      - grafana
+      - istio-discovery
+      - istio-egress
+      - istio-ingress
+      - kiali
+      - mesh-config
+      - prometheus
+      - telemetry-common
+      unready: []
+
+---
+apiVersion: maistra.io/v1
+kind: ServiceMeshMemberRoll
+metadata:
+  name: default
+  namespace: istio-system
+spec:
+  members:
+  - tracing-system
+  - bookinfo
+  - otlp-app
+status:
+  configuredMembers:
+  - bookinfo
+  - otlp-app
+  - tracing-system
+  members:
+  - bookinfo
+  - otlp-app
+  - tracing-system
+
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: kiali
+    app.kubernetes.io/instance: kiali
+    app.kubernetes.io/name: kiali
+    app.kubernetes.io/part-of: kiali
+  namespace: istio-system
+status:
+  containerStatuses:
+  - name: kiali
+    ready: true
+    started: true
+  phase: Running

--- a/tests/e2e-openshift-ossm/ossm-tempostack-otel/install-ossm.yaml
+++ b/tests/e2e-openshift-ossm/ossm-tempostack-otel/install-ossm.yaml
@@ -1,0 +1,58 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: istio-system
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tracing-system
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: bookinfo
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: otlp-app
+
+---
+apiVersion: maistra.io/v2
+kind: ServiceMeshControlPlane
+metadata:
+  name: istio-system
+  namespace: istio-system
+spec:
+  version: v2.5
+  tracing:
+    type: None
+    sampling: 10000
+  meshConfig:
+    extensionProviders:
+      - name: tempo
+        zipkin:
+          service: simplest-collector.tracing-system.svc.cluster.local
+          port: 9411
+  addons:
+    kiali:
+      enabled: true
+      name: kiali
+    grafana:
+      enabled: true
+
+---
+kind: ServiceMeshMemberRoll
+apiVersion: maistra.io/v1
+metadata:
+  name: default
+  namespace: istio-system
+spec:
+  members:
+    - tracing-system
+    - bookinfo
+    - otlp-app

--- a/tests/e2e-openshift-ossm/ossm-tempostack-otel/install-otel-collector-assert.yaml
+++ b/tests/e2e-openshift-ossm/ossm-tempostack-otel/install-otel-collector-assert.yaml
@@ -1,0 +1,9 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simplest-collector
+  namespace: tracing-system
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1

--- a/tests/e2e-openshift-ossm/ossm-tempostack-otel/install-otel-collector.yaml
+++ b/tests/e2e-openshift-ossm/ossm-tempostack-otel/install-otel-collector.yaml
@@ -1,0 +1,28 @@
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: simplest
+  namespace: tracing-system
+spec:
+  config: |
+    receivers:
+      zipkin:
+      otlp:
+        protocols:
+          grpc:
+          http:
+      
+    processors:
+
+    exporters:
+        otlp:
+          endpoint: tempo-simplest-distributor.tracing-system.svc.cluster.local:4317
+          tls:
+            insecure: true
+
+    service:
+      pipelines:
+        traces:
+          receivers: [zipkin, otlp]
+          processors: []
+          exporters: [otlp]

--- a/tests/e2e-openshift-ossm/ossm-tempostack-otel/install-tempo-assert.yaml
+++ b/tests/e2e-openshift-ossm/ossm-tempostack-otel/install-tempo-assert.yaml
@@ -1,0 +1,390 @@
+apiVersion: tempo.grafana.com/v1alpha1
+kind: TempoStack
+metadata:
+  name: simplest
+  namespace: tracing-system
+#
+# Service Accounts
+#
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tempo-simplest
+  namespace: tracing-system
+  labels:
+    app.kubernetes.io/component: serviceaccount
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+#
+# Deployments
+#
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tempo-simplest-query-frontend
+  namespace: tracing-system
+  labels:
+    app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: query-frontend
+      app.kubernetes.io/instance: simplest
+      app.kubernetes.io/managed-by: tempo-operator
+      app.kubernetes.io/name: tempo
+status:
+  readyReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tempo-simplest-distributor
+  namespace: tracing-system
+  labels:
+    app.kubernetes.io/component: distributor
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: distributor
+      app.kubernetes.io/instance: simplest
+      app.kubernetes.io/managed-by: tempo-operator
+      app.kubernetes.io/name: tempo
+status:
+  readyReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tempo-simplest-querier
+  namespace: tracing-system
+  labels:
+    app.kubernetes.io/component: querier
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: querier
+      app.kubernetes.io/instance: simplest
+      app.kubernetes.io/managed-by: tempo-operator
+      app.kubernetes.io/name: tempo
+status:
+  readyReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tempo-simplest-compactor
+  namespace: tracing-system
+  labels:
+    app.kubernetes.io/component: compactor
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: compactor
+      app.kubernetes.io/instance: simplest
+      app.kubernetes.io/managed-by: tempo-operator
+      app.kubernetes.io/name: tempo
+status:
+  readyReplicas: 1
+#
+# StatefulSets
+#
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: tempo-simplest-ingester
+  namespace: tracing-system
+  labels:
+    app.kubernetes.io/component: ingester
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: ingester
+      app.kubernetes.io/instance: simplest
+      app.kubernetes.io/managed-by: tempo-operator
+      app.kubernetes.io/name: tempo
+status:
+  readyReplicas: 1
+#
+# Services
+#
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: compactor
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+  name: tempo-simplest-compactor
+  namespace: tracing-system
+spec:
+  ports:
+    - name: http-memberlist
+      port: 7946
+      protocol: TCP
+      targetPort: http-memberlist
+    - name: http
+      port: 3200
+      protocol: TCP
+      targetPort: http
+  selector:
+    app.kubernetes.io/component: compactor
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: distributor
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+  name: tempo-simplest-distributor
+  namespace: tracing-system
+spec:
+  ports:
+    - name: otlp-grpc
+      port: 4317
+      protocol: TCP
+      targetPort: otlp-grpc
+    - name: http
+      port: 3200
+      protocol: TCP
+      targetPort: http
+    - name: otlp-http
+      port: 4318
+      protocol: TCP
+      targetPort: otlp-http
+    - name: thrift-http
+      port: 14268
+      protocol: TCP
+      targetPort: thrift-http
+    - name: thrift-compact
+      port: 6831
+      protocol: UDP
+      targetPort: thrift-compact
+    - name: thrift-binary
+      port: 6832
+      protocol: UDP
+      targetPort: thrift-binary
+    - name: jaeger-grpc
+      port: 14250
+      protocol: TCP
+      targetPort: jaeger-grpc
+    - name: http-zipkin
+      port: 9411
+      protocol: TCP
+      targetPort: http-zipkin
+  selector:
+    app.kubernetes.io/component: distributor
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: gossip-ring
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+  name: tempo-simplest-gossip-ring
+  namespace: tracing-system
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - name: http-memberlist
+      port: 7946
+      protocol: TCP
+      targetPort: http-memberlist
+  selector:
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+    tempo-gossip-member: "true"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: ingester
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+  name: tempo-simplest-ingester
+  namespace: tracing-system
+spec:
+  ports:
+    - name: http
+      port: 3200
+      protocol: TCP
+      targetPort: http
+    - name: grpc
+      port: 9095
+      protocol: TCP
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/component: ingester
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: querier
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+  name: tempo-simplest-querier
+  namespace: tracing-system
+spec:
+  ports:
+    - name: http-memberlist
+      port: 7946
+      protocol: TCP
+      targetPort: http-memberlist
+    - name: http
+      port: 3200
+      protocol: TCP
+      targetPort: http
+    - name: grpc
+      port: 9095
+      protocol: TCP
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/component: querier
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+  name: tempo-simplest-query-frontend
+  namespace: tracing-system
+spec:
+  ports:
+    - name: http
+      port: 3200
+      protocol: TCP
+      targetPort: http
+    - name: grpc
+      port: 9095
+      protocol: TCP
+      targetPort: grpc
+    - name: jaeger-grpc
+      port: 16685
+      protocol: TCP
+      targetPort: jaeger-grpc
+    - name: jaeger-ui
+      port: 16686
+      protocol: TCP
+      targetPort: jaeger-ui
+    - name: jaeger-metrics
+      port: 16687
+      protocol: TCP
+      targetPort: jaeger-metrics
+  selector:
+    app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: query-frontend-discovery
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+  name: tempo-simplest-query-frontend-discovery
+  namespace: tracing-system
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - name: http
+      port: 3200
+      protocol: TCP
+      targetPort: http
+    - name: grpc
+      port: 9095
+      protocol: TCP
+      targetPort: grpc
+    - name: grpclb
+      port: 9096
+      protocol: TCP
+      targetPort: grpclb
+    - name: jaeger-grpc
+      port: 16685
+      protocol: TCP
+      targetPort: jaeger-grpc
+    - name: jaeger-ui
+      port: 16686
+      protocol: TCP
+      targetPort: jaeger-ui
+    - name: jaeger-metrics
+      port: 16687
+      protocol: TCP
+      targetPort: jaeger-metrics
+  selector:
+    app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+#
+# Route
+#
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: tempo-simplest-query-frontend
+  namespace: tracing-system
+spec:
+  port:
+    targetPort: jaeger-ui
+  tls:
+    termination: edge
+  to:
+    kind: Service
+    name: tempo-simplest-query-frontend
+    weight: 100
+  wildcardPolicy: None
+status:
+  ingress:
+  - conditions:
+    - status: "True"
+      type: Admitted

--- a/tests/e2e-openshift-ossm/ossm-tempostack-otel/install-tempo.yaml
+++ b/tests/e2e-openshift-ossm/ossm-tempostack-otel/install-tempo.yaml
@@ -1,0 +1,22 @@
+apiVersion: tempo.grafana.com/v1alpha1
+kind: TempoStack
+metadata:
+  name: simplest
+  namespace: tracing-system
+spec:
+  storage:
+    secret:
+      name: minio
+      type: s3
+  storageSize: 200M
+  resources:
+    total:
+      limits:
+        memory: 2Gi
+        cpu: 2000m
+  template:
+    queryFrontend:
+      jaegerQuery:
+        enabled: true
+        ingress:
+          type: route

--- a/tests/e2e-openshift-ossm/ossm-tempostack-otel/update-kiali-assert.yaml
+++ b/tests/e2e-openshift-ossm/ossm-tempostack-otel/update-kiali-assert.yaml
@@ -1,0 +1,30 @@
+apiVersion: kiali.io/v1alpha1
+kind: Kiali
+metadata:
+  name: kiali
+  namespace: istio-system
+spec:
+  external_services:
+    tracing:
+      query_timeout: 30
+      enabled: true
+      in_cluster_url: 'http://tempo-simplest-query-frontend.tracing-system.svc.cluster.local:16686'
+      url: '[Tempo query frontend Route url]'
+      use_grpc: false
+
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: kiali
+    app.kubernetes.io/instance: kiali
+    app.kubernetes.io/name: kiali
+    app.kubernetes.io/part-of: kiali
+  namespace: istio-system
+status:
+  containerStatuses:
+  - name: kiali
+    ready: true
+    started: true
+  phase: Running

--- a/tests/e2e-openshift-ossm/ossm-tempostack-otel/update-kiali.yaml
+++ b/tests/e2e-openshift-ossm/ossm-tempostack-otel/update-kiali.yaml
@@ -1,0 +1,13 @@
+apiVersion: kiali.io/v1alpha1
+kind: Kiali
+metadata:
+  name: kiali
+  namespace: istio-system
+spec:
+  external_services:
+    tracing:
+      query_timeout: 30
+      enabled: true
+      in_cluster_url: 'http://tempo-simplest-query-frontend.tracing-system.svc.cluster.local:16686'
+      url: '[Tempo query frontend Route url]'
+      use_grpc: false

--- a/tests/e2e-openshift-ossm/ossm-tempostack-otel/verify-traces-assert.yaml
+++ b/tests/e2e-openshift-ossm/ossm-tempostack-otel/verify-traces-assert.yaml
@@ -1,0 +1,7 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify-traces
+  namespace: istio-system
+status:
+  succeeded: 1

--- a/tests/e2e-openshift-ossm/ossm-tempostack-otel/verify-traces-otel-assert.yaml
+++ b/tests/e2e-openshift-ossm/ossm-tempostack-otel/verify-traces-otel-assert.yaml
@@ -1,0 +1,7 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify-traces-otel
+  namespace: otlp-app
+status:
+  succeeded: 1

--- a/tests/e2e-openshift-ossm/ossm-tempostack-otel/verify-traces-otel.yaml
+++ b/tests/e2e-openshift-ossm/ossm-tempostack-otel/verify-traces-otel.yaml
@@ -1,0 +1,33 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify-traces-otel
+  namespace: otlp-app
+spec:
+  template:
+    spec:
+      containers:
+      - name: verify-traces-otel
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - /bin/bash
+        - -eux
+        - -c
+        args:
+        - |
+          # Check for service telemetrygen-http
+          curl -v -G http://tempo-simplest-query-frontend.tracing-system.svc.cluster.local:16686/api/traces --data-urlencode "service=telemetrygen-http" | tee /tmp/jaeger-http.out
+          num_traces_http=$(jq ".data | length" /tmp/jaeger-http.out)
+          if [[ "$num_traces_http" -ne 10 ]]; then
+            echo && echo "The TempoQuery API for telemetrygen-http returned $num_traces_http instead of 10 traces."
+            exit 1
+          fi
+
+          # Check for service telemetrygen-grpc
+          curl -v -G http://tempo-simplest-query-frontend.tracing-system.svc.cluster.local:16686/api/traces --data-urlencode "service=telemetrygen-grpc" | tee /tmp/jaeger-grpc.out
+          num_traces_grpc=$(jq ".data | length" /tmp/jaeger-grpc.out)
+          if [[ "$num_traces_grpc" -ne 10 ]]; then
+            echo && echo "The TempoQuery API for telemetrygen-grpc returned $num_traces_grpc instead of 10 traces."
+            exit 1
+          fi
+      restartPolicy: Never

--- a/tests/e2e-openshift-ossm/ossm-tempostack-otel/verify-traces.yaml
+++ b/tests/e2e-openshift-ossm/ossm-tempostack-otel/verify-traces.yaml
@@ -1,0 +1,25 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify-traces
+  namespace: istio-system
+spec:
+  template:
+    spec:
+      serviceAccountName: kiali-service-account
+      containers:
+      - name: verify-traces
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command: ["/bin/bash", "-eux", "-c"]
+        args:
+        - |
+            TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+            KIALI_URL=https://kiali.istio-system.svc.cluster.local:20001
+            START_MICROS=1712566368978000
+            OUTPUT=$(curl -k -H "Authorization: Bearer $TOKEN" "$KIALI_URL/api/namespaces/bookinfo/services/productpage/traces?startMicros=$START_MICROS&tags=&limit=100")
+            if echo "$OUTPUT" | grep -q '"serviceName":"productpage.bookinfo"'; then
+              exit 0
+            else
+              exit 1
+            fi
+      restartPolicy: Never

--- a/tests/e2e-openshift-ossm/ossm-tempostack/apply-telemetry-cr-assert.yaml
+++ b/tests/e2e-openshift-ossm/ossm-tempostack/apply-telemetry-cr-assert.yaml
@@ -1,0 +1,27 @@
+apiVersion: telemetry.istio.io/v1alpha1
+kind: Telemetry
+metadata:
+  name: mesh-default
+  namespace: istio-system
+spec:
+  tracing:
+  - providers:
+    - name: tempo
+    randomSamplingPercentage: 100
+
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: kiali
+    app.kubernetes.io/instance: kiali
+    app.kubernetes.io/name: kiali
+    app.kubernetes.io/part-of: kiali
+  namespace: istio-system
+status:
+  containerStatuses:
+  - name: kiali
+    ready: true
+    started: true
+  phase: Running

--- a/tests/e2e-openshift-ossm/ossm-tempostack/apply-telemetry-cr.yaml
+++ b/tests/e2e-openshift-ossm/ossm-tempostack/apply-telemetry-cr.yaml
@@ -1,0 +1,10 @@
+apiVersion: telemetry.istio.io/v1alpha1
+kind: Telemetry
+metadata:
+  name: mesh-default
+  namespace: istio-system
+spec:
+  tracing:
+  - providers:
+    - name: tempo
+    randomSamplingPercentage: 100

--- a/tests/e2e-openshift-ossm/ossm-tempostack/chainsaw-test.yaml
+++ b/tests/e2e-openshift-ossm/ossm-tempostack/chainsaw-test.yaml
@@ -1,0 +1,65 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: ossm-tempostack
+spec:
+  # Avoid running this test case in parallel as it uses high resources and uses static namespaces. 
+  concurrent: false
+  steps:
+  - name: Install OSSM
+    try:
+    - apply:
+        file: install-ossm.yaml
+    - assert:
+        file: install-ossm-assert.yaml
+  - name: Install Minio object store
+    try:
+    - apply:
+        file: install-minio.yaml
+    - assert:
+        file: install-minio-assert.yaml
+  - name: Install TempoStack
+    try:
+    - apply:
+        file: install-tempo.yaml
+    - assert:
+        file: install-tempo-assert.yaml
+  - name: Update Kiali config
+    try:
+    - patch:
+        file: update-kiali.yaml
+    - sleep:
+        duration: 10s
+    - assert:
+        file: update-kiali-assert.yaml
+  - name: Enable OSSM Tempo provider
+    try:
+    - apply:
+        file: apply-telemetry-cr.yaml
+    - sleep:
+        duration: 10s
+    - assert:
+        file: apply-telemetry-cr-assert.yaml
+  - name: Install Bookinfo app
+    try:
+    - apply:
+        file: install-bookinfo.yaml
+    - assert:
+        file: install-bookinfo-assert.yaml
+  - name: Generate traces from the bookinfo app
+    try:
+    - script:
+        content: |
+            for i in {1..20}
+            do
+                curl http://$(oc -n istio-system get route istio-ingressgateway -o jsonpath='{.spec.host}')/productpage
+                sleep 1
+            done
+  - name: Check traces in Kiali
+    try:
+    - apply:
+        file: verify-traces.yaml
+    - assert:
+        file: verify-traces-assert.yaml
+

--- a/tests/e2e-openshift-ossm/ossm-tempostack/install-bookinfo-assert.yaml
+++ b/tests/e2e-openshift-ossm/ossm-tempostack/install-bookinfo-assert.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: details-v1
+  namespace: bookinfo
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: productpage-v1
+  namespace: bookinfo
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ratings-v1
+  namespace: bookinfo
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: reviews-v1
+  namespace: bookinfo
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: reviews-v2
+  namespace: bookinfo
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: reviews-v3
+  namespace: bookinfo
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+

--- a/tests/e2e-openshift-ossm/ossm-tempostack/install-bookinfo.yaml
+++ b/tests/e2e-openshift-ossm/ossm-tempostack/install-bookinfo.yaml
@@ -1,0 +1,473 @@
+# Copyright Istio Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+##################################################################################################
+# This file defines the services, service accounts, and deployments for the Bookinfo sample.
+#
+# To apply all 4 Bookinfo services, their corresponding service accounts, and deployments:
+#
+#   kubectl apply -f samples/bookinfo/platform/kube/bookinfo.yaml
+#
+# Alternatively, you can deploy any resource separately:
+#
+#   kubectl apply -f samples/bookinfo/platform/kube/bookinfo.yaml -l service=reviews # reviews Service
+#   kubectl apply -f samples/bookinfo/platform/kube/bookinfo.yaml -l account=reviews # reviews ServiceAccount
+#   kubectl apply -f samples/bookinfo/platform/kube/bookinfo.yaml -l app=reviews,version=v3 # reviews-v3 Deployment
+##################################################################################################
+
+##################################################################################################
+# Details service
+##################################################################################################
+apiVersion: v1
+kind: Service
+metadata:
+  name: details
+  labels:
+    app: details
+    service: details
+  namespace: bookinfo
+spec:
+  ports:
+  - port: 9080
+    name: http
+  selector:
+    app: details
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: bookinfo-details
+  namespace: bookinfo
+  labels:
+    account: details
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: details-v1
+  namespace: bookinfo
+  labels:
+    app: details
+    version: v1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: details
+      version: v1
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "true"
+      labels:
+        app: details
+        version: v1
+    spec:
+      serviceAccountName: bookinfo-details
+      containers:
+      - name: details
+        image: quay.io/maistra/examples-bookinfo-details-v1:2.4.0
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 9080
+---
+##################################################################################################
+# Ratings service
+##################################################################################################
+apiVersion: v1
+kind: Service
+metadata:
+  name: ratings
+  namespace: bookinfo
+  labels:
+    app: ratings
+    service: ratings
+spec:
+  ports:
+  - port: 9080
+    name: http
+  selector:
+    app: ratings
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: bookinfo-ratings
+  namespace: bookinfo
+  labels:
+    account: ratings
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ratings-v1
+  namespace: bookinfo
+  labels:
+    app: ratings
+    version: v1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ratings
+      version: v1
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "true"
+      labels:
+        app: ratings
+        version: v1
+    spec:
+      serviceAccountName: bookinfo-ratings
+      containers:
+      - name: ratings
+        image: quay.io/maistra/examples-bookinfo-ratings-v1:2.4.0
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 9080
+---
+##################################################################################################
+# Reviews service
+##################################################################################################
+apiVersion: v1
+kind: Service
+metadata:
+  name: reviews
+  namespace: bookinfo
+  labels:
+    app: reviews
+    service: reviews
+spec:
+  ports:
+  - port: 9080
+    name: http
+  selector:
+    app: reviews
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: bookinfo-reviews
+  namespace: bookinfo
+  labels:
+    account: reviews
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: reviews-v1
+  namespace: bookinfo
+  labels:
+    app: reviews
+    version: v1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: reviews
+      version: v1
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "true"
+      labels:
+        app: reviews
+        version: v1
+    spec:
+      serviceAccountName: bookinfo-reviews
+      containers:
+      - name: reviews
+        image: quay.io/maistra/examples-bookinfo-reviews-v1:2.4.0
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: LOG_DIR
+          value: "/tmp/logs"
+        ports:
+        - containerPort: 9080
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        - name: wlp-output
+          mountPath: /opt/ibm/wlp/output
+      volumes:
+      - name: wlp-output
+        emptyDir: {}
+      - name: tmp
+        emptyDir: {}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: reviews-v2
+  namespace: bookinfo
+  labels:
+    app: reviews
+    version: v2
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: reviews
+      version: v2
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "true"
+      labels:
+        app: reviews
+        version: v2
+    spec:
+      serviceAccountName: bookinfo-reviews
+      containers:
+      - name: reviews
+        image: quay.io/maistra/examples-bookinfo-reviews-v2:2.4.0
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: LOG_DIR
+          value: "/tmp/logs"
+        ports:
+        - containerPort: 9080
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        - name: wlp-output
+          mountPath: /opt/ibm/wlp/output
+      volumes:
+      - name: wlp-output
+        emptyDir: {}
+      - name: tmp
+        emptyDir: {}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: reviews-v3
+  namespace: bookinfo
+  labels:
+    app: reviews
+    version: v3
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: reviews
+      version: v3
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "true"
+      labels:
+        app: reviews
+        version: v3
+    spec:
+      serviceAccountName: bookinfo-reviews
+      containers:
+      - name: reviews
+        image: quay.io/maistra/examples-bookinfo-reviews-v3:2.4.0
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: LOG_DIR
+          value: "/tmp/logs"
+        ports:
+        - containerPort: 9080
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        - name: wlp-output
+          mountPath: /opt/ibm/wlp/output
+      volumes:
+      - name: wlp-output
+        emptyDir: {}
+      - name: tmp
+        emptyDir: {}
+---
+##################################################################################################
+# Productpage services
+##################################################################################################
+apiVersion: v1
+kind: Service
+metadata:
+  name: productpage
+  namespace: bookinfo
+  labels:
+    app: productpage
+    service: productpage
+spec:
+  ports:
+  - port: 9080
+    name: http
+  selector:
+    app: productpage
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: bookinfo-productpage
+  namespace: bookinfo
+  labels:
+    account: productpage
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: productpage-v1
+  namespace: bookinfo
+  labels:
+    app: productpage
+    version: v1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: productpage
+      version: v1
+  template:
+    metadata:
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9080"
+        prometheus.io/path: "/metrics"
+        sidecar.istio.io/inject: "true"
+      labels:
+        app: productpage
+        version: v1
+    spec:
+      serviceAccountName: bookinfo-productpage
+      containers:
+      - name: productpage
+        image: quay.io/maistra/examples-bookinfo-productpage-v1:2.4.0
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 9080
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: bookinfo-gateway
+  namespace: bookinfo
+spec:
+  # The selector matches the ingress gateway pod labels.
+  # If you installed Istio using Helm following the standard documentation, this would be "istio=ingress"
+  selector:
+    istio: ingressgateway # use istio default controller
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts:
+    - "*"
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: bookinfo
+  namespace: bookinfo
+spec:
+  hosts:
+  - "*"
+  gateways:
+  - bookinfo-gateway
+  http:
+  - match:
+    - uri:
+        exact: /productpage
+    - uri:
+        prefix: /static
+    - uri:
+        exact: /login
+    - uri:
+        exact: /logout
+    - uri:
+        prefix: /api/v1/products
+    route:
+    - destination:
+        host: productpage
+        port:
+          number: 9080
+
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: productpage
+  namespace: bookinfo
+spec:
+  host: productpage
+  subsets:
+  - name: v1
+    labels:
+      version: v1
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: reviews
+  namespace: bookinfo
+spec:
+  host: reviews
+  subsets:
+  - name: v1
+    labels:
+      version: v1
+  - name: v2
+    labels:
+      version: v2
+  - name: v3
+    labels:
+      version: v3
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: ratings
+  namespace: bookinfo
+spec:
+  host: ratings
+  subsets:
+  - name: v1
+    labels:
+      version: v1
+  - name: v2
+    labels:
+      version: v2
+  - name: v2-mysql
+    labels:
+      version: v2-mysql
+  - name: v2-mysql-vm
+    labels:
+      version: v2-mysql-vm
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: details
+  namespace: bookinfo
+spec:
+  host: details
+  subsets:
+  - name: v1
+    labels:
+      version: v1
+  - name: v2
+    labels:
+      version: v2
+---

--- a/tests/e2e-openshift-ossm/ossm-tempostack/install-minio-assert.yaml
+++ b/tests/e2e-openshift-ossm/ossm-tempostack/install-minio-assert.yaml
@@ -1,0 +1,7 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+  namespace: tracing-system
+status:
+  readyReplicas: 1

--- a/tests/e2e-openshift-ossm/ossm-tempostack/install-minio.yaml
+++ b/tests/e2e-openshift-ossm/ossm-tempostack/install-minio.yaml
@@ -1,0 +1,79 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app.kubernetes.io/name: minio
+  name: minio
+  namespace: tracing-system
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+  namespace: tracing-system
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: minio
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: minio
+    spec:
+      containers:
+        - command:
+            - /bin/sh
+            - -c
+            - |
+              mkdir -p /storage/tempo && \
+              minio server /storage
+          env:
+            - name: MINIO_ACCESS_KEY
+              value: tempo
+            - name: MINIO_SECRET_KEY
+              value: supersecret
+          image: minio/minio
+          name: minio
+          ports:
+            - containerPort: 9000
+          volumeMounts:
+            - mountPath: /storage
+              name: storage
+      volumes:
+        - name: storage
+          persistentVolumeClaim:
+            claimName: minio
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+  namespace: tracing-system
+spec:
+  ports:
+    - port: 9000
+      protocol: TCP
+      targetPort: 9000
+  selector:
+    app.kubernetes.io/name: minio
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio
+  namespace: tracing-system
+stringData:
+  endpoint: http://minio.tracing-system.svc.cluster.local:9000
+  bucket: tempo
+  access_key_id: tempo
+  access_key_secret: supersecret
+type: Opaque

--- a/tests/e2e-openshift-ossm/ossm-tempostack/install-ossm-assert.yaml
+++ b/tests/e2e-openshift-ossm/ossm-tempostack/install-ossm-assert.yaml
@@ -1,0 +1,73 @@
+apiVersion: project.openshift.io/v1
+kind: Project
+metadata:
+  name: istio-system
+spec:
+  finalizers:
+  - kubernetes
+status:
+  phase: Active
+
+---
+apiVersion: project.openshift.io/v1
+kind: Project
+metadata:
+  name: tracing-system
+spec:
+  finalizers:
+  - kubernetes
+status:
+  phase: Active
+
+---
+apiVersion: maistra.io/v2
+kind: ServiceMeshControlPlane
+metadata:
+  name: istio-system
+  namespace: istio-system
+status:
+  readiness:
+    components:
+      pending: []
+      ready:
+      - grafana
+      - istio-discovery
+      - istio-egress
+      - istio-ingress
+      - kiali
+      - mesh-config
+      - prometheus
+      - telemetry-common
+      unready: []
+
+---
+kind: ServiceMeshMemberRoll
+apiVersion: maistra.io/v1
+metadata:
+  name: default
+  namespace: istio-system
+spec:
+  members:
+    - tracing-system
+    - bookinfo
+status:
+  members:
+  - bookinfo
+  - tracing-system
+
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: kiali
+    app.kubernetes.io/instance: kiali
+    app.kubernetes.io/name: kiali
+    app.kubernetes.io/part-of: kiali
+  namespace: istio-system
+status:
+  containerStatuses:
+  - name: kiali
+    ready: true
+    started: true
+  phase: Running

--- a/tests/e2e-openshift-ossm/ossm-tempostack/install-ossm.yaml
+++ b/tests/e2e-openshift-ossm/ossm-tempostack/install-ossm.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: istio-system
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tracing-system
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: bookinfo
+
+---
+apiVersion: maistra.io/v2
+kind: ServiceMeshControlPlane
+metadata:
+  name: istio-system
+  namespace: istio-system
+spec:
+  version: v2.5
+  tracing:
+    type: None
+    sampling: 10000
+  meshConfig:
+    extensionProviders:
+      - name: tempo
+        zipkin:
+          service: tempo-simplest-distributor.tracing-system.svc.cluster.local
+          port: 9411
+  addons:
+    kiali:
+      enabled: true
+      name: kiali
+    grafana:
+      enabled: true
+
+---
+kind: ServiceMeshMemberRoll
+apiVersion: maistra.io/v1
+metadata:
+  name: default
+  namespace: istio-system
+spec:
+  members:
+    - tracing-system
+    - bookinfo

--- a/tests/e2e-openshift-ossm/ossm-tempostack/install-tempo-assert.yaml
+++ b/tests/e2e-openshift-ossm/ossm-tempostack/install-tempo-assert.yaml
@@ -1,0 +1,390 @@
+apiVersion: tempo.grafana.com/v1alpha1
+kind: TempoStack
+metadata:
+  name: simplest
+  namespace: tracing-system
+#
+# Service Accounts
+#
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tempo-simplest
+  namespace: tracing-system
+  labels:
+    app.kubernetes.io/component: serviceaccount
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+#
+# Deployments
+#
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tempo-simplest-query-frontend
+  namespace: tracing-system
+  labels:
+    app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: query-frontend
+      app.kubernetes.io/instance: simplest
+      app.kubernetes.io/managed-by: tempo-operator
+      app.kubernetes.io/name: tempo
+status:
+  readyReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tempo-simplest-distributor
+  namespace: tracing-system
+  labels:
+    app.kubernetes.io/component: distributor
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: distributor
+      app.kubernetes.io/instance: simplest
+      app.kubernetes.io/managed-by: tempo-operator
+      app.kubernetes.io/name: tempo
+status:
+  readyReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tempo-simplest-querier
+  namespace: tracing-system
+  labels:
+    app.kubernetes.io/component: querier
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: querier
+      app.kubernetes.io/instance: simplest
+      app.kubernetes.io/managed-by: tempo-operator
+      app.kubernetes.io/name: tempo
+status:
+  readyReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tempo-simplest-compactor
+  namespace: tracing-system
+  labels:
+    app.kubernetes.io/component: compactor
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: compactor
+      app.kubernetes.io/instance: simplest
+      app.kubernetes.io/managed-by: tempo-operator
+      app.kubernetes.io/name: tempo
+status:
+  readyReplicas: 1
+#
+# StatefulSets
+#
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: tempo-simplest-ingester
+  namespace: tracing-system
+  labels:
+    app.kubernetes.io/component: ingester
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: ingester
+      app.kubernetes.io/instance: simplest
+      app.kubernetes.io/managed-by: tempo-operator
+      app.kubernetes.io/name: tempo
+status:
+  readyReplicas: 1
+#
+# Services
+#
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: compactor
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+  name: tempo-simplest-compactor
+  namespace: tracing-system
+spec:
+  ports:
+    - name: http-memberlist
+      port: 7946
+      protocol: TCP
+      targetPort: http-memberlist
+    - name: http
+      port: 3200
+      protocol: TCP
+      targetPort: http
+  selector:
+    app.kubernetes.io/component: compactor
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: distributor
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+  name: tempo-simplest-distributor
+  namespace: tracing-system
+spec:
+  ports:
+    - name: otlp-grpc
+      port: 4317
+      protocol: TCP
+      targetPort: otlp-grpc
+    - name: http
+      port: 3200
+      protocol: TCP
+      targetPort: http
+    - name: otlp-http
+      port: 4318
+      protocol: TCP
+      targetPort: otlp-http
+    - name: thrift-http
+      port: 14268
+      protocol: TCP
+      targetPort: thrift-http
+    - name: thrift-compact
+      port: 6831
+      protocol: UDP
+      targetPort: thrift-compact
+    - name: thrift-binary
+      port: 6832
+      protocol: UDP
+      targetPort: thrift-binary
+    - name: jaeger-grpc
+      port: 14250
+      protocol: TCP
+      targetPort: jaeger-grpc
+    - name: http-zipkin
+      port: 9411
+      protocol: TCP
+      targetPort: http-zipkin
+  selector:
+    app.kubernetes.io/component: distributor
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: gossip-ring
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+  name: tempo-simplest-gossip-ring
+  namespace: tracing-system
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - name: http-memberlist
+      port: 7946
+      protocol: TCP
+      targetPort: http-memberlist
+  selector:
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+    tempo-gossip-member: "true"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: ingester
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+  name: tempo-simplest-ingester
+  namespace: tracing-system
+spec:
+  ports:
+    - name: http
+      port: 3200
+      protocol: TCP
+      targetPort: http
+    - name: grpc
+      port: 9095
+      protocol: TCP
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/component: ingester
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: querier
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+  name: tempo-simplest-querier
+  namespace: tracing-system
+spec:
+  ports:
+    - name: http-memberlist
+      port: 7946
+      protocol: TCP
+      targetPort: http-memberlist
+    - name: http
+      port: 3200
+      protocol: TCP
+      targetPort: http
+    - name: grpc
+      port: 9095
+      protocol: TCP
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/component: querier
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+  name: tempo-simplest-query-frontend
+  namespace: tracing-system
+spec:
+  ports:
+    - name: http
+      port: 3200
+      protocol: TCP
+      targetPort: http
+    - name: grpc
+      port: 9095
+      protocol: TCP
+      targetPort: grpc
+    - name: jaeger-grpc
+      port: 16685
+      protocol: TCP
+      targetPort: jaeger-grpc
+    - name: jaeger-ui
+      port: 16686
+      protocol: TCP
+      targetPort: jaeger-ui
+    - name: jaeger-metrics
+      port: 16687
+      protocol: TCP
+      targetPort: jaeger-metrics
+  selector:
+    app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: query-frontend-discovery
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+  name: tempo-simplest-query-frontend-discovery
+  namespace: tracing-system
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - name: http
+      port: 3200
+      protocol: TCP
+      targetPort: http
+    - name: grpc
+      port: 9095
+      protocol: TCP
+      targetPort: grpc
+    - name: grpclb
+      port: 9096
+      protocol: TCP
+      targetPort: grpclb
+    - name: jaeger-grpc
+      port: 16685
+      protocol: TCP
+      targetPort: jaeger-grpc
+    - name: jaeger-ui
+      port: 16686
+      protocol: TCP
+      targetPort: jaeger-ui
+    - name: jaeger-metrics
+      port: 16687
+      protocol: TCP
+      targetPort: jaeger-metrics
+  selector:
+    app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+#
+# Route
+#
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: tempo-simplest-query-frontend
+  namespace: tracing-system
+spec:
+  port:
+    targetPort: jaeger-ui
+  tls:
+    termination: edge
+  to:
+    kind: Service
+    name: tempo-simplest-query-frontend
+    weight: 100
+  wildcardPolicy: None
+status:
+  ingress:
+  - conditions:
+    - status: "True"
+      type: Admitted

--- a/tests/e2e-openshift-ossm/ossm-tempostack/install-tempo.yaml
+++ b/tests/e2e-openshift-ossm/ossm-tempostack/install-tempo.yaml
@@ -1,0 +1,22 @@
+apiVersion: tempo.grafana.com/v1alpha1
+kind: TempoStack
+metadata:
+  name: simplest
+  namespace: tracing-system
+spec:
+  storage:
+    secret:
+      name: minio
+      type: s3
+  storageSize: 200M
+  resources:
+    total:
+      limits:
+        memory: 2Gi
+        cpu: 2000m
+  template:
+    queryFrontend:
+      jaegerQuery:
+        enabled: true
+        ingress:
+          type: route

--- a/tests/e2e-openshift-ossm/ossm-tempostack/update-kiali-assert.yaml
+++ b/tests/e2e-openshift-ossm/ossm-tempostack/update-kiali-assert.yaml
@@ -1,0 +1,30 @@
+apiVersion: kiali.io/v1alpha1
+kind: Kiali
+metadata:
+  name: kiali
+  namespace: istio-system
+spec:
+  external_services:
+    tracing:
+      query_timeout: 30
+      enabled: true
+      in_cluster_url: 'http://tempo-simplest-query-frontend.tracing-system.svc.cluster.local:16686'
+      url: '[Tempo query frontend Route url]'
+      use_grpc: false
+
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: kiali
+    app.kubernetes.io/instance: kiali
+    app.kubernetes.io/name: kiali
+    app.kubernetes.io/part-of: kiali
+  namespace: istio-system
+status:
+  containerStatuses:
+  - name: kiali
+    ready: true
+    started: true
+  phase: Running

--- a/tests/e2e-openshift-ossm/ossm-tempostack/update-kiali.yaml
+++ b/tests/e2e-openshift-ossm/ossm-tempostack/update-kiali.yaml
@@ -1,0 +1,13 @@
+apiVersion: kiali.io/v1alpha1
+kind: Kiali
+metadata:
+  name: kiali
+  namespace: istio-system
+spec:
+  external_services:
+    tracing:
+      query_timeout: 30
+      enabled: true
+      in_cluster_url: 'http://tempo-simplest-query-frontend.tracing-system.svc.cluster.local:16686'
+      url: '[Tempo query frontend Route url]'
+      use_grpc: false

--- a/tests/e2e-openshift-ossm/ossm-tempostack/verify-traces-assert.yaml
+++ b/tests/e2e-openshift-ossm/ossm-tempostack/verify-traces-assert.yaml
@@ -1,0 +1,7 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify-traces
+  namespace: istio-system
+status:
+  succeeded: 1

--- a/tests/e2e-openshift-ossm/ossm-tempostack/verify-traces.yaml
+++ b/tests/e2e-openshift-ossm/ossm-tempostack/verify-traces.yaml
@@ -1,0 +1,25 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify-traces
+  namespace: istio-system
+spec:
+  template:
+    spec:
+      serviceAccountName: kiali-service-account
+      containers:
+      - name: verify-traces
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command: ["/bin/bash", "-eux", "-c"]
+        args:
+        - |
+            TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+            KIALI_URL=https://kiali.istio-system.svc.cluster.local:20001
+            START_MICROS=1712566368978000
+            OUTPUT=$(curl -k -H "Authorization: Bearer $TOKEN" "$KIALI_URL/api/namespaces/bookinfo/services/productpage/traces?startMicros=$START_MICROS&tags=&limit=100")
+            if echo "$OUTPUT" | grep -q '"serviceName":"productpage.bookinfo"'; then
+              exit 0
+            else
+              exit 1
+            fi
+      restartPolicy: Never

--- a/tests/e2e-openshift/monolithic-multitenancy-openshift/01-assert.yaml
+++ b/tests/e2e-openshift/monolithic-multitenancy-openshift/01-assert.yaml
@@ -4,6 +4,28 @@ metadata:
   name: tempo-simplest
 status:
   readyReplicas: 1
+
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: tempo-simplest-0
+status:
+  containerStatuses:
+  - name: tempo
+    ready: true
+    started: true
+  - name: tempo-gateway
+    ready: true
+    started: true
+  - name: tempo-gateway-opa
+    ready: true
+    started: true
+  - name: tempo-query
+    ready: true
+    started: true
+  phase: Running
+
 ---
 apiVersion: v1
 kind: Service

--- a/tests/e2e-openshift/monolithic-multitenancy-openshift/02-assert.yaml
+++ b/tests/e2e-openshift/monolithic-multitenancy-openshift/02-assert.yaml
@@ -5,3 +5,16 @@ metadata:
   name: dev-collector
 status:
   readyReplicas: 1
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dev-collector
+spec:
+  ports:
+  - appProtocol: grpc
+    name: otlp-grpc
+    port: 4317
+    protocol: TCP
+    targetPort: 4317

--- a/tests/e2e-openshift/monolithic-multitenancy-openshift/chainsaw-test.yaml
+++ b/tests/e2e-openshift/monolithic-multitenancy-openshift/chainsaw-test.yaml
@@ -31,3 +31,13 @@ spec:
         file: 04-verify-traces.yaml
     - assert:
         file: 04-assert.yaml
+    catch:
+    - events: {}
+    - podLogs:
+        selector: job-name=verify-traces-jaegerui
+        tail: 50
+    - podLogs:
+        selector: job-name=verify-traces-traceql
+        tail: 50
+    - podLogs:
+        selector: app.kubernetes.io/name=tempo-monolithic


### PR DESCRIPTION
* The PR adds interoperability e2e test cases for Tempo and OpenShift Service Mesh. 
Refer [documentation link](https://docs.openshift.com/container-platform/4.15/service_mesh/v2x/ossm-observability.html#ossm-configuring-distr-tracing-tempo_observability) for configuring Distributed Tracing platform Tempo with OSSM.
```
--- PASS: chainsaw (617.47s)
    --- PASS: chainsaw/ossm-monolithic-otel (290.62s)
    --- PASS: chainsaw/ossm-tempostack (326.85s)
PASS
Tests Summary...
- Passed  tests 2
- Failed  tests 0
- Skipped tests 0
Done.
```

Add zipkin receiver support in Tempo Monolithic to work with OpenShift Service Mesh. 
https://issues.redhat.com/browse/TRACING-4129 

* Updated the monolithic-multitenancy-openshift test to print debug logs and events if it fails. The test is working locally and when we execute it from the debug CI env. However it fails during the automated CI run. Need to investigate why. 