### PR TITLE
[chore] e2e: update tempo instance name to avoid race condition

### DIFF
--- a/tests/e2e-openshift/monolithic-multitenancy-openshift/01-assert.yaml
+++ b/tests/e2e-openshift/monolithic-multitenancy-openshift/01-assert.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: tempo-simplest
+  name: tempo-monolithic-multitenancy-openshift
 status:
   readyReplicas: 1
 
@@ -9,7 +9,7 @@ status:
 apiVersion: v1
 kind: Pod
 metadata:
-  name: tempo-simplest-0
+  name: tempo-monolithic-multitenancy-openshift-0
 status:
   containerStatuses:
   - name: tempo
@@ -30,7 +30,7 @@ status:
 apiVersion: v1
 kind: Service
 metadata:
-  name: tempo-simplest-gateway
+  name: tempo-monolithic-multitenancy-openshift-gateway
 spec:
   ports:
   - name: public

--- a/tests/e2e-openshift/monolithic-multitenancy-openshift/01-install-tempo.yaml
+++ b/tests/e2e-openshift/monolithic-multitenancy-openshift/01-install-tempo.yaml
@@ -1,7 +1,7 @@
 apiVersion: tempo.grafana.com/v1alpha1
 kind: TempoMonolithic
 metadata:
-  name: simplest
+  name: monolithic-multitenancy-openshift
 spec:
   jaegerui:
     enabled: true

--- a/tests/e2e-openshift/monolithic-multitenancy-openshift/02-install-otelcol.yaml
+++ b/tests/e2e-openshift/monolithic-multitenancy-openshift/02-install-otelcol.yaml
@@ -15,7 +15,7 @@ spec:
 
     exporters:
       otlp:
-        endpoint: tempo-simplest-gateway.chainsaw-monolithic-multitenancy.svc.cluster.local:4317
+        endpoint: tempo-monolithic-multitenancy-openshift-gateway.chainsaw-monolithic-multitenancy.svc.cluster.local:4317
         tls:
           ca_file: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
         auth:

--- a/tests/e2e-openshift/monolithic-multitenancy-openshift/04-verify-traces.yaml
+++ b/tests/e2e-openshift/monolithic-multitenancy-openshift/04-verify-traces.yaml
@@ -14,7 +14,7 @@ spec:
           curl -vG \
             --header "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
             --cacert /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt \
-            https://tempo-simplest-gateway.chainsaw-monolithic-multitenancy.svc:8080/api/traces/v1/dev/api/traces \
+            https://tempo-monolithic-multitenancy-openshift-gateway.chainsaw-monolithic-multitenancy.svc:8080/api/traces/v1/dev/api/traces \
             --data-urlencode "service=telemetrygen" \
             | tee /tmp/jaeger.out
 
@@ -42,7 +42,7 @@ spec:
             --header "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
             --cacert /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt \
             --data-urlencode 'q={ resource.service.name="telemetrygen" }' \
-            https://tempo-simplest-gateway.chainsaw-monolithic-multitenancy.svc:8080/api/traces/v1/dev/tempo/api/search \
+            https://tempo-monolithic-multitenancy-openshift-gateway.chainsaw-monolithic-multitenancy.svc:8080/api/traces/v1/dev/tempo/api/search \
             | tee /tmp/tempo.out
 
           num_traces=$(jq ".traces | length" /tmp/tempo.out)


### PR DESCRIPTION
All OpenShift multitenancy tests create cluster-scoped resources (e.g. ClusterRole `tempo-<name>-gateway`), therefore we must use unique names across the cluster, otherwise running the e2e test suite in parallel will fail randomly.