### PR TITLE
[Chore] Bump Chainsaw version and update Makefile to add platform var for bundle build. 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -207,7 +207,7 @@ GEN_API_DOCS_VERSION ?= v0.6.0
 ENVTEST_VERSION ?= latest
 OPERATOR_SDK_VERSION ?= 1.32.0
 CERTMANAGER_VERSION ?= 1.9.1
-CHAINSAW_VERSION ?= v0.1.7
+CHAINSAW_VERSION ?= v0.2.0
 
 ## Tool Binaries
 KUSTOMIZE ?= $(LOCALBIN)/kustomize-$(KUSTOMIZE_VERSION)
@@ -259,7 +259,7 @@ bundle:
 
 .PHONY: bundle-build
 bundle-build: ## Build the bundle image.
-	docker build -f $(BUNDLE_DIR)/bundle.Dockerfile -t $(BUNDLE_IMG) $(BUNDLE_DIR)
+	docker buildx build --load --platform linux/${ARCH} -f $(BUNDLE_DIR)/bundle.Dockerfile -t $(BUNDLE_IMG) $(BUNDLE_DIR)
 
 .PHONY: bundle-push
 bundle-push: ## Push the bundle image.

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -16,7 +16,7 @@ RUN curl -LO https://github.com/kudobuilder/kuttl/releases/download/v0.15.0/kube
     && mv kubectl-kuttl_0.15.0_linux_x86_64 /usr/local/bin/kuttl
 
 # Install chainsaw
-RUN go install github.com/kyverno/chainsaw@v0.1.7
+RUN go install github.com/kyverno/chainsaw@v0.2.0
 
 # Install kubectl and oc
 RUN curl -L -o oc.tar.gz https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/latest/openshift-client-linux.tar.gz \


### PR DESCRIPTION
The PR bumps the Chainsaw version to v0.2.0 and adds the platform var in the bundle build, which fixes issues when building on platforms like Mac with Apple Silicon. 