### PR TITLE
[Chore] Add tests for Tempo single tenant oauth

### DIFF
--- a/tests/e2e-openshift/monolithic-route/chainsaw-test.yaml
+++ b/tests/e2e-openshift/monolithic-route/chainsaw-test.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: monolithic-route
+spec:
+  namespace: chainsaw-mono-route
+  steps:
+  - name: Create Tempo Monolithic instance
+    try:
+    - apply:
+        file: install-tempo.yaml
+    - assert:
+        file: install-tempo-assert.yaml

--- a/tests/e2e-openshift/monolithic-route/install-tempo-assert.yaml
+++ b/tests/e2e-openshift/monolithic-route/install-tempo-assert.yaml
@@ -1,0 +1,143 @@
+apiVersion: tempo.grafana.com/v1alpha1
+kind: TempoMonolithic
+metadata:
+  name: mono-route
+  namespace: chainsaw-mono-route
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    app.kubernetes.io/component: tempo
+    app.kubernetes.io/instance: mono-route
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo-monolithic
+  name: tempo-mono-route
+  namespace: chainsaw-mono-route
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: tempo
+      app.kubernetes.io/instance: mono-route
+      app.kubernetes.io/managed-by: tempo-operator
+      app.kubernetes.io/name: tempo-monolithic
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: tempo
+        app.kubernetes.io/instance: mono-route
+        app.kubernetes.io/managed-by: tempo-operator
+        app.kubernetes.io/name: tempo-monolithic
+    spec:
+      containers:
+      - name: tempo
+      - name: tempo-query
+      - args:
+        - --cookie-secret-file=/etc/proxy/cookie//session_secret
+        - --https-address=:8443
+        - --openshift-service-account=tempo-mono-route
+        - --provider=openshift
+        - --tls-cert=/etc/tls/private/tls.crt
+        - --tls-key=/etc/tls/private/tls.key
+        - --upstream=http://localhost:16686
+        - '--openshift-sar={"namespace": "chainsaw-mono-route", "resource": "pods", "verb":
+          "get"}'
+        name: oauth-proxy
+        ports:
+        - containerPort: 8443
+          name: oauth-proxy
+          protocol: TCP
+status:
+  availableReplicas: 1
+  currentReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app.kubernetes.io/component: tempo
+    app.kubernetes.io/instance: mono-route
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo-monolithic
+  namespace: chainsaw-mono-route
+status:
+  containerStatuses:
+  - name: oauth-proxy
+    ready: true
+    started: true
+  - name: tempo
+    ready: true
+    started: true
+  - name: tempo-query
+    ready: true
+    started: true
+  phase: Running
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: tempo
+    app.kubernetes.io/instance: mono-route
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo-monolithic
+  name: tempo-mono-route
+  namespace: chainsaw-mono-route
+spec:
+  ipFamilyPolicy: SingleStack
+  ports:
+  - name: http
+    port: 3200
+    protocol: TCP
+    targetPort: http
+  - name: otlp-grpc
+    port: 4317
+    protocol: TCP
+    targetPort: otlp-grpc
+  - name: otlp-http
+    port: 4318
+    protocol: TCP
+    targetPort: otlp-http
+  selector:
+    app.kubernetes.io/component: tempo
+    app.kubernetes.io/instance: mono-route
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo-monolithic
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: jaegerui
+    app.kubernetes.io/instance: mono-route
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo-monolithic
+  name: tempo-mono-route-jaegerui
+  namespace: chainsaw-mono-route
+spec:
+  ipFamilyPolicy: SingleStack
+  ports:
+  - name: jaeger-grpc
+    port: 16685
+    protocol: TCP
+    targetPort: jaeger-grpc
+  - name: jaeger-ui
+    port: 16686
+    protocol: TCP
+    targetPort: jaeger-ui
+  - name: jaeger-metrics
+    port: 16687
+    protocol: TCP
+    targetPort: jaeger-metrics
+  - name: oauth-proxy
+    port: 8443
+    protocol: TCP
+    targetPort: oauth-proxy
+  selector:
+    app.kubernetes.io/component: tempo
+    app.kubernetes.io/instance: mono-route
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo-monolithic

--- a/tests/e2e-openshift/monolithic-route/install-tempo.yaml
+++ b/tests/e2e-openshift/monolithic-route/install-tempo.yaml
@@ -1,0 +1,10 @@
+apiVersion: tempo.grafana.com/v1alpha1
+kind: TempoMonolithic
+metadata:
+  name: mono-route
+  namespace: chainsaw-mono-route
+spec:
+  jaegerui:
+    enabled: true
+    route:
+      enabled: true

--- a/tests/e2e-openshift/monolithic-single-tenant-auth/chainsaw-test.yaml
+++ b/tests/e2e-openshift/monolithic-single-tenant-auth/chainsaw-test.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: monolithic-single-tenant-auth
+spec:
+  namespace: chainsaw-mst
+  steps:
+  - name: Create Tempo Monolithic instance
+    try:
+    - apply:
+        file: install-tempo.yaml
+    - assert:
+        file: install-tempo-assert.yaml
+  - name: Generate traces
+    try:
+    - apply:
+        file: generate-traces.yaml
+    - assert:
+        file: generate-traces-assert.yaml
+  - name: Verify traces using Jaeger UI
+    try:
+    - apply:
+        file: verify-traces-jaeger.yaml
+    - assert:
+        file: verify-traces-jaeger-assert.yaml
+  - name: Verify traces from TraceQL
+    try:
+    - apply:
+        file: verify-traces-traceql.yaml
+    - assert:
+        file: verify-traces-traceql-assert.yaml

--- a/tests/e2e-openshift/monolithic-single-tenant-auth/generate-traces-assert.yaml
+++ b/tests/e2e-openshift/monolithic-single-tenant-auth/generate-traces-assert.yaml
@@ -1,0 +1,9 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: generate-traces
+  namespace: chainsaw-mst
+status:
+  conditions:
+    - status: "True"
+      type: Complete

--- a/tests/e2e-openshift/monolithic-single-tenant-auth/generate-traces.yaml
+++ b/tests/e2e-openshift/monolithic-single-tenant-auth/generate-traces.yaml
@@ -1,0 +1,18 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: generate-traces
+  namespace: chainsaw-mst
+spec:
+  template:
+    spec:
+      containers:
+      - name: telemetrygen
+        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
+        args:
+        - traces
+        - --otlp-endpoint=tempo-monolithic-st:4317
+        - --otlp-insecure
+        - --traces=10
+      restartPolicy: Never
+  backoffLimit: 4

--- a/tests/e2e-openshift/monolithic-single-tenant-auth/install-tempo-assert.yaml
+++ b/tests/e2e-openshift/monolithic-single-tenant-auth/install-tempo-assert.yaml
@@ -1,0 +1,151 @@
+apiVersion: tempo.grafana.com/v1alpha1
+kind: TempoMonolithic
+metadata:
+  name: monolithic-st
+  namespace: chainsaw-mst
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    app.kubernetes.io/component: tempo
+    app.kubernetes.io/instance: monolithic-st
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo-monolithic
+  name: tempo-monolithic-st
+  namespace: chainsaw-mst
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: tempo
+      app.kubernetes.io/instance: monolithic-st
+      app.kubernetes.io/managed-by: tempo-operator
+      app.kubernetes.io/name: tempo-monolithic
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: tempo
+        app.kubernetes.io/instance: monolithic-st
+        app.kubernetes.io/managed-by: tempo-operator
+        app.kubernetes.io/name: tempo-monolithic
+    spec:
+      containers:
+      - name: tempo
+      - name: tempo-query
+      - args:
+        - --cookie-secret-file=/etc/proxy/cookie//session_secret
+        - --https-address=:8443
+        - --openshift-service-account=tempo-monolithic-st
+        - --provider=openshift
+        - --tls-cert=/etc/tls/private/tls.crt
+        - --tls-key=/etc/tls/private/tls.key
+        - --upstream=http://localhost:16686
+        - '--openshift-sar={"namespace": "chainsaw-mst", "resource": "pods", "verb":
+          "get"}'
+        name: oauth-proxy
+        ports:
+        - containerPort: 8443
+          name: oauth-proxy
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 200m
+            memory: 512Gi
+          requests:
+            cpu: 100m
+            memory: 256Mi
+
+status:
+  availableReplicas: 1
+  currentReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app.kubernetes.io/component: tempo
+    app.kubernetes.io/instance: monolithic-st
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo-monolithic
+  namespace: chainsaw-mst
+status:
+  containerStatuses:
+  - name: oauth-proxy
+    ready: true
+    started: true
+  - name: tempo
+    ready: true
+    started: true
+  - name: tempo-query
+    ready: true
+    started: true
+  phase: Running
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: tempo
+    app.kubernetes.io/instance: monolithic-st
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo-monolithic
+  name: tempo-monolithic-st
+  namespace: chainsaw-mst
+spec:
+  ipFamilyPolicy: SingleStack
+  ports:
+  - name: http
+    port: 3200
+    protocol: TCP
+    targetPort: http
+  - name: otlp-grpc
+    port: 4317
+    protocol: TCP
+    targetPort: otlp-grpc
+  - name: otlp-http
+    port: 4318
+    protocol: TCP
+    targetPort: otlp-http
+  selector:
+    app.kubernetes.io/component: tempo
+    app.kubernetes.io/instance: monolithic-st
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo-monolithic
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: jaegerui
+    app.kubernetes.io/instance: monolithic-st
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo-monolithic
+  name: tempo-monolithic-st-jaegerui
+  namespace: chainsaw-mst
+spec:
+  ipFamilyPolicy: SingleStack
+  ports:
+  - name: jaeger-grpc
+    port: 16685
+    protocol: TCP
+    targetPort: jaeger-grpc
+  - name: jaeger-ui
+    port: 16686
+    protocol: TCP
+    targetPort: jaeger-ui
+  - name: jaeger-metrics
+    port: 16687
+    protocol: TCP
+    targetPort: jaeger-metrics
+  - name: oauth-proxy
+    port: 8443
+    protocol: TCP
+    targetPort: oauth-proxy
+  selector:
+    app.kubernetes.io/component: tempo
+    app.kubernetes.io/instance: monolithic-st
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo-monolithic

--- a/tests/e2e-openshift/monolithic-single-tenant-auth/install-tempo.yaml
+++ b/tests/e2e-openshift/monolithic-single-tenant-auth/install-tempo.yaml
@@ -1,0 +1,20 @@
+apiVersion: tempo.grafana.com/v1alpha1
+kind: TempoMonolithic
+metadata:
+  name: monolithic-st
+  namespace: chainsaw-mst
+spec:
+  jaegerui:
+    enabled: true
+    authentication:
+      enabled: true
+      sar: "{\"namespace\": \"chainsaw-mst\", \"resource\": \"pods\", \"verb\": \"get\"}"
+      resources:
+        limits:
+          cpu: 200m
+          memory: 512Gi
+        requests:
+          cpu: 100m
+          memory: 256Mi
+    route:
+      enabled: true

--- a/tests/e2e-openshift/monolithic-single-tenant-auth/verify-traces-jaeger-assert.yaml
+++ b/tests/e2e-openshift/monolithic-single-tenant-auth/verify-traces-jaeger-assert.yaml
@@ -1,0 +1,9 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify-traces-jaeger
+  namespace: chainsaw-mst
+status:
+  conditions:
+    - status: "True"
+      type: Complete

--- a/tests/e2e-openshift/monolithic-single-tenant-auth/verify-traces-jaeger.yaml
+++ b/tests/e2e-openshift/monolithic-single-tenant-auth/verify-traces-jaeger.yaml
@@ -1,0 +1,25 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify-traces-jaeger
+  namespace: chainsaw-mst
+spec:
+  template:
+    spec:
+      containers:
+      - name: verify-traces
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command: ["/bin/bash", "-eux", "-c"]
+        args:
+        - |
+          curl -vG \
+            http://tempo-monolithic-st-jaegerui.chainsaw-mst.svc:16686/api/traces \
+            --data-urlencode "service=telemetrygen" \
+            | tee /tmp/jaeger.out
+
+          num_traces=$(jq ".data | length" /tmp/jaeger.out)
+          if [[ "$num_traces" != "10" ]]; then
+            echo && echo "The Jaeger API returned $num_traces instead of 10 traces."
+            exit 1
+          fi
+      restartPolicy: Never

--- a/tests/e2e-openshift/monolithic-single-tenant-auth/verify-traces-traceql-assert.yaml
+++ b/tests/e2e-openshift/monolithic-single-tenant-auth/verify-traces-traceql-assert.yaml
@@ -1,0 +1,9 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify-traces-traceql
+  namespace: chainsaw-mst
+status:
+  conditions:
+    - status: "True"
+      type: Complete

--- a/tests/e2e-openshift/monolithic-single-tenant-auth/verify-traces-traceql.yaml
+++ b/tests/e2e-openshift/monolithic-single-tenant-auth/verify-traces-traceql.yaml
@@ -1,0 +1,26 @@
+# Simulate Grafana Dashboard API requests.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify-traces-traceql
+  namespace: chainsaw-mst
+spec:
+  template:
+    spec:
+      containers:
+      - name: verify-traces
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command: ["/bin/bash", "-eux", "-c"]
+        args:
+        - |
+          curl -sS -G \
+            --data-urlencode 'q={ resource.service.name="telemetrygen" }' \
+            http://tempo-monolithic-st.chainsaw-mst.svc:3200/api/search \
+            | tee /tmp/tempo.out
+
+          num_traces=$(jq ".traces | length" /tmp/tempo.out)
+          if [[ "$num_traces" != "10" ]]; then
+            echo && echo "The Tempo API returned $num_traces instead of 10 traces."
+            exit 1
+          fi
+      restartPolicy: Never

--- a/tests/e2e-openshift/tempo-single-tenant-auth/chainsaw-test.yaml
+++ b/tests/e2e-openshift/tempo-single-tenant-auth/chainsaw-test.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: tempo-single-tenant-auth
+spec:
+  namespace: chainsaw-tst
+  steps:
+  - name: Install Minio for object store
+    try:
+    - apply:
+        file: install-storage.yaml
+    - assert:
+        file: install-storage-assert.yaml
+  - name: Create TempoStack instance
+    try:
+    - apply:
+        file: install-tempo.yaml
+    - assert:
+        file: install-tempo-assert.yaml
+  - name: Generate traces
+    try:
+    - apply:
+        file: generate-traces.yaml
+    - assert:
+        file: generate-traces-assert.yaml
+  - name: Verify traces using Jaeger UI
+    try:
+    - apply:
+        file: verify-traces-jaeger.yaml
+    - assert:
+        file: verify-traces-jaeger-assert.yaml
+  - name: Verify traces from TraceQL
+    try:
+    - apply:
+        file: verify-traces-traceql.yaml
+    - assert:
+        file: verify-traces-traceql-assert.yaml

--- a/tests/e2e-openshift/tempo-single-tenant-auth/generate-traces-assert.yaml
+++ b/tests/e2e-openshift/tempo-single-tenant-auth/generate-traces-assert.yaml
@@ -1,0 +1,9 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: generate-traces
+  namespace: chainsaw-tst
+status:
+  conditions:
+    - status: "True"
+      type: Complete

--- a/tests/e2e-openshift/tempo-single-tenant-auth/generate-traces.yaml
+++ b/tests/e2e-openshift/tempo-single-tenant-auth/generate-traces.yaml
@@ -1,0 +1,18 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: generate-traces
+  namespace: chainsaw-tst
+spec:
+  template:
+    spec:
+      containers:
+      - name: telemetrygen
+        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
+        args:
+        - traces
+        - --otlp-endpoint=tempo-tempo-st-distributor:4317
+        - --otlp-insecure
+        - --traces=10
+      restartPolicy: Never
+  backoffLimit: 4

--- a/tests/e2e-openshift/tempo-single-tenant-auth/install-storage-assert.yaml
+++ b/tests/e2e-openshift/tempo-single-tenant-auth/install-storage-assert.yaml
@@ -1,0 +1,7 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+  namespace: chainsaw-tst
+status:
+  readyReplicas: 1

--- a/tests/e2e-openshift/tempo-single-tenant-auth/install-storage.yaml
+++ b/tests/e2e-openshift/tempo-single-tenant-auth/install-storage.yaml
@@ -1,0 +1,79 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app.kubernetes.io/name: minio
+  name: minio
+  namespace: chainsaw-tst
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+  namespace: chainsaw-tst
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: minio
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: minio
+    spec:
+      containers:
+        - command:
+            - /bin/sh
+            - -c
+            - |
+              mkdir -p /storage/tempo && \
+              minio server /storage
+          env:
+            - name: MINIO_ACCESS_KEY
+              value: tempo
+            - name: MINIO_SECRET_KEY
+              value: supersecret
+          image: minio/minio
+          name: minio
+          ports:
+            - containerPort: 9000
+          volumeMounts:
+            - mountPath: /storage
+              name: storage
+      volumes:
+        - name: storage
+          persistentVolumeClaim:
+            claimName: minio
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+  namespace: chainsaw-tst
+spec:
+  ports:
+    - port: 9000
+      protocol: TCP
+      targetPort: 9000
+  selector:
+    app.kubernetes.io/name: minio
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio
+  namespace: chainsaw-tst
+stringData:
+  endpoint: http://minio:9000
+  bucket: tempo
+  access_key_id: tempo
+  access_key_secret: supersecret
+type: Opaque

--- a/tests/e2e-openshift/tempo-single-tenant-auth/install-tempo-assert.yaml
+++ b/tests/e2e-openshift/tempo-single-tenant-auth/install-tempo-assert.yaml
@@ -1,0 +1,417 @@
+apiVersion: tempo.grafana.com/v1alpha1
+kind: TempoStack
+metadata:
+  name: tempo-st
+#
+# Service Accounts
+#
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tempo-tempo-st
+  labels:
+    app.kubernetes.io/component: serviceaccount
+    app.kubernetes.io/instance: tempo-st
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+#
+# Deployments
+#
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/instance: tempo-st
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+  name: tempo-tempo-st-query-frontend
+  namespace: chainsaw-tst
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: query-frontend
+      app.kubernetes.io/instance: tempo-st
+      app.kubernetes.io/managed-by: tempo-operator
+      app.kubernetes.io/name: tempo
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: query-frontend
+        app.kubernetes.io/instance: tempo-st
+        app.kubernetes.io/managed-by: tempo-operator
+        app.kubernetes.io/name: tempo
+        tempo-gossip-member: "true"
+    spec:
+      containers:
+      - name: tempo
+      - name: tempo-query
+      - args:
+        - --cookie-secret-file=/etc/proxy/cookie//session_secret
+        - --https-address=:8443
+        - --openshift-service-account=tempo-tempo-st-query-frontend
+        - --provider=openshift
+        - --tls-cert=/etc/tls/private/tls.crt
+        - --tls-key=/etc/tls/private/tls.key
+        - --upstream=http://localhost:16686
+        - '--openshift-sar={"namespace": "chainsaw-mst", "resource": "pods", "verb":
+          "get"}'
+        name: oauth-proxy
+        ports:
+        - containerPort: 8443
+          name: oauth-proxy
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 200m
+            memory: 512Gi
+          requests:
+            cpu: 100m
+            memory: 256Mi
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tempo-tempo-st-distributor
+  labels:
+    app.kubernetes.io/component: distributor
+    app.kubernetes.io/instance: tempo-st
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: distributor
+      app.kubernetes.io/instance: tempo-st
+      app.kubernetes.io/managed-by: tempo-operator
+      app.kubernetes.io/name: tempo
+status:
+  readyReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tempo-tempo-st-querier
+  labels:
+    app.kubernetes.io/component: querier
+    app.kubernetes.io/instance: tempo-st
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: querier
+      app.kubernetes.io/instance: tempo-st
+      app.kubernetes.io/managed-by: tempo-operator
+      app.kubernetes.io/name: tempo
+status:
+  readyReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tempo-tempo-st-compactor
+  labels:
+    app.kubernetes.io/component: compactor
+    app.kubernetes.io/instance: tempo-st
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: compactor
+      app.kubernetes.io/instance: tempo-st
+      app.kubernetes.io/managed-by: tempo-operator
+      app.kubernetes.io/name: tempo
+status:
+  readyReplicas: 1
+#
+# StatefulSets
+#
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: tempo-tempo-st-ingester
+  labels:
+    app.kubernetes.io/component: ingester
+    app.kubernetes.io/instance: tempo-st
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: ingester
+      app.kubernetes.io/instance: tempo-st
+      app.kubernetes.io/managed-by: tempo-operator
+      app.kubernetes.io/name: tempo
+status:
+  readyReplicas: 1
+#
+# Services
+#
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: compactor
+    app.kubernetes.io/instance: tempo-st
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+  name: tempo-tempo-st-compactor
+spec:
+  ports:
+    - name: http-memberlist
+      port: 7946
+      protocol: TCP
+      targetPort: http-memberlist
+    - name: http
+      port: 3200
+      protocol: TCP
+      targetPort: http
+  selector:
+    app.kubernetes.io/component: compactor
+    app.kubernetes.io/instance: tempo-st
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: distributor
+    app.kubernetes.io/instance: tempo-st
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+  name: tempo-tempo-st-distributor
+spec:
+  ports:
+    - name: otlp-grpc
+      port: 4317
+      protocol: TCP
+      targetPort: otlp-grpc
+    - name: http
+      port: 3200
+      protocol: TCP
+      targetPort: http
+    - name: otlp-http
+      port: 4318
+      protocol: TCP
+      targetPort: otlp-http
+    - name: thrift-http
+      port: 14268
+      protocol: TCP
+      targetPort: thrift-http
+    - name: thrift-compact
+      port: 6831
+      protocol: UDP
+      targetPort: thrift-compact
+    - name: thrift-binary
+      port: 6832
+      protocol: UDP
+      targetPort: thrift-binary
+    - name: jaeger-grpc
+      port: 14250
+      protocol: TCP
+      targetPort: jaeger-grpc
+    - name: http-zipkin
+      port: 9411
+      protocol: TCP
+      targetPort: http-zipkin
+  selector:
+    app.kubernetes.io/component: distributor
+    app.kubernetes.io/instance: tempo-st
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: gossip-ring
+    app.kubernetes.io/instance: tempo-st
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+  name: tempo-tempo-st-gossip-ring
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - name: http-memberlist
+      port: 7946
+      protocol: TCP
+      targetPort: http-memberlist
+  selector:
+    app.kubernetes.io/instance: tempo-st
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+    tempo-gossip-member: "true"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: ingester
+    app.kubernetes.io/instance: tempo-st
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+  name: tempo-tempo-st-ingester
+spec:
+  ports:
+    - name: http
+      port: 3200
+      protocol: TCP
+      targetPort: http
+    - name: grpc
+      port: 9095
+      protocol: TCP
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/component: ingester
+    app.kubernetes.io/instance: tempo-st
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: querier
+    app.kubernetes.io/instance: tempo-st
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+  name: tempo-tempo-st-querier
+spec:
+  ports:
+    - name: http-memberlist
+      port: 7946
+      protocol: TCP
+      targetPort: http-memberlist
+    - name: http
+      port: 3200
+      protocol: TCP
+      targetPort: http
+    - name: grpc
+      port: 9095
+      protocol: TCP
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/component: querier
+    app.kubernetes.io/instance: tempo-st
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/instance: tempo-st
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+  name: tempo-tempo-st-query-frontend
+  namespace: chainsaw-tst
+spec:
+  ports:
+  - name: http
+    port: 3200
+    protocol: TCP
+    targetPort: http
+  - name: grpc
+    port: 9095
+    protocol: TCP
+    targetPort: grpc
+  - name: jaeger-grpc
+    port: 16685
+    protocol: TCP
+    targetPort: jaeger-grpc
+  - name: jaeger-ui
+    port: 16686
+    protocol: TCP
+    targetPort: jaeger-ui
+  - name: jaeger-metrics
+    port: 16687
+    protocol: TCP
+    targetPort: jaeger-metrics
+  - name: oauth-proxy
+    port: 8443
+    protocol: TCP
+    targetPort: oauth-proxy
+  selector:
+    app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/instance: tempo-st
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: query-frontend-discovery
+    app.kubernetes.io/instance: tempo-st
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+  name: tempo-tempo-st-query-frontend-discovery
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - name: http
+      port: 3200
+      protocol: TCP
+      targetPort: http
+    - name: grpc
+      port: 9095
+      protocol: TCP
+      targetPort: grpc
+    - name: grpclb
+      port: 9096
+      protocol: TCP
+      targetPort: grpclb
+    - name: jaeger-grpc
+      port: 16685
+      protocol: TCP
+      targetPort: jaeger-grpc
+    - name: jaeger-ui
+      port: 16686
+      protocol: TCP
+      targetPort: jaeger-ui
+    - name: jaeger-metrics
+      port: 16687
+      protocol: TCP
+      targetPort: jaeger-metrics
+  selector:
+    app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/instance: tempo-st
+    app.kubernetes.io/managed-by: tempo-operator
+#
+# Ingresses
+#
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  labels:
+    app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/instance: tempo-st
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+  name: tempo-tempo-st-query-frontend
+  namespace: chainsaw-tst
+spec:
+  port:
+    targetPort: oauth-proxy
+  tls:
+    termination: reencrypt
+  to:
+    kind: Service
+    name: tempo-tempo-st-query-frontend
+    weight: 100

--- a/tests/e2e-openshift/tempo-single-tenant-auth/install-tempo.yaml
+++ b/tests/e2e-openshift/tempo-single-tenant-auth/install-tempo.yaml
@@ -1,0 +1,32 @@
+apiVersion: tempo.grafana.com/v1alpha1
+kind: TempoStack
+metadata:
+  name: tempo-st
+  namespace: chainsaw-tst
+spec:
+  storage:
+    secret:
+      name: minio
+      type: s3
+  storageSize: 200M
+  resources:
+    total:
+      limits:
+        memory: 2Gi
+        cpu: 2000m
+  template:
+    queryFrontend:
+      jaegerQuery:
+        enabled: true
+        authentication:
+          enabled: true
+          sar: "{\"namespace\": \"chainsaw-mst\", \"resource\": \"pods\", \"verb\": \"get\"}"
+          resources:
+            limits:
+              cpu: 200m
+              memory: 512Gi
+            requests:
+              cpu: 100m
+              memory: 256Mi
+        ingress:
+          type: route

--- a/tests/e2e-openshift/tempo-single-tenant-auth/verify-traces-jaeger-assert.yaml
+++ b/tests/e2e-openshift/tempo-single-tenant-auth/verify-traces-jaeger-assert.yaml
@@ -1,0 +1,9 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify-traces-jaeger
+  namespace: chainsaw-tst
+status:
+  conditions:
+    - status: "True"
+      type: Complete

--- a/tests/e2e-openshift/tempo-single-tenant-auth/verify-traces-jaeger.yaml
+++ b/tests/e2e-openshift/tempo-single-tenant-auth/verify-traces-jaeger.yaml
@@ -1,0 +1,25 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify-traces-jaeger
+  namespace: chainsaw-tst
+spec:
+  template:
+    spec:
+      containers:
+      - name: verify-traces
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command: ["/bin/bash", "-eux", "-c"]
+        args:
+        - |
+          curl -vG \
+            http://tempo-tempo-st-query-frontend.chainsaw-tst.svc:16686/api/traces \
+            --data-urlencode "service=telemetrygen" \
+            | tee /tmp/jaeger.out
+
+          num_traces=$(jq ".data | length" /tmp/jaeger.out)
+          if [[ "$num_traces" != "10" ]]; then
+            echo && echo "The Jaeger API returned $num_traces instead of 10 traces."
+            exit 1
+          fi
+      restartPolicy: Never

--- a/tests/e2e-openshift/tempo-single-tenant-auth/verify-traces-traceql-assert.yaml
+++ b/tests/e2e-openshift/tempo-single-tenant-auth/verify-traces-traceql-assert.yaml
@@ -1,0 +1,9 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify-traces-traceql
+  namespace: chainsaw-tst
+status:
+  conditions:
+    - status: "True"
+      type: Complete

--- a/tests/e2e-openshift/tempo-single-tenant-auth/verify-traces-traceql.yaml
+++ b/tests/e2e-openshift/tempo-single-tenant-auth/verify-traces-traceql.yaml
@@ -1,0 +1,26 @@
+# Simulate Grafana Dashboard API requests.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify-traces-traceql
+  namespace: chainsaw-tst
+spec:
+  template:
+    spec:
+      containers:
+      - name: verify-traces
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command: ["/bin/bash", "-eux", "-c"]
+        args:
+        - |
+          curl -sS -G \
+            --data-urlencode 'q={ resource.service.name="telemetrygen" }' \
+            http://tempo-tempo-st-query-frontend.chainsaw-tst.svc:3200/api/search \
+            | tee /tmp/tempo.out
+
+          num_traces=$(jq ".traces | length" /tmp/tempo.out)
+          if [[ "$num_traces" != "10" ]]; then
+            echo && echo "The Tempo API returned $num_traces instead of 10 traces."
+            exit 1
+          fi
+      restartPolicy: Never


### PR DESCRIPTION
* Add test cases for TempoStack and Monolithic Tempo with single tenant oauth. 
* Add test case for Monolithic instance with route enabled and check the Monolithic instance enables oauth by default.

Tested on OpenShift 4.14

```
--- PASS: chainsaw (1503.82s)
    --- PASS: chainsaw/ossm-monolithic-otel (328.39s)
    --- PASS: chainsaw/ossm-tempostack (349.48s)
    --- PASS: chainsaw/ossm-tempostack-otel (393.22s)
    --- PASS: chainsaw/monitoring (206.07s)
    --- PASS: chainsaw/red-metrics (226.67s)
    --- PASS: chainsaw/monolithic-route (76.89s)
    --- PASS: chainsaw/monolithic-memory (97.02s)
    --- PASS: chainsaw/monolithic-ingestion-mtls (99.34s)
    --- PASS: chainsaw/monolithic-multitenancy-openshift (99.34s)
    --- PASS: chainsaw/monolithic-single-tenant-auth (109.93s)
    --- PASS: chainsaw/route (147.23s)
    --- PASS: chainsaw/tempo-single-tenant-auth (157.33s)
    --- PASS: chainsaw/receivers-mtls (159.77s)
    --- PASS: chainsaw/monolithic-multitenancy-static (110.21s)
    --- PASS: chainsaw/gateway (67.53s)
    --- PASS: chainsaw/generate (68.82s)
    --- PASS: chainsaw/monolithic-s3-tls (122.78s)
    --- PASS: chainsaw/reconcile (134.38s)
    --- PASS: chainsaw/multitenancy (166.46s)
    --- PASS: chainsaw/receivers-tls (171.47s)
    --- PASS: chainsaw/monolithic-pv (114.97s)
    --- PASS: chainsaw/custom-ca (147.15s)
    --- PASS: chainsaw/compatibility (158.69s)
PASS
Tests Summary...
- Passed  tests 23
- Failed  tests 0
- Skipped tests 0
Done.

```
