### PR TITLE
[Chore] FIx tests querying OpenShift user workload monitoring stack

### DIFF
--- a/tests/e2e-openshift/monitoring/check_metrics.sh
+++ b/tests/e2e-openshift/monitoring/check_metrics.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-SECRET=$(oc get secret -n openshift-user-workload-monitoring | grep prometheus-user-workload-token | head -n 1 | awk '{print $1}')
-TOKEN=$(echo $(oc get secret $SECRET -n openshift-user-workload-monitoring -o json | jq -r '.data.token') | base64 -d)
+TOKEN=$(oc create token prometheus-user-workload -n openshift-user-workload-monitoring)
 THANOS_QUERIER_HOST=$(oc get route thanos-querier -n openshift-monitoring -o json | jq -r '.spec.host')
 
 #Check metrics used in the prometheus rules created for TempoStack. Refer issue https://issues.redhat.com/browse/TRACING-3399 for skipped metrics.

--- a/tests/e2e-openshift/red-metrics/check_metrics.sh
+++ b/tests/e2e-openshift/red-metrics/check_metrics.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-SECRET=$(oc get secret -n openshift-user-workload-monitoring | grep prometheus-user-workload-token | head -n 1 | awk '{print $1}')
-TOKEN=$(echo $(oc get secret $SECRET -n openshift-user-workload-monitoring -o json | jq -r '.data.token') | base64 -d)
+TOKEN=$(oc create token prometheus-user-workload -n openshift-user-workload-monitoring)
 THANOS_QUERIER_HOST=$(oc get route thanos-querier -n openshift-monitoring -o json | jq -r '.spec.host')
 
 #Check metrics used in the prometheus rules created for TempoStack. Refer issue https://issues.redhat.com/browse/TRACING-3399 for skipped metrics.


### PR DESCRIPTION
In OpenShift 4.16 tokens for service account are not generated by default and we have to now use the TokenRequest API to create token. The PR fixes the check_metrics.sh script to create a token from prometheus-user-workload SA. Tested on OpenShift 4.16 and 4.15

```
--- PASS: chainsaw (1680.86s)
    --- PASS: chainsaw/ossm-monolithic-otel (455.74s)
    --- PASS: chainsaw/ossm-tempostack (368.49s)
    --- PASS: chainsaw/ossm-tempostack-otel (404.15s)
    --- PASS: chainsaw/monitoring (215.61s)
    --- PASS: chainsaw/red-metrics (236.87s)
    --- PASS: chainsaw/route (51.14s)
    --- PASS: chainsaw/gateway (68.05s)
    --- PASS: chainsaw/monolithic-multitenancy-openshift (115.89s)
    --- PASS: chainsaw/monolithic-memory (116.76s)
    --- PASS: chainsaw/monolithic-pv (120.70s)
    --- PASS: chainsaw/monolithic-s3-tls (128.72s)
    --- PASS: chainsaw/reconcile (148.41s)
    --- PASS: chainsaw/receivers-tls (166.55s)
    --- PASS: chainsaw/generate (80.47s)
    --- PASS: chainsaw/custom-ca (163.19s)
    --- PASS: chainsaw/monolithic-route (94.97s)
    --- PASS: chainsaw/compatibility (179.55s)
    --- PASS: chainsaw/monolithic-ingestion-mtls (135.85s)
    --- PASS: chainsaw/tempo-single-tenant-auth (180.16s)
    --- PASS: chainsaw/receivers-mtls (183.40s)
    --- PASS: chainsaw/monolithic-single-tenant-auth (116.72s)
    --- PASS: chainsaw/monolithic-multitenancy-static (113.36s)
    --- PASS: chainsaw/multitenancy (181.94s)
PASS
Tests Summary...
- Passed  tests 23
- Failed  tests 0
- Skipped tests 0
Done.
```