### PR TITLE
[chore] fix upgrade e2e test

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -108,7 +108,7 @@ jobs:
     - name: Build and push operator and bundle image to local container registry
       run: |
         make opm
-        export LATEST_VERSION=$(bin/opm render quay.io/operatorhubio/catalog:latest | grep tempo-operator:v | tail -1 | grep -oP 'v.*(?=")')
+        export LATEST_VERSION=$(bin/opm render quay.io/operatorhubio/catalog:latest | grep ghcr.io/grafana/tempo-operator/tempo-operator:v | sort -V | tail -1 | grep -oP 'v.*(?=")')
         export BUNDLE_IMGS=ghcr.io/grafana/tempo-operator/tempo-operator-bundle:${LATEST_VERSION},${IMG_PREFIX}/tempo-operator-bundle:v${OPERATOR_VERSION}
         make bundle docker-build docker-push bundle-build bundle-push catalog-build catalog-push
       env:

--- a/tests/e2e-upgrade/upgrade/README.md
+++ b/tests/e2e-upgrade/upgrade/README.md
@@ -21,7 +21,7 @@ make olm-install
 
 export IMG_PREFIX=docker.io/${USER}  # specify a container registry with push permissions
 export OPERATOR_VERSION=100.0.0
-export LATEST_VERSION=$(bin/opm render quay.io/operatorhubio/catalog:latest | grep tempo-operator:v | tail -1 | grep -oP 'v.*(?=")')
+export LATEST_VERSION=$(bin/opm render quay.io/operatorhubio/catalog:latest | grep ghcr.io/grafana/tempo-operator/tempo-operator:v | sort -V | tail -1 | grep -oP 'v.*(?=")')
 export BUNDLE_IMGS=ghcr.io/grafana/tempo-operator/tempo-operator-bundle:${LATEST_VERSION},${IMG_PREFIX}/tempo-operator-bundle:v${OPERATOR_VERSION}
 make bundle docker-build docker-push bundle-build bundle-push catalog-build catalog-push
 


### PR DESCRIPTION
The test retrieved the wrong version (0.10.0 comes before 0.8.0 when sorting alphabetically), built a bundle with the wrong version, and then OLM could not determine an upgrade path.