### PR TITLE
[Chore] Bump Golang version to 1.22 for OCP CI tests runner image

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,6 +1,6 @@
 # The Dockerfile's resulting image is purpose-built for executing Tempo Operator e2e tests within the OpenShift release (https://github.com/openshift/release) using Prow CI. 
 
-FROM golang:1.21
+FROM golang:1.22
 
 # Copy the repository files
 COPY . /tmp/tempo-operator


### PR DESCRIPTION
The PR bumps Golang version to 1.22 for tests/Dockerfile