### PR TITLE
[Chore] Fix Golang version in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/tempo-operator
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.1


### PR DESCRIPTION
The PR fixes the Golang version in go.mod as the wrong version is causing our rebase job on the fork to [fail](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-eng-rebasebot-main-tempo-operator/1808092991135420416/artifacts/tempo-operator/tempo-operator/build-log.txt)