### PR TITLE
Add support for AWS STS

### DIFF
--- a/.chloggen/aws-sts-monolithic.yaml
+++ b/.chloggen/aws-sts-monolithic.yaml
@@ -1,0 +1,23 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. tempostack, tempomonolithic, github action)
+component: tempostack
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add support for AWS S3 STS authentication.
+
+# One or more tracking issues related to the change
+issues: [978]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Now storage secret for S3 can contain
+  ```
+  data:
+    bucket:      # Bucket name
+    region:      # A valid AWS region, e.g. us-east-1
+    role_arn:    # The AWS IAM Role associated with a trust relationship to Tempo serviceaccount
+  ```

--- a/.chloggen/aws-sts-tempostack.yaml
+++ b/.chloggen/aws-sts-tempostack.yaml
@@ -1,0 +1,23 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. tempostack, tempomonolithic, github action)
+component: tempostack
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add support for AWS S3 STS authentication.
+
+# One or more tracking issues related to the change
+issues: [978]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: | 
+  Now storage secret for S3 can contain
+  ```
+  data:
+    bucket:      # Bucket name
+    region:      # A valid AWS region, e.g. us-east-1
+    role_arn:    # The AWS IAM Role associated with a trust relationship to Tempo serviceaccount
+  ```

--- a/cmd/generate/main.go
+++ b/cmd/generate/main.go
@@ -189,8 +189,10 @@ func NewGenerateCommand() *cobra.Command {
 				}
 			case s3Endpoint != "":
 				params.StorageParams.S3 = &manifestutils.S3{
-					Endpoint: s3Endpoint,
-					Bucket:   s3Bucket,
+					LongLived: &manifestutils.S3LongLived{
+						Endpoint: s3Endpoint,
+						Bucket:   s3Bucket,
+					},
 				}
 			}
 

--- a/internal/handlers/storage/secret.go
+++ b/internal/handlers/storage/secret.go
@@ -45,7 +45,7 @@ func ensureNotEmpty(storageSecret corev1.Secret, fields []string, path *field.Pa
 }
 
 func validateS3Secret(storageSecret corev1.Secret, path *field.Path) field.ErrorList {
-	if storageSecret.Data["role_arn"] != nil {
+	if storageSecret.Data["role_arn"] != nil || storageSecret.Data["region"] != nil {
 		secretFieldsShortLived := []string{
 			"bucket",
 			"region",
@@ -86,7 +86,7 @@ func getS3Params(storageSecret corev1.Secret, path *field.Path) (*manifestutils.
 		return nil, errs
 	}
 
-	if storageSecret.Data["role_arn"] != nil {
+	if storageSecret.Data["role_arn"] != nil || storageSecret.Data["region"] != nil {
 		return &manifestutils.S3{
 			ShortLived: &manifestutils.S3ShortLived{
 				Bucket:  string(storageSecret.Data["bucket"]),

--- a/internal/handlers/storage/secret_test.go
+++ b/internal/handlers/storage/secret_test.go
@@ -19,9 +19,9 @@ func TestGetS3ParamsInsecure(t *testing.T) {
 
 	s3, errs := getS3Params(storageSecret, nil)
 	require.Len(t, errs, 0)
-	require.Equal(t, "minio:9000", s3.Endpoint)
-	require.True(t, s3.Insecure)
-	require.Equal(t, "testbucket", s3.Bucket)
+	require.Equal(t, "minio:9000", s3.LongLived.Endpoint)
+	require.True(t, s3.LongLived.Insecure)
+	require.Equal(t, "testbucket", s3.LongLived.Bucket)
 }
 
 func TestGetS3ParamsSecure(t *testing.T) {
@@ -36,7 +36,7 @@ func TestGetS3ParamsSecure(t *testing.T) {
 
 	s3, errs := getS3Params(storageSecret, nil)
 	require.Len(t, errs, 0)
-	require.Equal(t, "minio:9000", s3.Endpoint)
-	require.False(t, s3.Insecure)
-	require.Equal(t, "testbucket", s3.Bucket)
+	require.Equal(t, "minio:9000", s3.LongLived.Endpoint)
+	require.False(t, s3.LongLived.Insecure)
+	require.Equal(t, "testbucket", s3.LongLived.Bucket)
 }

--- a/internal/handlers/storage/secret_test.go
+++ b/internal/handlers/storage/secret_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/grafana/tempo-operator/internal/manifests/manifestutils"
 )
 
 func TestGetS3ParamsInsecure(t *testing.T) {
@@ -39,4 +41,22 @@ func TestGetS3ParamsSecure(t *testing.T) {
 	require.Equal(t, "minio:9000", s3.LongLived.Endpoint)
 	require.False(t, s3.LongLived.Insecure)
 	require.Equal(t, "testbucket", s3.LongLived.Bucket)
+}
+
+func TestGetS3Params_short_lived(t *testing.T) {
+	storageSecret := corev1.Secret{
+		Data: map[string][]byte{
+			"bucket":   []byte("testbucket"),
+			"role_arn": []byte("abc"),
+			"region":   []byte("rrrr"),
+		},
+	}
+
+	s3, errs := getS3Params(storageSecret, nil)
+	require.Len(t, errs, 0)
+	require.Equal(t, &manifestutils.S3ShortLived{
+		Bucket:  "testbucket",
+		RoleARN: "abc",
+		Region:  "rrrr",
+	}, s3.ShortLived)
 }

--- a/internal/handlers/storage/storage.go
+++ b/internal/handlers/storage/storage.go
@@ -32,7 +32,7 @@ func GetStorageParamsForTempoStack(ctx context.Context, client client.Client, te
 		}
 
 		if tempo.Spec.Storage.TLS.Enabled {
-			storageParams.S3.TLS, errs = getTLSParams(ctx, client, tempo.Namespace, tempo.Spec.Storage.TLS, tlsPath.Child("caName"))
+			storageParams.S3.LongLived.TLS, errs = getTLSParams(ctx, client, tempo.Namespace, tempo.Spec.Storage.TLS, tlsPath.Child("caName"))
 			if len(errs) > 0 {
 				return manifestutils.StorageParams{}, errs
 			}
@@ -115,7 +115,7 @@ func GetStorageParamsForTempoMonolithic(ctx context.Context, client client.Clien
 
 		if tempo.Spec.Storage.Traces.S3.TLS != nil && tempo.Spec.Storage.Traces.S3.TLS.Enabled {
 			caPath := tracesPath.Child("s3", "tls", "caName")
-			storageParams.S3.TLS, errs = getTLSParams(ctx, client, tempo.Namespace, *tempo.Spec.Storage.Traces.S3.TLS, caPath)
+			storageParams.S3.LongLived.TLS, errs = getTLSParams(ctx, client, tempo.Namespace, *tempo.Spec.Storage.Traces.S3.TLS, caPath)
 			if len(errs) > 0 {
 				return manifestutils.StorageParams{}, errs
 			}

--- a/internal/manifests/compactor/compactor.go
+++ b/internal/manifests/compactor/compactor.go
@@ -142,7 +142,7 @@ func deployment(params manifestutils.Params) (*v1.Deployment, error) {
 		},
 	}
 
-	err := manifestutils.ConfigureStorage(tempo, &d.Spec.Template.Spec, "tempo")
+	err := manifestutils.ConfigureStorage(params.StorageParams, tempo, &d.Spec.Template.Spec, "tempo")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/manifests/config/build.go
+++ b/internal/manifests/config/build.go
@@ -128,7 +128,7 @@ func buildS3StorageTLSConfig(params manifestutils.Params) storageTLSOptions {
 		MinTLSVersion: params.Tempo.Spec.Storage.TLS.MinVersion,
 	}
 	if tempo.Spec.Storage.TLS.CA != "" {
-		opts.CA = path.Join(manifestutils.StorageTLSCADir, params.StorageParams.S3.TLS.CAFilename)
+		opts.CA = path.Join(manifestutils.StorageTLSCADir, params.StorageParams.S3.LongLived.TLS.CAFilename)
 	}
 	if tempo.Spec.Storage.TLS.Cert != "" {
 		opts.Certificate = path.Join(manifestutils.StorageTLSCertDir, manifestutils.TLSCertFilename)

--- a/internal/manifests/config/build_test.go
+++ b/internal/manifests/config/build_test.go
@@ -2408,3 +2408,115 @@ query_frontend:
 	}
 
 }
+
+func TestBuildConfiguration_S3_short_lived(t *testing.T) {
+	expCfg := `
+---
+compactor:
+  compaction:
+    block_retention: 48h0m0s
+  ring:
+    kvstore:
+      store: memberlist
+distributor:
+  receivers:
+    jaeger:
+      protocols:
+        thrift_http:
+          endpoint: 0.0.0.0:14268
+        thrift_binary:
+          endpoint: 0.0.0.0:6832
+        thrift_compact:
+          endpoint: 0.0.0.0:6831
+        grpc:
+          endpoint: 0.0.0.0:14250
+    zipkin:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: "0.0.0.0:4317"
+        http:
+          endpoint: "0.0.0.0:4318"
+  ring:
+    kvstore:
+      store: memberlist
+ingester:
+  lifecycler:
+    ring:
+      kvstore:
+        store: memberlist
+      replication_factor: 1
+    tokens_file_path: /var/tempo/tokens.json
+  max_block_duration: 10m
+memberlist:
+  abort_if_cluster_join_fails: false
+  join_members:
+    - tempo-test-gossip-ring
+multitenancy_enabled: false
+querier:
+  max_concurrent_queries: 20
+  search:
+    external_hedge_requests_at: 8s
+    external_hedge_requests_up_to: 2
+  frontend_worker:
+    frontend_address: "tempo-test-query-frontend-discovery:9095"
+server:
+  grpc_server_max_recv_msg_size: 4194304
+  grpc_server_max_send_msg_size: 4194304
+  http_listen_port: 3200
+  http_server_read_timeout: 3m
+  http_server_write_timeout: 3m
+  log_format: logfmt
+storage:
+  trace:
+    backend: s3
+    blocklist_poll: 5m
+    cache: none
+    local:
+      path: /var/tempo/traces
+    s3:
+      bucket: tempo
+      endpoint: "s3.us-east-2.amazonaws.com"
+    wal:
+      path: /var/tempo/wal
+usage_report:
+  reporting_enabled: false
+query_frontend:
+  search:
+    concurrent_jobs: 2000
+    max_duration: 0s
+`
+	cfg, err := buildConfiguration(manifestutils.Params{
+		Tempo: v1alpha1.TempoStack{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test",
+			},
+			Spec: v1alpha1.TempoStackSpec{
+				Storage: v1alpha1.ObjectStorageSpec{
+					Secret: v1alpha1.ObjectStorageSecretSpec{
+						Type: v1alpha1.ObjectStorageSecretS3,
+					},
+				},
+				ReplicationFactor: 1,
+				Retention: v1alpha1.RetentionSpec{
+					Global: v1alpha1.RetentionConfig{
+						Traces: metav1.Duration{Duration: 48 * time.Hour},
+					},
+				},
+			},
+		},
+		StorageParams: manifestutils.StorageParams{
+			S3: &manifestutils.S3{
+				ShortLived: &manifestutils.S3ShortLived{
+					Bucket: "tempo",
+					Region: "us-east-2",
+				},
+			},
+		},
+		TLSProfile: tlsprofile.TLSProfileOptions{
+			MinTLSVersion: string(openshiftconfigv1.VersionTLS13),
+		},
+	})
+	require.NoError(t, err)
+	require.YAMLEq(t, expCfg, string(cfg))
+}

--- a/internal/manifests/config/build_test.go
+++ b/internal/manifests/config/build_test.go
@@ -118,9 +118,11 @@ query_frontend:
 		},
 		StorageParams: manifestutils.StorageParams{
 			S3: &manifestutils.S3{
-				Endpoint: "minio:9000",
-				Bucket:   "tempo",
-				Insecure: true,
+				LongLived: &manifestutils.S3LongLived{
+					Endpoint: "minio:9000",
+					Bucket:   "tempo",
+					Insecure: true,
+				},
 			},
 		},
 		TLSProfile: tlsprofile.TLSProfileOptions{
@@ -978,9 +980,11 @@ query_frontend:
 				},
 				StorageParams: manifestutils.StorageParams{
 					S3: &manifestutils.S3{
-						Endpoint: "minio:9000",
-						Bucket:   "tempo",
-						Insecure: true,
+						LongLived: &manifestutils.S3LongLived{
+							Endpoint: "minio:9000",
+							Bucket:   "tempo",
+							Insecure: true,
+						},
 					},
 				},
 				TLSProfile: tlsprofile.TLSProfileOptions{
@@ -1350,9 +1354,11 @@ query_frontend:
 		},
 		StorageParams: manifestutils.StorageParams{
 			S3: &manifestutils.S3{
-				Endpoint: "minio:9000",
-				Bucket:   "tempo",
-				Insecure: true,
+				LongLived: &manifestutils.S3LongLived{
+					Endpoint: "minio:9000",
+					Bucket:   "tempo",
+					Insecure: true,
+				},
 			},
 		},
 		TLSProfile: tlsprofile.TLSProfileOptions{
@@ -1639,9 +1645,11 @@ ingester_client:
 				},
 				StorageParams: manifestutils.StorageParams{
 					S3: &manifestutils.S3{
-						Endpoint: "minio:9000",
-						Bucket:   "tempo",
-						Insecure: true,
+						LongLived: &manifestutils.S3LongLived{
+							Endpoint: "minio:9000",
+							Bucket:   "tempo",
+							Insecure: true,
+						},
 					},
 				},
 				TLSProfile: tc.options,
@@ -1801,9 +1809,11 @@ ingester_client:
 		},
 		StorageParams: manifestutils.StorageParams{
 			S3: &manifestutils.S3{
-				Endpoint: "minio:9000",
-				Bucket:   "tempo",
-				Insecure: true,
+				LongLived: &manifestutils.S3LongLived{
+					Endpoint: "minio:9000",
+					Bucket:   "tempo",
+					Insecure: true,
+				},
 			},
 		},
 		TLSProfile: tlsprofile.TLSProfileOptions{
@@ -2166,9 +2176,11 @@ query_frontend:
 				},
 				StorageParams: manifestutils.StorageParams{
 					S3: &manifestutils.S3{
-						Endpoint: "minio:9000",
-						Bucket:   "tempo",
-						Insecure: true,
+						LongLived: &manifestutils.S3LongLived{
+							Endpoint: "minio:9000",
+							Bucket:   "tempo",
+							Insecure: true,
+						},
 					},
 				},
 				TLSProfile: tlsprofile.TLSProfileOptions{
@@ -2382,9 +2394,11 @@ query_frontend:
 				},
 				StorageParams: manifestutils.StorageParams{
 					S3: &manifestutils.S3{
-						Endpoint: "minio:9000",
-						Bucket:   "tempo",
-						Insecure: true,
+						LongLived: &manifestutils.S3LongLived{
+							Endpoint: "minio:9000",
+							Bucket:   "tempo",
+							Insecure: true,
+						},
 					},
 				},
 			})

--- a/internal/manifests/config/configmap_test.go
+++ b/internal/manifests/config/configmap_test.go
@@ -34,8 +34,10 @@ func TestConfigmap(t *testing.T) {
 		},
 		StorageParams: manifestutils.StorageParams{
 			S3: &manifestutils.S3{
-				Endpoint: "http://minio:9000",
-				Bucket:   "tempo",
+				LongLived: &manifestutils.S3LongLived{
+					Endpoint: "http://minio:9000",
+					Bucket:   "tempo",
+				},
 			},
 		},
 	})

--- a/internal/manifests/config/tempo-config.yaml
+++ b/internal/manifests/config/tempo-config.yaml
@@ -218,13 +218,12 @@ storage:
     gcs:
       bucket_name: {{ .Bucket }}
     {{- end }}
-    {{- with .StorageParams.S3 }}
+    {{- if and .StorageParams.S3 .StorageParams.S3.LongLived }}
     s3:
-      endpoint: {{ .Endpoint }}
-      bucket: {{ .Bucket }}
-      insecure: {{ .Insecure }}
-    {{- end }}
-{{- if and .StorageParams.S3 .S3StorageTLS.Enabled }}
+      endpoint: {{ .StorageParams.S3.LongLived.Endpoint }}
+      bucket: {{ .StorageParams.S3.LongLived.Bucket }}
+      insecure: {{ .StorageParams.S3.LongLived.Insecure }}
+    {{- if .S3StorageTLS.Enabled }}
     {{- if .S3StorageTLS.CA }}
       tls_ca_path: {{ .S3StorageTLS.CA }}
     {{- end }}
@@ -234,7 +233,13 @@ storage:
     {{- if and .S3StorageTLS.Key }}
       tls_key_path: {{ .S3StorageTLS.Key }}
     {{- end }}
-{{- end }}
+    {{- end }}
+  {{- end }}
+  {{- if and .StorageParams.S3 .StorageParams.S3.ShortLived }}
+  s3:
+    bucket: {{ .StorageParams.S3.ShortLived.Bucket }}
+    endpoint: s3.{{ .StorageParams.S3.ShortLived.Region }}.amazonaws.com
+  {{- end }}
     local:
       path: /var/tempo/traces
     wal:

--- a/internal/manifests/config/tempo-config.yaml
+++ b/internal/manifests/config/tempo-config.yaml
@@ -235,11 +235,11 @@ storage:
     {{- end }}
     {{- end }}
   {{- end }}
-  {{- if and .StorageParams.S3 .StorageParams.S3.ShortLived }}
-  s3:
-    bucket: {{ .StorageParams.S3.ShortLived.Bucket }}
-    endpoint: s3.{{ .StorageParams.S3.ShortLived.Region }}.amazonaws.com
-  {{- end }}
+    {{- if and .StorageParams.S3 .StorageParams.S3.ShortLived }}
+    s3:
+      bucket: {{ .StorageParams.S3.ShortLived.Bucket }}
+      endpoint: s3.{{ .StorageParams.S3.ShortLived.Region }}.amazonaws.com
+    {{- end }}
     local:
       path: /var/tempo/traces
     wal:

--- a/internal/manifests/ingester/ingester.go
+++ b/internal/manifests/ingester/ingester.go
@@ -162,7 +162,7 @@ func statefulSet(params manifestutils.Params) (*v1.StatefulSet, error) {
 		},
 	}
 
-	err := manifestutils.ConfigureStorage(tempo, &ss.Spec.Template.Spec, "tempo")
+	err := manifestutils.ConfigureStorage(params.StorageParams, tempo, &ss.Spec.Template.Spec, "tempo")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/manifests/manifests.go
+++ b/internal/manifests/manifests.go
@@ -54,7 +54,7 @@ func BuildAll(params manifestutils.Params) ([]client.Object, error) {
 	var manifests []client.Object
 	manifests = append(manifests, configMaps)
 	if params.Tempo.Spec.ServiceAccount == naming.DefaultServiceAccountName(params.Tempo.Name) {
-		manifests = append(manifests, serviceaccount.BuildDefaultServiceAccount(params.Tempo, params.StorageParams))
+		manifests = append(manifests, serviceaccount.BuildDefaultServiceAccount(params))
 	}
 	manifests = append(manifests, distributorObjs...)
 	manifests = append(manifests, ingesterObjs...)

--- a/internal/manifests/manifests.go
+++ b/internal/manifests/manifests.go
@@ -54,7 +54,7 @@ func BuildAll(params manifestutils.Params) ([]client.Object, error) {
 	var manifests []client.Object
 	manifests = append(manifests, configMaps)
 	if params.Tempo.Spec.ServiceAccount == naming.DefaultServiceAccountName(params.Tempo.Name) {
-		manifests = append(manifests, serviceaccount.BuildDefaultServiceAccount(params.Tempo))
+		manifests = append(manifests, serviceaccount.BuildDefaultServiceAccount(params.Tempo, params.StorageParams))
 	}
 	manifests = append(manifests, distributorObjs...)
 	manifests = append(manifests, ingesterObjs...)

--- a/internal/manifests/manifests_test.go
+++ b/internal/manifests/manifests_test.go
@@ -21,8 +21,10 @@ func TestBuildAll(t *testing.T) {
 				Bucket: "test",
 			},
 			S3: &manifestutils.S3{
-				Endpoint: "https://localhost",
-				Bucket:   "test",
+				LongLived: &manifestutils.S3LongLived{
+					Endpoint: "https://localhost",
+					Bucket:   "test",
+				},
 			},
 		},
 		Tempo: v1alpha1.TempoStack{

--- a/internal/manifests/manifestutils/annotations.go
+++ b/internal/manifests/manifestutils/annotations.go
@@ -6,3 +6,12 @@ func CommonAnnotations(configChecksum string) map[string]string {
 		"tempo.grafana.com/config.hash": configChecksum,
 	}
 }
+
+// S3AWSSTSAnnotations returns service account annotations required by AWS STS.
+func S3AWSSTSAnnotations(secret S3ShortLived) map[string]string {
+	return map[string]string{
+		"eks.amazonaws.com/audience": "sts.amazonaws.com",
+		"eks.amazonaws.com/role-arn": secret.RoleARN,
+	}
+
+}

--- a/internal/manifests/manifestutils/params.go
+++ b/internal/manifests/manifestutils/params.go
@@ -43,6 +43,7 @@ type S3 struct {
 }
 
 // S3LongLived holds long-lived S3 configuration.
+// The long-lived token uses access key and secret.
 type S3LongLived struct {
 	// Endpoint without http/https
 	Endpoint string
@@ -53,6 +54,7 @@ type S3LongLived struct {
 }
 
 // S3ShortLived holds short-lived S3 configuration.
+// The short-lived S3 token uses AWS STS.
 type S3ShortLived struct {
 	Bucket  string
 	RoleARN string

--- a/internal/manifests/manifestutils/params.go
+++ b/internal/manifests/manifestutils/params.go
@@ -42,6 +42,7 @@ type S3 struct {
 	ShortLived *S3ShortLived
 }
 
+// S3LongLived holds long-lived S3 configuration.
 type S3LongLived struct {
 	// Endpoint without http/https
 	Endpoint string
@@ -51,6 +52,7 @@ type S3LongLived struct {
 	TLS StorageTLS
 }
 
+// S3ShortLived holds short-lived S3 configuration.
 type S3ShortLived struct {
 	Bucket  string
 	RoleARN string

--- a/internal/manifests/manifestutils/params.go
+++ b/internal/manifests/manifestutils/params.go
@@ -38,11 +38,23 @@ type GCS struct {
 
 // S3 holds S3 configuration.
 type S3 struct {
+	LongLived  *S3LongLived
+	ShortLived *S3ShortLived
+}
+
+type S3LongLived struct {
 	// Endpoint without http/https
 	Endpoint string
 	Bucket   string
 	Insecure bool
-	TLS      StorageTLS
+
+	TLS StorageTLS
+}
+
+type S3ShortLived struct {
+	Bucket  string
+	RoleARN string
+	Region  string
 }
 
 // StorageTLS holds StorageTLS configuration.

--- a/internal/manifests/monolithic/configmap.go
+++ b/internal/manifests/monolithic/configmap.go
@@ -214,7 +214,7 @@ func buildTempoConfig(opts Options) ([]byte, error) {
 				}
 			} else if opts.StorageParams.S3.ShortLived != nil {
 				config.Storage.Trace.S3.Bucket = opts.StorageParams.S3.ShortLived.Bucket
-				config.Storage.Trace.S3.Endpoint = fmt.Sprintf("s3.%s.amazonaws.com ", opts.StorageParams.S3.ShortLived.Region)
+				config.Storage.Trace.S3.Endpoint = fmt.Sprintf("s3.%s.amazonaws.com", opts.StorageParams.S3.ShortLived.Region)
 			}
 
 		case v1alpha1.MonolithicTracesStorageBackendAzure:

--- a/internal/manifests/monolithic/configmap.go
+++ b/internal/manifests/monolithic/configmap.go
@@ -193,23 +193,28 @@ func buildTempoConfig(opts Options) ([]byte, error) {
 		case v1alpha1.MonolithicTracesStorageBackendS3:
 			config.Storage.Trace.Backend = "s3"
 			config.Storage.Trace.S3 = &tempoS3Config{}
-			config.Storage.Trace.S3.Endpoint = opts.StorageParams.S3.Endpoint
-			config.Storage.Trace.S3.Insecure = opts.StorageParams.S3.Insecure
-			config.Storage.Trace.S3.Bucket = opts.StorageParams.S3.Bucket
-			if tempo.Spec.Storage.Traces.S3 != nil && tempo.Spec.Storage.Traces.S3.TLS != nil && tempo.Spec.Storage.Traces.S3.TLS.Enabled {
-				if tempo.Spec.Storage.Traces.S3.TLS.CA != "" {
-					config.Storage.Trace.S3.TLSCAPath = path.Join(manifestutils.StorageTLSCADir, opts.StorageParams.S3.TLS.CAFilename)
+			if opts.StorageParams.S3.LongLived != nil {
+				config.Storage.Trace.S3.Endpoint = opts.StorageParams.S3.LongLived.Endpoint
+				config.Storage.Trace.S3.Insecure = opts.StorageParams.S3.LongLived.Insecure
+				config.Storage.Trace.S3.Bucket = opts.StorageParams.S3.LongLived.Bucket
+				if tempo.Spec.Storage.Traces.S3 != nil && tempo.Spec.Storage.Traces.S3.TLS != nil && tempo.Spec.Storage.Traces.S3.TLS.Enabled {
+					if tempo.Spec.Storage.Traces.S3.TLS.CA != "" {
+						config.Storage.Trace.S3.TLSCAPath = path.Join(manifestutils.StorageTLSCADir, opts.StorageParams.S3.LongLived.TLS.CAFilename)
+					}
+					if tempo.Spec.Storage.Traces.S3.TLS.Cert != "" {
+						config.Storage.Trace.S3.TLSCertPath = path.Join(manifestutils.StorageTLSCertDir, manifestutils.TLSCertFilename)
+						config.Storage.Trace.S3.TLSKeyPath = path.Join(manifestutils.StorageTLSCertDir, manifestutils.TLSKeyFilename)
+					}
+					if tempo.Spec.Storage.Traces.S3.TLS.MinVersion != "" {
+						config.Storage.Trace.S3.TLSMinVersion = tempo.Spec.Storage.Traces.S3.TLS.MinVersion
+					} else if opts.TLSProfile.MinTLSVersion != "" {
+						config.Storage.Trace.S3.TLSMinVersion = opts.TLSProfile.MinTLSVersion
+					}
+					config.Storage.Trace.S3.TLSCipherSuites = opts.TLSProfile.TLSCipherSuites()
 				}
-				if tempo.Spec.Storage.Traces.S3.TLS.Cert != "" {
-					config.Storage.Trace.S3.TLSCertPath = path.Join(manifestutils.StorageTLSCertDir, manifestutils.TLSCertFilename)
-					config.Storage.Trace.S3.TLSKeyPath = path.Join(manifestutils.StorageTLSCertDir, manifestutils.TLSKeyFilename)
-				}
-				if tempo.Spec.Storage.Traces.S3.TLS.MinVersion != "" {
-					config.Storage.Trace.S3.TLSMinVersion = tempo.Spec.Storage.Traces.S3.TLS.MinVersion
-				} else if opts.TLSProfile.MinTLSVersion != "" {
-					config.Storage.Trace.S3.TLSMinVersion = opts.TLSProfile.MinTLSVersion
-				}
-				config.Storage.Trace.S3.TLSCipherSuites = opts.TLSProfile.TLSCipherSuites()
+			} else if opts.StorageParams.S3.ShortLived != nil {
+				config.Storage.Trace.S3.Bucket = opts.StorageParams.S3.ShortLived.Bucket
+				config.Storage.Trace.S3.Endpoint = fmt.Sprintf("s3.%s.amazonaws.com ", opts.StorageParams.S3.ShortLived.Region)
 			}
 
 		case v1alpha1.MonolithicTracesStorageBackendAzure:

--- a/internal/manifests/monolithic/configmap_test.go
+++ b/internal/manifests/monolithic/configmap_test.go
@@ -252,8 +252,10 @@ usage_report:
 				},
 				StorageParams: manifestutils.StorageParams{
 					S3: &manifestutils.S3{
-						Endpoint: "minio",
-						Bucket:   "tempo",
+						LongLived: &manifestutils.S3LongLived{
+							Endpoint: "minio",
+							Bucket:   "tempo",
+						},
 					},
 				},
 			},

--- a/internal/manifests/monolithic/serviceaccount.go
+++ b/internal/manifests/monolithic/serviceaccount.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/grafana/tempo-operator/apis/tempo/v1alpha1"
 	"github.com/grafana/tempo-operator/internal/manifests/gateway"
+	"github.com/grafana/tempo-operator/internal/manifests/manifestutils"
 	"github.com/grafana/tempo-operator/internal/manifests/naming"
 )
 
@@ -22,6 +23,15 @@ func BuildServiceAccount(opts Options) *corev1.ServiceAccount {
 		annotations = gateway.BuildServiceAccountAnnotations(tempo.Spec.Multitenancy.TenantsSpec, naming.Name("jaegerui", tempo.Name))
 	}
 
+	if opts.StorageParams.S3 != nil && opts.StorageParams.S3.ShortLived != nil {
+		awsAnnotations := manifestutils.S3AWSSTSAnnotations(*opts.StorageParams.S3.ShortLived)
+		if annotations == nil {
+			annotations = map[string]string{}
+		}
+		for k, v := range awsAnnotations {
+			annotations[k] = v
+		}
+	}
 	return &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        naming.DefaultServiceAccountName(tempo.Name),

--- a/internal/manifests/monolithic/serviceaccount_test.go
+++ b/internal/manifests/monolithic/serviceaccount_test.go
@@ -8,6 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/grafana/tempo-operator/apis/tempo/v1alpha1"
+	"github.com/grafana/tempo-operator/internal/manifests/manifestutils"
 )
 
 func TestBuildServiceAccount(t *testing.T) {
@@ -27,6 +28,38 @@ func TestBuildServiceAccount(t *testing.T) {
 			Name:      "tempo-sample",
 			Namespace: "default",
 			Labels:    labels,
+		},
+	}, sa)
+}
+
+func TestBuildServiceAccount_aws_sts(t *testing.T) {
+	opts := Options{
+		Tempo: v1alpha1.TempoMonolithic{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "sample",
+				Namespace: "default",
+			},
+		},
+		StorageParams: manifestutils.StorageParams{
+			S3: &manifestutils.S3{
+				ShortLived: &manifestutils.S3ShortLived{
+					RoleARN: "arn:aws:iam::123456777012:role/aws-service-role",
+				},
+			},
+		},
+	}
+	sa := BuildServiceAccount(opts)
+
+	labels := ComponentLabels("serviceaccount", "sample")
+	require.Equal(t, &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tempo-sample",
+			Namespace: "default",
+			Labels:    labels,
+			Annotations: map[string]string{
+				"eks.amazonaws.com/audience": "sts.amazonaws.com",
+				"eks.amazonaws.com/role-arn": "arn:aws:iam::123456777012:role/aws-service-role",
+			},
 		},
 	}, sa)
 }

--- a/internal/manifests/monolithic/statefulset.go
+++ b/internal/manifests/monolithic/statefulset.go
@@ -257,7 +257,7 @@ func configureStorage(opts Options, sts *appsv1.StatefulSet) error {
 			return errors.New("please configure .spec.storage.traces.s3")
 		}
 
-		err := manifestutils.ConfigureS3Storage(&sts.Spec.Template.Spec, "tempo", tempo.Spec.Storage.Traces.S3.Secret, tempo.Spec.Storage.Traces.S3.TLS)
+		err := manifestutils.ConfigureS3Storage(&sts.Spec.Template.Spec, "tempo", tempo.Spec.Storage.Traces.S3.Secret, tempo.Spec.Storage.Traces.S3.TLS, opts.StorageParams.S3)
 		if err != nil {
 			return err
 		}

--- a/internal/manifests/querier/querier.go
+++ b/internal/manifests/querier/querier.go
@@ -146,7 +146,7 @@ func deployment(params manifestutils.Params) (*v1.Deployment, error) {
 		},
 	}
 
-	err := manifestutils.ConfigureStorage(tempo, &d.Spec.Template.Spec, "tempo")
+	err := manifestutils.ConfigureStorage(params.StorageParams, tempo, &d.Spec.Template.Spec, "tempo")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/manifests/queryfrontend/query_frontend.go
+++ b/internal/manifests/queryfrontend/query_frontend.go
@@ -315,7 +315,7 @@ func deployment(params manifestutils.Params) (*appsv1.Deployment, error) {
 		d.Spec.Template.Spec.Volumes = append(d.Spec.Template.Spec.Volumes, jaegerQueryVolume)
 	}
 
-	err := manifestutils.ConfigureStorage(tempo, &d.Spec.Template.Spec, "tempo")
+	err := manifestutils.ConfigureStorage(params.StorageParams, tempo, &d.Spec.Template.Spec, "tempo")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/manifests/queryfrontend/query_frontend.go
+++ b/internal/manifests/queryfrontend/query_frontend.go
@@ -87,7 +87,7 @@ func BuildQueryFrontend(params manifestutils.Params) ([]client.Object, error) {
 				if err != nil {
 					return nil, err
 				}
-				manifests = append(manifests, oauthproxy.OAuthServiceAccount(tempo.ObjectMeta), secret)
+				manifests = append(manifests, oauthproxy.OAuthServiceAccount(params), secret)
 				oauthproxy.PatchRouteForOauthProxy(routeObj)
 			}
 			manifests = append(manifests, routeObj)

--- a/internal/manifests/serviceaccount/serviceaccount.go
+++ b/internal/manifests/serviceaccount/serviceaccount.go
@@ -4,7 +4,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/grafana/tempo-operator/apis/tempo/v1alpha1"
 	"github.com/grafana/tempo-operator/internal/manifests/manifestutils"
 	"github.com/grafana/tempo-operator/internal/manifests/naming"
 )
@@ -14,16 +13,16 @@ const (
 )
 
 // BuildDefaultServiceAccount creates a Kubernetes service account for tempo.
-func BuildDefaultServiceAccount(tempo v1alpha1.TempoStack, storage manifestutils.StorageParams) *corev1.ServiceAccount {
-	labels := manifestutils.ComponentLabels(componentName, tempo.Name)
+func BuildDefaultServiceAccount(params manifestutils.Params) *corev1.ServiceAccount {
+	labels := manifestutils.ComponentLabels(componentName, params.Tempo.Name)
 	var annotations map[string]string
-	if storage.S3 != nil && storage.S3.ShortLived != nil {
-		annotations = manifestutils.S3AWSSTSAnnotations(*storage.S3.ShortLived)
+	if params.StorageParams.S3 != nil && params.StorageParams.S3.ShortLived != nil {
+		annotations = manifestutils.S3AWSSTSAnnotations(*params.StorageParams.S3.ShortLived)
 	}
 	return &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        naming.DefaultServiceAccountName(tempo.Name),
-			Namespace:   tempo.Namespace,
+			Name:        naming.DefaultServiceAccountName(params.Tempo.Name),
+			Namespace:   params.Tempo.Namespace,
 			Labels:      labels,
 			Annotations: annotations,
 		},

--- a/internal/manifests/serviceaccount/serviceaccount.go
+++ b/internal/manifests/serviceaccount/serviceaccount.go
@@ -14,13 +14,18 @@ const (
 )
 
 // BuildDefaultServiceAccount creates a Kubernetes service account for tempo.
-func BuildDefaultServiceAccount(tempo v1alpha1.TempoStack) *corev1.ServiceAccount {
+func BuildDefaultServiceAccount(tempo v1alpha1.TempoStack, storage manifestutils.StorageParams) *corev1.ServiceAccount {
 	labels := manifestutils.ComponentLabels(componentName, tempo.Name)
+	var annotations map[string]string
+	if storage.S3 != nil && storage.S3.ShortLived != nil {
+		annotations = manifestutils.S3AWSSTSAnnotations(*storage.S3.ShortLived)
+	}
 	return &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      naming.DefaultServiceAccountName(tempo.Name),
-			Namespace: tempo.Namespace,
-			Labels:    labels,
+			Name:        naming.DefaultServiceAccountName(tempo.Name),
+			Namespace:   tempo.Namespace,
+			Labels:      labels,
+			Annotations: annotations,
 		},
 	}
 }

--- a/internal/manifests/serviceaccount/serviceaccount_test.go
+++ b/internal/manifests/serviceaccount/serviceaccount_test.go
@@ -18,6 +18,31 @@ func TestBuildDefaultServiceAccount(t *testing.T) {
 			Name:      "test",
 			Namespace: "ns1",
 		},
+	}, manifestutils.StorageParams{})
+
+	labels := manifestutils.ComponentLabels("serviceaccount", "test")
+	require.NotNil(t, serviceAccount)
+	assert.Equal(t, &v1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tempo-test",
+			Namespace: "ns1",
+			Labels:    labels,
+		},
+	}, serviceAccount)
+}
+
+func TestBuildDefaultServiceAccount_aws_sts(t *testing.T) {
+	serviceAccount := BuildDefaultServiceAccount(v1alpha1.TempoStack{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "ns1",
+		},
+	}, manifestutils.StorageParams{
+		S3: &manifestutils.S3{
+			ShortLived: &manifestutils.S3ShortLived{
+				RoleARN: "arn:aws:iam::123456777012:role/aws-service-role",
+			},
+		},
 	})
 
 	labels := manifestutils.ComponentLabels("serviceaccount", "test")
@@ -27,6 +52,10 @@ func TestBuildDefaultServiceAccount(t *testing.T) {
 			Name:      "tempo-test",
 			Namespace: "ns1",
 			Labels:    labels,
+			Annotations: map[string]string{
+				"eks.amazonaws.com/audience": "sts.amazonaws.com",
+				"eks.amazonaws.com/role-arn": "arn:aws:iam::123456777012:role/aws-service-role",
+			},
 		},
 	}, serviceAccount)
 }

--- a/internal/manifests/serviceaccount/serviceaccount_test.go
+++ b/internal/manifests/serviceaccount/serviceaccount_test.go
@@ -13,12 +13,13 @@ import (
 )
 
 func TestBuildDefaultServiceAccount(t *testing.T) {
-	serviceAccount := BuildDefaultServiceAccount(v1alpha1.TempoStack{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test",
-			Namespace: "ns1",
-		},
-	}, manifestutils.StorageParams{})
+	serviceAccount := BuildDefaultServiceAccount(manifestutils.Params{
+		Tempo: v1alpha1.TempoStack{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "ns1",
+			},
+		}})
 
 	labels := manifestutils.ComponentLabels("serviceaccount", "test")
 	require.NotNil(t, serviceAccount)
@@ -32,18 +33,20 @@ func TestBuildDefaultServiceAccount(t *testing.T) {
 }
 
 func TestBuildDefaultServiceAccount_aws_sts(t *testing.T) {
-	serviceAccount := BuildDefaultServiceAccount(v1alpha1.TempoStack{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test",
-			Namespace: "ns1",
-		},
-	}, manifestutils.StorageParams{
-		S3: &manifestutils.S3{
-			ShortLived: &manifestutils.S3ShortLived{
-				RoleARN: "arn:aws:iam::123456777012:role/aws-service-role",
+	serviceAccount := BuildDefaultServiceAccount(manifestutils.Params{
+		Tempo: v1alpha1.TempoStack{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "ns1",
 			},
 		},
-	})
+		StorageParams: manifestutils.StorageParams{
+			S3: &manifestutils.S3{
+				ShortLived: &manifestutils.S3ShortLived{
+					RoleARN: "arn:aws:iam::123456777012:role/aws-service-role",
+				},
+			},
+		}})
 
 	labels := manifestutils.ComponentLabels("serviceaccount", "test")
 	require.NotNil(t, serviceAccount)

--- a/internal/webhooks/tempostack_webhook_test.go
+++ b/internal/webhooks/tempostack_webhook_test.go
@@ -679,6 +679,68 @@ func TestValidateStorageSecret(t *testing.T) {
 			},
 			expected: nil,
 		},
+		{
+			name:  "S3 short lived - valid",
+			tempo: tempoS3,
+			input: corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: tempoS3.Spec.Storage.Secret.Name,
+				},
+				Data: map[string][]byte{
+					"bucket":   []byte("bucket"),
+					"region":   []byte("us-east-1"),
+					"role_arn": []byte("role-arn"),
+				},
+			},
+		},
+		{
+			name:  "S3 short lived - missing bucket",
+			tempo: tempoS3,
+			input: corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: tempoS3.Spec.Storage.Secret.Name,
+				},
+				Data: map[string][]byte{
+					"role_arn": []byte("role"),
+					"region":   []byte("us-east-1"),
+				},
+			},
+			expected: field.ErrorList{
+				field.Invalid(secretNamePath, tempoS3.Spec.Storage.Secret.Name, "storage secret must contain \"bucket\" field"),
+			},
+		},
+		{
+			name:  "S3 short lived - missing role_arn",
+			tempo: tempoS3,
+			input: corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: tempoS3.Spec.Storage.Secret.Name,
+				},
+				Data: map[string][]byte{
+					"bucket": []byte("bucket"),
+					"region": []byte("us-east-1"),
+				},
+			},
+			expected: field.ErrorList{
+				field.Invalid(secretNamePath, tempoS3.Spec.Storage.Secret.Name, "storage secret must contain \"role_arn\" field"),
+			},
+		},
+		{
+			name:  "S3 short lived - missing region",
+			tempo: tempoS3,
+			input: corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: tempoS3.Spec.Storage.Secret.Name,
+				},
+				Data: map[string][]byte{
+					"bucket":   []byte("bucket"),
+					"role_arn": []byte("role"),
+				},
+			},
+			expected: field.ErrorList{
+				field.Invalid(secretNamePath, tempoS3.Spec.Storage.Secret.Name, "storage secret must contain \"region\" field"),
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/internal/webhooks/tempostack_webhook_test.go
+++ b/internal/webhooks/tempostack_webhook_test.go
@@ -606,8 +606,8 @@ func TestValidateStorageSecret(t *testing.T) {
 				},
 			},
 			expected: field.ErrorList{
-				field.Invalid(secretNamePath, tempoS3.Spec.Storage.Secret.Name, "storage secret must contain \"endpoint\" field"),
 				field.Invalid(secretNamePath, tempoS3.Spec.Storage.Secret.Name, "storage secret must contain \"bucket\" field"),
+				field.Invalid(secretNamePath, tempoS3.Spec.Storage.Secret.Name, "storage secret must contain \"endpoint\" field"),
 				field.Invalid(secretNamePath, tempoS3.Spec.Storage.Secret.Name, "storage secret must contain \"access_key_id\" field"),
 				field.Invalid(secretNamePath, tempoS3.Spec.Storage.Secret.Name, "storage secret must contain \"access_key_secret\" field"),
 			},
@@ -624,8 +624,8 @@ func TestValidateStorageSecret(t *testing.T) {
 				},
 			},
 			expected: field.ErrorList{
-				field.Invalid(secretNamePath, tempoS3.Spec.Storage.Secret.Name, "storage secret must contain \"endpoint\" field"),
 				field.Invalid(secretNamePath, tempoS3.Spec.Storage.Secret.Name, "storage secret must contain \"bucket\" field"),
+				field.Invalid(secretNamePath, tempoS3.Spec.Storage.Secret.Name, "storage secret must contain \"endpoint\" field"),
 				field.Invalid(secretNamePath, tempoS3.Spec.Storage.Secret.Name, "storage secret must contain \"access_key_id\" field"),
 				field.Invalid(secretNamePath, tempoS3.Spec.Storage.Secret.Name, "storage secret must contain \"access_key_secret\" field"),
 			},
@@ -739,6 +739,23 @@ func TestValidateStorageSecret(t *testing.T) {
 			},
 			expected: field.ErrorList{
 				field.Invalid(secretNamePath, tempoS3.Spec.Storage.Secret.Name, "storage secret must contain \"region\" field"),
+			},
+		},
+		{
+			name:  "S3 short lived and long lived",
+			tempo: tempoS3,
+			input: corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: tempoS3.Spec.Storage.Secret.Name,
+				},
+				Data: map[string][]byte{
+					"role_arn": []byte("role"),
+					"region":   []byte("us-east-1"),
+					"endpoint": []byte("us-east-1"),
+				},
+			},
+			expected: field.ErrorList{
+				field.Invalid(secretNamePath, tempoS3.Spec.Storage.Secret.Name, "storage secret contains fields for long lived and short lived configuration"),
 			},
 		},
 	}


### PR DESCRIPTION
Resolves #553 

https://issues.redhat.com/browse/TRACING-4227



Test instructions:
```
kubectl create namespace tempo-operator-system
IMG_PREFIX=docker.io/pavolloffay OPERATOR_VERSION=$(date +%s).0.0 BUNDLE_VARIANT=openshift make docker-build docker-push bundle bundle-build bundle-push olm-deploy


kubectl apply -f - <<EOF
apiVersion: v1
kind: Secret
metadata:
  name: aws-sts
stringData:
  bucket: tempoploffay
  region: us-east-2
  role_arn: arn:aws:iam::TBD:role/ploffay-simplest
type: Opaque
EOF


kubectl apply -f - <<EOF
apiVersion: tempo.grafana.com/v1alpha1
kind: TempoStack
metadata:
  name: simplest
spec:
  storage:
    secret:
      name: aws-sts
      type: s3
  storageSize: 1Gi
  resources:
    total:
      limits:
        memory: 2Gi
        cpu: 2000m
  template:
    queryFrontend:
      jaegerQuery:
        enabled: true
        ingress:
          type: route
EOF


kubectl apply -f - <<EOF
apiVersion: tempo.grafana.com/v1alpha1
kind: TempoMonolithic
metadata:
  name: simplest
spec:
  storage:
    traces:
      backend: s3
      s3:
        secret: aws-sts
EOF
```
