### PR TITLE
Fix TLS on monolithic deployment

### DIFF
--- a/tests/e2e-openshift/tls-monolithic-singletenant/01-install-tempo.yaml
+++ b/tests/e2e-openshift/tls-monolithic-singletenant/01-install-tempo.yaml
@@ -1,11 +1,13 @@
 apiVersion: tempo.grafana.com/v1alpha1
 kind: TempoMonolithic
 metadata:
-  name: mono-cert
+  name: mono
   namespace: chainsaw-tls-mono-st
 spec:
   jaegerui:
     enabled: true
+    route:
+      enabled: true
   ingestion:
     otlp:
       grpc:

--- a/tests/e2e-openshift/tls-monolithic-singletenant/02-install-otelcol.yaml
+++ b/tests/e2e-openshift/tls-monolithic-singletenant/02-install-otelcol.yaml
@@ -1,9 +1,9 @@
-# based on config/samples/otelcol_v1alpha1_openshift.yaml
+
 apiVersion: opentelemetry.io/v1alpha1
 kind: OpenTelemetryCollector
 metadata:
   name: dev
-  namespace: chainsaw-tls-monolithic-singletenant
+  namespace: chainsaw-tls-mono-st
 spec:
   config: |
     receivers:
@@ -15,12 +15,12 @@ spec:
           http:
     exporters:
       otlp:
-        endpoint: tempo-monolithic-cert.chainsaw-tls-monolithic-singletenant.svc.cluster.local:4317
+        endpoint: tempo-mono.chainsaw-tls-mono-st.svc.cluster.local:4317
         tls:
           insecure: false
           ca_file: "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
       otlphttp:
-        endpoint: https://tempo-monolithic-cert.chainsaw-tls-monolithic-singletenant.svc.cluster.local:4318
+        endpoint: https://tempo-mono.chainsaw-tls-mono-st.svc.cluster.local:4318
         tls:
           insecure: false
           ca_file: "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
@@ -37,3 +37,4 @@ spec:
         traces/http:
           receivers: [otlp/http]
           exporters: [otlphttp]
+

--- a/tests/e2e-openshift/tls-monolithic-singletenant/03-generate-traces.yaml
+++ b/tests/e2e-openshift/tls-monolithic-singletenant/03-generate-traces.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: generate-traces-grpc
-  namespace: tls-monolithic-singletenant
+  namespace: chainsaw-tls-mono-st
 spec:
   template:
     spec:
@@ -21,7 +21,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: generate-traces-http
-  namespace: tls-monolithic-singletenant
+  namespace: chainsaw-tls-mono-st
 spec:
   template:
     spec:


### PR DESCRIPTION
This fixes https://issues.redhat.com/browse/TRACING-4487 

There is one note here: We currently don't support mTLS for OpenShift service cert certificates. Our current implementation of mTLS is enabled when the user specify a CA, but in this case none of them are provided.



Solution:

 I think we need to add a new field to the `TLSSpec` , something like `clientVerification`: true/false . This is off course a breaking change. We need to update all the current users that specified the CA , with the new field to true. I'll address all of this in a separate PR.

@andreasgerstmayr Please let me know what do you think.