### PR TITLE
[Chore] Test metrics produced by Tempo Monolithc

### DIFF
--- a/tests/e2e-openshift/monitoring-monolithic/chainsaw-test.yaml
+++ b/tests/e2e-openshift/monitoring-monolithic/chainsaw-test.yaml
@@ -1,0 +1,38 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: monolithic-monitoring
+spec:
+  description: Test metrics produced by Tempo Monolithc can be scraped by in-cluster monitoring
+  # Avoid running this test case in parallel to prevent the deletion of shared resources used by multiple tests, specifically in the context of OpenShift user workload monitoring.
+  concurrent: false
+  steps:
+  - name: Enable user workload monitoring
+    try:
+    - apply:
+        file: workload-monitoring.yaml
+    - assert:
+        file: workload-monitoring-assert.yaml
+  - name: Create Tempo Monolithc instance
+    try:
+    - apply:
+        file: install-monolithic.yaml
+    - assert:
+        file: install-monolithic-assert.yaml
+  - name: Generate traces and export to the Monolithc instance
+    try:
+    - apply:
+        file: generate-traces.yaml
+    - assert:
+        file: generate-traces-assert.yaml
+  - name: Verify traces in Monolithic instance
+    try:
+    - apply:
+        file: verify-traces.yaml
+    - apply:
+        file: workload-monitoring-assert.yaml
+  - name: Check Tempo Monolithc metrics scraped by user workload monitoring
+    try:
+    - script:
+        timeout: 5m
+        content: ./check_metrics.sh

--- a/tests/e2e-openshift/monitoring-monolithic/check_metrics.sh
+++ b/tests/e2e-openshift/monitoring-monolithic/check_metrics.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+TOKEN=$(oc create token prometheus-user-workload -n openshift-user-workload-monitoring)
+THANOS_QUERIER_HOST=$(oc get route thanos-querier -n openshift-monitoring -o json | jq -r '.spec.host')
+
+#Check TempoMonolithc metircs
+metrics="tempo_distributor_bytes_received_total tempo_distributor_spans_received_total tempo_ingester_bytes_received_total tempo_distributor_traces_per_batch_count tempo_build_info"
+
+for metric in $metrics; do
+query="$metric"
+count=0
+
+# Keep fetching and checking the metrics until metrics with value is present.
+while [[ $count -eq 0 ]]; do
+    response=$(curl -k -H "Authorization: Bearer $TOKEN" -H "Content-type: application/json" "https://$THANOS_QUERIER_HOST/api/v1/query?query=$query")
+    count=$(echo "$response" | jq -r '.data.result | length')
+
+    if [[ $count -eq 0 ]]; then
+    echo "No metric '$metric' with value present. Retrying..."
+    sleep 5  # Wait for 5 seconds before retrying
+    else
+    echo "Metric '$metric' with value is present."
+    fi
+  done
+done

--- a/tests/e2e-openshift/monitoring-monolithic/generate-traces-assert.yaml
+++ b/tests/e2e-openshift/monitoring-monolithic/generate-traces-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: generate-traces
+status:
+  active: 1

--- a/tests/e2e-openshift/monitoring-monolithic/generate-traces.yaml
+++ b/tests/e2e-openshift/monitoring-monolithic/generate-traces.yaml
@@ -1,0 +1,18 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: generate-traces
+spec:
+  template:
+    spec:
+      containers:
+      - name: telemetrygen
+        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
+        args:
+        - traces
+        - --otlp-endpoint=tempo-monitor:4317
+        - --otlp-insecure
+        - --duration=3m
+        - --workers=1
+        - --span-duration=1s
+      restartPolicy: Never

--- a/tests/e2e-openshift/monitoring-monolithic/install-monolithic-assert.yaml
+++ b/tests/e2e-openshift/monitoring-monolithic/install-monolithic-assert.yaml
@@ -1,0 +1,125 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: tempo-monitor
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: tempo-monitor-0
+status:
+  containerStatuses:
+  - name: oauth-proxy
+    ready: true
+    started: true
+  - name: tempo
+    ready: true
+    started: true
+  - name: tempo-query
+    ready: true
+    started: true
+  phase: Running
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tempo-monitor
+spec:
+  ports:
+  - name: http
+    port: 3200
+    protocol: TCP
+    targetPort: http
+  - name: otlp-grpc
+    port: 4317
+    protocol: TCP
+    targetPort: otlp-grpc
+  - name: otlp-http
+    port: 4318
+    protocol: TCP
+    targetPort: otlp-http
+  selector:
+    app.kubernetes.io/component: tempo
+    app.kubernetes.io/instance: monitor
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo-monolithic
+  type: ClusterIP
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tempo-monitor-jaegerui
+spec:
+  ports:
+  - name: jaeger-grpc
+    port: 16685
+    protocol: TCP
+    targetPort: jaeger-grpc
+  - name: jaeger-ui
+    port: 16686
+    protocol: TCP
+    targetPort: jaeger-ui
+  - name: jaeger-metrics
+    port: 16687
+    protocol: TCP
+    targetPort: jaeger-metrics
+  - name: oauth-proxy
+    port: 8443
+    protocol: TCP
+    targetPort: oauth-proxy
+  selector:
+    app.kubernetes.io/component: tempo
+    app.kubernetes.io/instance: monitor
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo-monolithic
+  type: ClusterIP
+
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: tempo-monitor-jaegerui
+spec:
+  port:
+    targetPort: oauth-proxy
+  tls:
+    termination: reencrypt
+  to:
+    kind: Service
+    name: tempo-monitor-jaegerui
+    weight: 100
+
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: tempo-monitor
+spec:
+  endpoints:
+  - path: /metrics
+    port: http
+    relabelings:
+    - action: replace
+      sourceLabels:
+      - __meta_kubernetes_service_label_app_kubernetes_io_instance
+      targetLabel: cluster
+    - action: replace
+      separator: /
+      sourceLabels:
+      - __meta_kubernetes_namespace
+      - __meta_kubernetes_service_label_app_kubernetes_io_component
+      targetLabel: job
+    scheme: http
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: tempo
+      app.kubernetes.io/instance: monitor
+      app.kubernetes.io/managed-by: tempo-operator
+      app.kubernetes.io/name: tempo-monolithic

--- a/tests/e2e-openshift/monitoring-monolithic/install-monolithic.yaml
+++ b/tests/e2e-openshift/monitoring-monolithic/install-monolithic.yaml
@@ -1,0 +1,15 @@
+apiVersion: tempo.grafana.com/v1alpha1
+kind: TempoMonolithic
+metadata:
+  name: monitor
+spec:
+  jaegerui:
+    enabled: true
+    route:
+      enabled: true
+  observability:
+    metrics:
+      prometheusRules:
+        enabled: true
+      serviceMonitors:
+        enabled: true

--- a/tests/e2e-openshift/monitoring-monolithic/verify-traces.yaml
+++ b/tests/e2e-openshift/monitoring-monolithic/verify-traces.yaml
@@ -1,0 +1,39 @@
+# Add the cluter role binding required for fetching metrics from Thanos querier. Refer https://issues.redhat.com/browse/MON-3379
+# The ClusterRoleBinding step is not a Tempo requirement and is used only by the test case to check the metrics using the check_metrics.sh script.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: chainsaw-tempo-monitoring-view
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-monitoring-view
+subjects:
+- kind: ServiceAccount
+  name: prometheus-user-workload
+  namespace: openshift-user-workload-monitoring
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify-traces
+spec:
+  template:
+    spec:
+      containers:
+      - name: verify-traces
+        image: registry.access.redhat.com/ubi9/ubi:9.1
+        command:
+        - /bin/bash
+        - -eux
+        - -c
+        args:
+        - |
+          curl -v -G http://tempo-monitor-jaegerui:16686/api/services | tee /tmp/out.log
+          if ! grep -q telemetrygen /tmp/out.log; then
+            echo && echo "No traces found"
+            exit 1
+          fi
+      restartPolicy: Never

--- a/tests/e2e-openshift/monitoring-monolithic/workload-monitoring-assert.yaml
+++ b/tests/e2e-openshift/monitoring-monolithic/workload-monitoring-assert.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus-operator
+  namespace: openshift-user-workload-monitoring
+(status.replicas == spec.replicas): true
+spec:
+  (replicas >= `1`): true
+
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: prometheus-user-workload
+  namespace: openshift-user-workload-monitoring
+(status.replicas == spec.replicas): true
+spec:
+  (replicas >= `1`): true
+
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: thanos-ruler-user-workload
+  namespace: openshift-user-workload-monitoring
+(status.replicas == spec.replicas): true
+spec:
+  (replicas >= `1`): true

--- a/tests/e2e-openshift/monitoring-monolithic/workload-monitoring.yaml
+++ b/tests/e2e-openshift/monitoring-monolithic/workload-monitoring.yaml
@@ -1,0 +1,13 @@
+# oc -n openshift-user-workload-monitoring get pod
+# https://docs.openshift.com/container-platform/4.13/monitoring/enabling-monitoring-for-user-defined-projects.html#accessing-metrics-from-outside-cluster_enabling-monitoring-for-user-defined-projects
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    enableUserWorkload: true 
+    alertmanagerMain:
+      enableUserAlertmanagerConfig: true

--- a/tests/e2e-openshift/monitoring/chainsaw-test.yaml
+++ b/tests/e2e-openshift/monitoring/chainsaw-test.yaml
@@ -7,6 +7,7 @@ metadata:
 spec:
   # Avoid running this test case in parallel to prevent the deletion of shared resources used by multiple tests, specifically in the context of OpenShift user workload monitoring.
   concurrent: false
+  namespace: chainsaw-monitoring
   steps:
   - name: step-00
     try:


### PR DESCRIPTION
Test metrics generated by Tempo Monolithic instance can be scraped by user workload monitoring stack. 