### PR TITLE
[Chore] Fix test monolithic-receivers-tls failing on OCP 4.17

### DIFF
--- a/tests/e2e/monolithic-receivers-tls/04-assert.yaml
+++ b/tests/e2e/monolithic-receivers-tls/04-assert.yaml
@@ -1,13 +1,17 @@
-apiVersion: v1
-kind: Pod
+apiVersion: batch/v1
+kind: Job
 metadata:
   name: verify-traces-http
 status:
-  phase: Succeeded
+  conditions:
+    - status: "True"
+      type: Complete
 ---
-apiVersion: v1
-kind: Pod
+apiVersion: batch/v1
+kind: Job
 metadata:
   name: verify-traces-grpc
 status:
-  phase: Succeeded
+  conditions:
+    - status: "True"
+      type: Complete

--- a/tests/e2e/monolithic-receivers-tls/04-verify-traces.yaml
+++ b/tests/e2e/monolithic-receivers-tls/04-verify-traces.yaml
@@ -1,61 +1,47 @@
-apiVersion: v1
-kind: Pod
+apiVersion: batch/v1
+kind: Job
 metadata:
   name: verify-traces-http
 spec:
-  containers:
-    - name: verify-traces
-      image: ghcr.io/grafana/tempo-operator/test-utils:main
-      command:
-        - /bin/bash
-        - -eu
-        - -c
-      args:
-        - |
-          while true
-          do
-            echo && echo "Starting test at $(date)..."
-            curl -v -G http://tempo-simplest-jaegerui:16686/api/traces --data-urlencode "service=http" | tee /tmp/jaeger.out
-            num_traces=$(jq ".data | length" /tmp/jaeger.out)
-            echo
-
-            if [[ "$num_traces" -eq 10 ]]; then
-              echo "Test passed."
-              exit 0
-            else
-              echo "Test failed: The Jaeger API returned $num_traces instead of 10 traces."
-              echo "Retrying in 10s..." && sleep 10
-            fi
-          done
-  restartPolicy: Never
+  template:
+    spec:
+      containers:
+        - name: verify-traces
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
+          command:
+            - /bin/bash
+            - -eux
+            - -c
+          args:
+            - |
+              curl -v -G http://tempo-simplest-jaegerui:16686/api/traces --data-urlencode "service=http" | tee /tmp/jaeger.out
+              num_traces=$(jq ".data | length" /tmp/jaeger.out)
+              if [[ "$num_traces" -ne 10 ]]; then
+                echo && echo "The Jaeger API returned $num_traces instead of 10 traces."
+                exit 1
+              fi
+      restartPolicy: Never
 ---
-apiVersion: v1
-kind: Pod
+apiVersion: batch/v1
+kind: Job
 metadata:
   name: verify-traces-grpc
 spec:
-  containers:
-    - name: verify-traces
-      image: ghcr.io/grafana/tempo-operator/test-utils:main
-      command:
-        - /bin/bash
-        - -eu
-        - -c
-      args:
-        - |
-          while true
-          do
-            echo && echo "Starting test at $(date)..."
-            curl -v -G http://tempo-simplest-jaegerui:16686/api/traces --data-urlencode "service=grpc" | tee /tmp/jaeger.out
-            num_traces=$(jq ".data | length" /tmp/jaeger.out)
-            echo
-
-            if [[ "$num_traces" -eq 10 ]]; then
-              echo "Test passed."
-              exit 0
-            else
-              echo "Test failed: The Jaeger API returned $num_traces instead of 10 traces."
-              echo "Retrying in 10s..." && sleep 10
-            fi
-          done
-  restartPolicy: Never
+  template:
+    spec:
+      containers:
+        - name: verify-traces
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
+          command:
+            - /bin/bash
+            - -eux
+            - -c
+          args:
+            - |
+              curl -v -G http://tempo-simplest-jaegerui:16686/api/traces --data-urlencode "service=grpc" | tee /tmp/jaeger.out
+              num_traces=$(jq ".data | length" /tmp/jaeger.out)
+              if [[ "$num_traces" -ne 10 ]]; then
+                echo && echo "The Jaeger API returned $num_traces instead of 10 traces."
+                exit 1
+              fi
+      restartPolicy: Never


### PR DESCRIPTION
Fix the test failing on OCP 4.17. 
```
        === ERROR
        pods "verify-traces-http" is forbidden: violates PodSecurity "restricted:v1.24": allowPrivilegeEscalation != false (container "verify-traces" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "verify-traces" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or container "verify-traces" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container "verify-traces" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
```

After fix:
```
--- PASS: chainsaw (0.00s)
    --- PASS: chainsaw/monolithic-receivers-tls (96.75s)
PASS
Tests Summary...
- Passed  tests 1
- Failed  tests 0
- Skipped tests 0
Done.
```