### PR TITLE
Cleanup operator instance metrics when instance is deleted

### DIFF
--- a/.chloggen/metrics-cleanup.yaml
+++ b/.chloggen/metrics-cleanup.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. tempostack, tempomonolithic, github action)
+component: tempostack, tempomonolithic
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Cleanup instance metrics from the operator on instance delete action.
+
+# One or more tracking issues related to the change
+issues: [1019]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/bundle/community/manifests/tempo-operator.clusterserviceversion.yaml
+++ b/bundle/community/manifests/tempo-operator.clusterserviceversion.yaml
@@ -74,7 +74,7 @@ metadata:
     capabilities: Deep Insights
     categories: Logging & Tracing,Monitoring
     containerImage: ghcr.io/grafana/tempo-operator/tempo-operator:v0.12.0
-    createdAt: "2024-08-12T10:08:34Z"
+    createdAt: "2024-08-27T16:10:18Z"
     description: Create and manage deployments of Tempo, a high-scale distributed
       tracing backend.
     operatorframework.io/cluster-monitoring: "true"
@@ -1584,6 +1584,7 @@ spec:
       operations:
       - CREATE
       - UPDATE
+      - DELETE
       resources:
       - tempomonolithics
     sideEffects: None
@@ -1604,6 +1605,7 @@ spec:
       operations:
       - CREATE
       - UPDATE
+      - DELETE
       resources:
       - tempostacks
     sideEffects: None

--- a/bundle/openshift/manifests/tempo-operator.clusterserviceversion.yaml
+++ b/bundle/openshift/manifests/tempo-operator.clusterserviceversion.yaml
@@ -74,7 +74,7 @@ metadata:
     capabilities: Deep Insights
     categories: Logging & Tracing,Monitoring
     containerImage: ghcr.io/grafana/tempo-operator/tempo-operator:v0.12.0
-    createdAt: "2024-08-12T10:08:32Z"
+    createdAt: "2024-08-27T16:10:16Z"
     description: Create and manage deployments of Tempo, a high-scale distributed
       tracing backend.
     operatorframework.io/cluster-monitoring: "true"
@@ -1605,6 +1605,7 @@ spec:
       operations:
       - CREATE
       - UPDATE
+      - DELETE
       resources:
       - tempomonolithics
     sideEffects: None
@@ -1625,6 +1626,7 @@ spec:
       operations:
       - CREATE
       - UPDATE
+      - DELETE
       resources:
       - tempostacks
     sideEffects: None

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -47,6 +47,7 @@ webhooks:
     operations:
     - CREATE
     - UPDATE
+    - DELETE
     resources:
     - tempomonolithics
   sideEffects: None
@@ -67,6 +68,7 @@ webhooks:
     operations:
     - CREATE
     - UPDATE
+    - DELETE
     resources:
     - tempostacks
   sideEffects: None

--- a/internal/status/metrics.go
+++ b/internal/status/metrics.go
@@ -40,3 +40,17 @@ func updateMetrics(metric *prometheus.GaugeVec, conditions []metav1.Condition, n
 		metric.WithLabelValues(namespace, name, condStr).Set(isActive)
 	}
 }
+
+func ClearTempoStackMetrics(namespace string, name string) {
+	for _, cond := range v1alpha1.AllStatusConditions {
+		condStr := string(cond)
+		metricTempoStackStatusCondition.WithLabelValues(namespace, name, condStr).Set(0)
+	}
+}
+
+func ClearMonolithicMetrics(namespace string, name string) {
+	for _, cond := range v1alpha1.AllStatusConditions {
+		condStr := string(cond)
+		metricTempoMonolithicStatusCondition.WithLabelValues(namespace, name, condStr).Set(0)
+	}
+}

--- a/internal/status/metrics.go
+++ b/internal/status/metrics.go
@@ -41,6 +41,7 @@ func updateMetrics(metric *prometheus.GaugeVec, conditions []metav1.Condition, n
 	}
 }
 
+// ClearTempoStackMetrics sets status condition metrics to zero.
 func ClearTempoStackMetrics(namespace string, name string) {
 	for _, cond := range v1alpha1.AllStatusConditions {
 		condStr := string(cond)
@@ -48,6 +49,7 @@ func ClearTempoStackMetrics(namespace string, name string) {
 	}
 }
 
+// ClearMonolithicMetrics sets status condition metrics to zero.
 func ClearMonolithicMetrics(namespace string, name string) {
 	for _, cond := range v1alpha1.AllStatusConditions {
 		condStr := string(cond)

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -2,6 +2,7 @@ package status
 
 import (
 	"context"
+
 	"github.com/grafana/tempo-operator/apis/tempo/v1alpha1"
 	"github.com/grafana/tempo-operator/internal/version"
 )

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -2,7 +2,6 @@ package status
 
 import (
 	"context"
-
 	"github.com/grafana/tempo-operator/apis/tempo/v1alpha1"
 	"github.com/grafana/tempo-operator/internal/version"
 )

--- a/internal/webhooks/tempomonolithic_webhook.go
+++ b/internal/webhooks/tempomonolithic_webhook.go
@@ -52,7 +52,6 @@ func (v *monolithicValidator) ValidateUpdate(ctx context.Context, oldObj, newObj
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
 func (v *monolithicValidator) ValidateDelete(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
-	fmt.Println("monolithic delete")
 	tempo, ok := obj.(*tempov1alpha1.TempoMonolithic)
 	if !ok {
 		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected a TempoMonolithic object but got %T", obj))

--- a/internal/webhooks/tempomonolithic_webhook.go
+++ b/internal/webhooks/tempomonolithic_webhook.go
@@ -18,6 +18,7 @@ import (
 	"github.com/grafana/tempo-operator/apis/tempo/v1alpha1"
 	tempov1alpha1 "github.com/grafana/tempo-operator/apis/tempo/v1alpha1"
 	"github.com/grafana/tempo-operator/internal/handlers/storage"
+	"github.com/grafana/tempo-operator/internal/status"
 )
 
 // TempoMonolithicWebhook provides webhooks for TempoMonolithic CR.
@@ -32,7 +33,7 @@ func (w *TempoMonolithicWebhook) SetupWebhookWithManager(mgr ctrl.Manager, ctrlC
 		Complete()
 }
 
-//+kubebuilder:webhook:path=/validate-tempo-grafana-com-v1alpha1-tempomonolithic,mutating=false,failurePolicy=fail,sideEffects=None,groups=tempo.grafana.com,resources=tempomonolithics,verbs=create;update,versions=v1alpha1,name=vtempomonolithic.kb.io,admissionReviewVersions=v1
+//+kubebuilder:webhook:path=/validate-tempo-grafana-com-v1alpha1-tempomonolithic,mutating=false,failurePolicy=fail,sideEffects=None,groups=tempo.grafana.com,resources=tempomonolithics,verbs=create;update;delete,versions=v1alpha1,name=vtempomonolithic.kb.io,admissionReviewVersions=v1
 
 type monolithicValidator struct {
 	client     client.Client
@@ -50,8 +51,13 @@ func (v *monolithicValidator) ValidateUpdate(ctx context.Context, oldObj, newObj
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
-func (v *monolithicValidator) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
-	// TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
+func (v *monolithicValidator) ValidateDelete(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
+	fmt.Println("monolithic delete")
+	tempo, ok := obj.(*tempov1alpha1.TempoMonolithic)
+	if !ok {
+		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected a TempoMonolithic object but got %T", obj))
+	}
+	status.ClearMonolithicMetrics(tempo.Namespace, tempo.Name)
 	return nil, nil
 }
 

--- a/internal/webhooks/tempostack_webhook.go
+++ b/internal/webhooks/tempostack_webhook.go
@@ -3,7 +3,6 @@ package webhooks
 import (
 	"context"
 	"fmt"
-	"github.com/grafana/tempo-operator/internal/status"
 	"math"
 	"net"
 	"strconv"
@@ -27,6 +26,7 @@ import (
 	"github.com/grafana/tempo-operator/internal/autodetect"
 	"github.com/grafana/tempo-operator/internal/handlers/storage"
 	"github.com/grafana/tempo-operator/internal/manifests/naming"
+	"github.com/grafana/tempo-operator/internal/status"
 )
 
 var (


### PR DESCRIPTION
https://issues.redhat.com/browse/TRACING-4609

Tested with 
```
kubectl apply -f - <<EOF
apiVersion: tempo.grafana.com/v1alpha1
kind: TempoMonolithic
metadata:
  name: simplestmono
spec:
  storage:
    traces:
      backend: s3 
      size: 3Gi 
      s3: 
        secret: minio-test
EOF


kubectl apply -f - <<EOF
apiVersion: tempo.grafana.com/v1alpha1
kind: TempoStack
metadata:
  name: simplest
spec:
  storage:
    secret:
      name: minio-test
      type: s3
  storageSize: 1Gi
EOF
```

Then port-forward the operator 8080 and check for metric `controller_runtime_reconcile_total` 