### PR TITLE
Fix clearing instance metrics when namespace is deleted

### DIFF
--- a/controllers/tempo/tempomonolithic_controller.go
+++ b/controllers/tempo/tempomonolithic_controller.go
@@ -57,6 +57,8 @@ func (r *TempoMonolithicReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			log.Error(err, "unable to fetch TempoMonolithic")
 			return ctrl.Result{}, fmt.Errorf("could not fetch tempo: %w", err)
 		}
+		// instance is not found, metrics can be cleared
+		status.ClearMonolithicMetrics(req.Namespace, req.Name)
 
 		// we'll ignore not-found errors, since they can't be fixed by an immediate
 		// requeue (we'll need to wait for a new notification), and we can get them

--- a/controllers/tempo/tempostack_controller.go
+++ b/controllers/tempo/tempostack_controller.go
@@ -82,6 +82,8 @@ func (r *TempoStackReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			log.Error(err, "unable to fetch TempoStack")
 			return ctrl.Result{}, fmt.Errorf("could not fetch tempo: %w", err)
 		}
+		// instance is not found, metrics can be cleared
+		status.ClearTempoStackMetrics(req.Namespace, req.Name)
 
 		// we'll ignore not-found errors, since they can't be fixed by an immediate
 		// requeue (we'll need to wait for a new notification), and we can get them


### PR DESCRIPTION
Related to #1019
