### PR TITLE
[Chore] Fix tests after standalone Tempo query change

### DIFF
--- a/tests/e2e-openshift-ossm/ossm-tempostack-otel/install-minio.yaml
+++ b/tests/e2e-openshift-ossm/ossm-tempostack-otel/install-minio.yaml
@@ -40,7 +40,7 @@ spec:
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: minio/minio
+          image: quay.io/minio/minio:latest
           name: minio
           ports:
             - containerPort: 9000

--- a/tests/e2e-openshift-ossm/ossm-tempostack-otel/install-tempo.yaml
+++ b/tests/e2e-openshift-ossm/ossm-tempostack-otel/install-tempo.yaml
@@ -12,7 +12,7 @@ spec:
   resources:
     total:
       limits:
-        memory: 2Gi
+        memory: 3Gi
         cpu: 2000m
   template:
     queryFrontend:

--- a/tests/e2e-openshift-ossm/ossm-tempostack/install-minio.yaml
+++ b/tests/e2e-openshift-ossm/ossm-tempostack/install-minio.yaml
@@ -40,7 +40,7 @@ spec:
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: minio/minio
+          image: quay.io/minio/minio:latest
           name: minio
           ports:
             - containerPort: 9000

--- a/tests/e2e-openshift-ossm/ossm-tempostack/install-tempo.yaml
+++ b/tests/e2e-openshift-ossm/ossm-tempostack/install-tempo.yaml
@@ -12,7 +12,7 @@ spec:
   resources:
     total:
       limits:
-        memory: 2Gi
+        memory: 3Gi
         cpu: 2000m
   template:
     queryFrontend:

--- a/tests/e2e-openshift-serverless/otel-tempo-serverless/install-minio.yaml
+++ b/tests/e2e-openshift-serverless/otel-tempo-serverless/install-minio.yaml
@@ -40,7 +40,7 @@ spec:
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: minio/minio
+          image: quay.io/minio/minio:latest
           name: minio
           ports:
             - containerPort: 9000

--- a/tests/e2e-openshift-serverless/tempo-serverless/install-minio.yaml
+++ b/tests/e2e-openshift-serverless/tempo-serverless/install-minio.yaml
@@ -40,7 +40,7 @@ spec:
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: minio/minio
+          image: quay.io/minio/minio:latest
           name: minio
           ports:
             - containerPort: 9000

--- a/tests/e2e-openshift/component-replicas/install-storage.yaml
+++ b/tests/e2e-openshift/component-replicas/install-storage.yaml
@@ -41,7 +41,7 @@ spec:
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: minio/minio
+          image: quay.io/minio/minio:latest
           name: minio
           ports:
             - containerPort: 9000

--- a/tests/e2e-openshift/monitoring-monolithic/install-monolithic-assert.yaml
+++ b/tests/e2e-openshift/monitoring-monolithic/install-monolithic-assert.yaml
@@ -14,6 +14,9 @@ metadata:
   name: tempo-monitor-0
 status:
   containerStatuses:
+  - name: jaeger-query
+    ready: true
+    started: true
   - name: oauth-proxy
     ready: true
     started: true

--- a/tests/e2e-openshift/monitoring/00-install-storage.yaml
+++ b/tests/e2e-openshift/monitoring/00-install-storage.yaml
@@ -48,7 +48,7 @@ spec:
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: minio/minio
+          image: quay.io/minio/minio:latest
           name: minio
           ports:
             - containerPort: 9000

--- a/tests/e2e-openshift/monolithic-multitenancy-openshift/01-assert.yaml
+++ b/tests/e2e-openshift/monolithic-multitenancy-openshift/01-assert.yaml
@@ -12,6 +12,9 @@ metadata:
   name: tempo-monolithic-multitenancy-openshift-0
 status:
   containerStatuses:
+  - name: jaeger-query
+    ready: true
+    started: true
   - name: tempo
     ready: true
     started: true

--- a/tests/e2e-openshift/monolithic-multitenancy-static/03-install-otel.yaml
+++ b/tests/e2e-openshift/monolithic-multitenancy-static/03-install-otel.yaml
@@ -52,7 +52,7 @@ spec:
     spec:
       containers:
       - name: opentelemetry-collector
-        image: otel/opentelemetry-collector-contrib:0.82.0
+        image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.106.1
         command: ["/otelcol-contrib", "--config=/conf/config.yaml"]
         volumeMounts:
         - mountPath: /conf

--- a/tests/e2e-openshift/monolithic-route/install-tempo-assert.yaml
+++ b/tests/e2e-openshift/monolithic-route/install-tempo-assert.yaml
@@ -31,8 +31,97 @@ spec:
         app.kubernetes.io/name: tempo-monolithic
     spec:
       containers:
-      - name: tempo
-      - name: tempo-query
+      - args:
+        - -config.file=/conf/tempo.yaml
+        - -mem-ballast-size-mbs=1024
+        - -log.level=info
+        name: tempo
+        ports:
+        - containerPort: 3200
+          name: http
+          protocol: TCP
+        - containerPort: 3101
+          name: tempo-internal
+          protocol: TCP
+        - containerPort: 4317
+          name: otlp-grpc
+          protocol: TCP
+        - containerPort: 4318
+          name: otlp-http
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /ready
+            port: tempo-internal
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /conf
+          name: tempo-conf
+          readOnly: true
+        - mountPath: /var/tempo
+          name: tempo-storage
+      - args:
+        - --query.base-path=/
+        - --span-storage.type=grpc
+        - --grpc-storage.server=localhost:7777
+        - --query.bearer-token-propagation=true
+        name: jaeger-query
+        ports:
+        - containerPort: 16685
+          name: jaeger-grpc
+          protocol: TCP
+        - containerPort: 16686
+          name: jaeger-ui
+          protocol: TCP
+        - containerPort: 16687
+          name: jaeger-metrics
+          protocol: TCP
+        resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /tmp
+          name: tempo-query-tmp
+      - args:
+        - -config=/conf/tempo-query.yaml
+        name: tempo-query
+        ports:
+        - containerPort: 7777
+          name: proxy-grpc
+          protocol: TCP
+        resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /conf
+          name: tempo-conf
+          readOnly: true
       - args:
         - --cookie-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token
         - --https-address=:8443
@@ -41,13 +130,28 @@ spec:
         - --tls-cert=/etc/tls/private/tls.crt
         - --tls-key=/etc/tls/private/tls.key
         - --upstream=http://localhost:16686
-        - '--openshift-sar={"namespace": "chainsaw-mono-route", "resource": "pods", "verb":
-          "get"}'
+        - '--openshift-sar={"namespace": "chainsaw-mono-route", "resource": "pods",
+          "verb": "get"}'
         name: oauth-proxy
         ports:
         - containerPort: 8443
           name: oauth-proxy
           protocol: TCP
+      volumes:
+      - configMap:
+          defaultMode: 420
+          name: tempo-mono-route-config
+        name: tempo-conf
+      - emptyDir:
+          medium: Memory
+          sizeLimit: 2Gi
+        name: tempo-storage
+      - emptyDir: {}
+        name: tempo-query-tmp
+      - name: mono-route-ui-oauth-proxy-tls
+        secret:
+          defaultMode: 420
+          secretName: mono-route-ui-oauth-proxy-tls
 status:
   availableReplicas: 1
   currentReplicas: 1
@@ -65,6 +169,9 @@ metadata:
   namespace: chainsaw-mono-route
 status:
   containerStatuses:
+  - name: jaeger-query
+    ready: true
+    started: true
   - name: oauth-proxy
     ready: true
     started: true

--- a/tests/e2e-openshift/monolithic-single-tenant-auth/install-tempo-assert.yaml
+++ b/tests/e2e-openshift/monolithic-single-tenant-auth/install-tempo-assert.yaml
@@ -31,8 +31,97 @@ spec:
         app.kubernetes.io/name: tempo-monolithic
     spec:
       containers:
-      - name: tempo
-      - name: tempo-query
+      - args:
+        - -config.file=/conf/tempo.yaml
+        - -mem-ballast-size-mbs=1024
+        - -log.level=info
+        name: tempo
+        ports:
+        - containerPort: 3200
+          name: http
+          protocol: TCP
+        - containerPort: 3101
+          name: tempo-internal
+          protocol: TCP
+        - containerPort: 4317
+          name: otlp-grpc
+          protocol: TCP
+        - containerPort: 4318
+          name: otlp-http
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /ready
+            port: tempo-internal
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /conf
+          name: tempo-conf
+          readOnly: true
+        - mountPath: /var/tempo
+          name: tempo-storage
+      - args:
+        - --query.base-path=/
+        - --span-storage.type=grpc
+        - --grpc-storage.server=localhost:7777
+        - --query.bearer-token-propagation=true
+        name: jaeger-query
+        ports:
+        - containerPort: 16685
+          name: jaeger-grpc
+          protocol: TCP
+        - containerPort: 16686
+          name: jaeger-ui
+          protocol: TCP
+        - containerPort: 16687
+          name: jaeger-metrics
+          protocol: TCP
+        resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /tmp
+          name: tempo-query-tmp
+      - args:
+        - -config=/conf/tempo-query.yaml
+        name: tempo-query
+        ports:
+        - containerPort: 7777
+          name: proxy-grpc
+          protocol: TCP
+        resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /conf
+          name: tempo-conf
+          readOnly: true
       - args:
         - --cookie-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token
         - --https-address=:8443
@@ -48,14 +137,42 @@ spec:
         - containerPort: 8443
           name: oauth-proxy
           protocol: TCP
-        resources:
-          limits:
-            cpu: 200m
-            memory: 512Gi
-          requests:
-            cpu: 100m
-            memory: 256Mi
-
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /oauth/healthz
+            port: oauth-proxy
+            scheme: HTTPS
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/tls/private
+          name: monolithic-st-ui-oauth-proxy-tls
+      volumes:
+      - configMap:
+          defaultMode: 420
+          name: tempo-monolithic-st-config
+        name: tempo-conf
+      - emptyDir:
+          medium: Memory
+          sizeLimit: 2Gi
+        name: tempo-storage
+      - emptyDir: {}
+        name: tempo-query-tmp
+      - name: monolithic-st-ui-oauth-proxy-tls
+        secret:
+          defaultMode: 420
+          secretName: monolithic-st-ui-oauth-proxy-tls
 status:
   availableReplicas: 1
   currentReplicas: 1
@@ -73,6 +190,9 @@ metadata:
   namespace: chainsaw-mst
 status:
   containerStatuses:
+  - name: jaeger-query
+    ready: true
+    started: true
   - name: oauth-proxy
     ready: true
     started: true

--- a/tests/e2e-openshift/multitenancy/00-install-storage.yaml
+++ b/tests/e2e-openshift/multitenancy/00-install-storage.yaml
@@ -46,7 +46,7 @@ spec:
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: minio/minio
+          image: quay.io/minio/minio:latest
           name: minio
           ports:
             - containerPort: 9000

--- a/tests/e2e-openshift/multitenancy/01-assert.yaml
+++ b/tests/e2e-openshift/multitenancy/01-assert.yaml
@@ -128,13 +128,8 @@ metadata:
     app.kubernetes.io/name: tempo
   name: tempo-simplest-gateway
   namespace: chainsaw-multitenancy
-  ownerReferences:
-  - apiVersion: tempo.grafana.com/v1alpha1
-    blockOwnerDeletion: true
-    controller: true
-    kind: TempoStack
-    name: simplest
 spec:
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/component: gateway
@@ -206,10 +201,10 @@ spec:
         resources:
           limits:
             cpu: 120m
-            memory: "107374184"
+            memory: "161061280"
           requests:
             cpu: 36m
-            memory: "32212256"
+            memory: "48318384"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -245,7 +240,6 @@ spec:
         - --opa.package=tempostack
         - --openshift.mappings=dev=tempo.grafana.com
         - --openshift.mappings=prod=tempo.grafana.com
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10
           httpGet:
@@ -310,6 +304,7 @@ spec:
           name: tempo-simplest-gateway-cabundle
         name: cabundle
 status:
+  availableReplicas: 1
   readyReplicas: 1
   replicas: 1
 ---

--- a/tests/e2e-openshift/multitenancy/01-install-tempo.yaml
+++ b/tests/e2e-openshift/multitenancy/01-install-tempo.yaml
@@ -13,7 +13,7 @@ spec:
   resources:
     total:
       limits:
-        memory: 2Gi
+        memory: 3Gi
         cpu: 2000m
   tenants:
     mode: openshift

--- a/tests/e2e-openshift/red-metrics/00-install-storage.yaml
+++ b/tests/e2e-openshift/red-metrics/00-install-storage.yaml
@@ -39,7 +39,7 @@ spec:
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: minio/minio
+          image: quay.io/minio/minio:latest
           name: minio
           ports:
             - containerPort: 9000

--- a/tests/e2e-openshift/red-metrics/04-install-hotrod.yaml
+++ b/tests/e2e-openshift/red-metrics/04-install-hotrod.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: hotrod
-          image: jaegertracing/example-hotrod:1.46.0
+          image: quay.io/jaegertracing/example-hotrod-snapshot:latest
           args:
             - all
             - --otel-exporter=otlp

--- a/tests/e2e-openshift/red-metrics/05-install-generate-traces.yaml
+++ b/tests/e2e-openshift/red-metrics/05-install-generate-traces.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
         - name: hotrod-curl
-          image: curlimages/curl
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
           command: ["/bin/sh", "-c"]
           args:
             - "for i in `seq 1 900`; do for j in `seq 1 10`; do curl http://hotrod:80/dispatch?customer=123 & done; wait; sleep 1; done"

--- a/tests/e2e-openshift/tempo-single-tenant-auth/install-storage.yaml
+++ b/tests/e2e-openshift/tempo-single-tenant-auth/install-storage.yaml
@@ -40,7 +40,7 @@ spec:
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: minio/minio
+          image: quay.io/minio/minio:latest
           name: minio
           ports:
             - containerPort: 9000

--- a/tests/e2e-openshift/tempo-single-tenant-auth/install-tempo-assert.yaml
+++ b/tests/e2e-openshift/tempo-single-tenant-auth/install-tempo-assert.yaml
@@ -30,6 +30,7 @@ metadata:
   name: tempo-tempo-st-query-frontend
   namespace: chainsaw-tst
 spec:
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/component: query-frontend
@@ -47,29 +48,79 @@ spec:
     spec:
       containers:
       - name: tempo
+        ports:
+        - containerPort: 3200
+          name: http
+          protocol: TCP
+        - containerPort: 9095
+          name: grpc
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /conf
+          name: tempo-conf
+          readOnly: true
+        - mountPath: /var/tempo
+          name: tempo-tmp-storage
+        - mountPath: /var/run/ca
+          name: tempo-tempo-st-ca-bundle
+        - mountPath: /var/run/tls/server
+          name: tempo-tempo-st-query-frontend-mtls
+      - name: jaeger-query
+        ports:
+        - containerPort: 16685
+          name: jaeger-grpc
+          protocol: TCP
+        - containerPort: 16686
+          name: jaeger-ui
+          protocol: TCP
+        - containerPort: 16687
+          name: jaeger-metrics
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /tmp
+          name: tempo-tmp-storage-query
+        - mountPath: /var/run/ca
+          name: tempo-tempo-st-ca-bundle
+        - mountPath: /var/run/tls/server
+          name: tempo-tempo-st-query-frontend-mtls
       - name: tempo-query
-      - args:
-        - --cookie-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token
-        - --https-address=:8443
-        - --openshift-service-account=tempo-tempo-st-query-frontend
-        - --provider=openshift
-        - --tls-cert=/etc/tls/private/tls.crt
-        - --tls-key=/etc/tls/private/tls.key
-        - --upstream=http://localhost:16686
-        - '--openshift-sar={"namespace": "chainsaw-mst", "resource": "pods", "verb":
-          "get"}'
-        name: oauth-proxy
+        ports:
+        - containerPort: 7777
+          name: proxy-grpc
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /conf
+          name: tempo-conf
+          readOnly: true
+      - name: oauth-proxy
         ports:
         - containerPort: 8443
           name: oauth-proxy
           protocol: TCP
-        resources:
-          limits:
-            cpu: 200m
-            memory: 512Gi
-          requests:
-            cpu: 100m
-            memory: 256Mi
+        volumeMounts:
+        - mountPath: /etc/tls/private
+          name: tempo-st-ui-oauth-proxy-tls
+      volumes:
+      - configMap:
+          defaultMode: 420
+          name: tempo-tempo-st
+        name: tempo-conf
+      - emptyDir: {}
+        name: tempo-tmp-storage
+      - emptyDir: {}
+        name: tempo-tmp-storage-query
+      - configMap:
+          defaultMode: 420
+          name: tempo-tempo-st-ca-bundle
+        name: tempo-tempo-st-ca-bundle
+      - name: tempo-tempo-st-query-frontend-mtls
+        secret:
+          defaultMode: 420
+          secretName: tempo-tempo-st-query-frontend-mtls
+      - name: tempo-st-ui-oauth-proxy-tls
+        secret:
+          defaultMode: 420
+          secretName: tempo-st-ui-oauth-proxy-tls
 status:
   availableReplicas: 1
   readyReplicas: 1

--- a/tests/e2e-openshift/tempostack-resources/install-storage.yaml
+++ b/tests/e2e-openshift/tempostack-resources/install-storage.yaml
@@ -39,7 +39,7 @@ spec:
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: minio/minio
+          image: quay.io/minio/minio:latest
           name: minio
           ports:
             - containerPort: 9000

--- a/tests/e2e-openshift/tempostack-resources/install-tempostack-assert.yaml
+++ b/tests/e2e-openshift/tempostack-resources/install-tempostack-assert.yaml
@@ -192,19 +192,27 @@ spec:
       - name: tempo
         resources:
           limits:
-            cpu: 160m
-            memory: "85899344"
+            cpu: 80m
+            memory: "42949672"
           requests:
-            cpu: 48m
-            memory: "25769804"
+            cpu: 24m
+            memory: "12884902"
+      - name: jaeger-query
+        resources:
+          limits:
+            cpu: 80m
+            memory: "42949672"
+          requests:
+            cpu: 24m
+            memory: "12884902"
       - name: tempo-query
         resources:
           limits:
-            cpu: 160m
-            memory: "85899344"
+            cpu: 80m
+            memory: "42949672"
           requests:
-            cpu: 48m
-            memory: "25769804"
+            cpu: 24m
+            memory: "12884902"
 status:
   availableReplicas: 1
   readyReplicas: 1

--- a/tests/e2e-openshift/tempostack-resources/update-tempostack-assert.yaml
+++ b/tests/e2e-openshift/tempostack-resources/update-tempostack-assert.yaml
@@ -277,6 +277,14 @@ spec:
           requests:
             cpu: 49m
             memory: 27Mi
+      - name: jaeger-query
+        resources:
+          limits:
+            cpu: 167m
+            memory: 86Mi
+          requests:
+            cpu: 49m
+            memory: 29Mi
       - name: tempo-query
         resources:
           limits:
@@ -289,4 +297,3 @@ status:
   availableReplicas: 1
   readyReplicas: 1
   replicas: 1
-

--- a/tests/e2e-openshift/tempostack-resources/update-tempostack.yaml
+++ b/tests/e2e-openshift/tempostack-resources/update-tempostack.yaml
@@ -82,6 +82,14 @@ spec:
             requests:
               cpu: 49m
               memory: 29Mi
+        tempoQuery:
+          resources:
+            limits:
+              cpu: 161m
+              memory: 83Mi
+            requests:
+              cpu: 49m
+              memory: 29Mi 
         enabled: true
         resources:
           limits:

--- a/tests/e2e-openshift/tls-monolithic-singletenant/00-install-storage.yaml
+++ b/tests/e2e-openshift/tls-monolithic-singletenant/00-install-storage.yaml
@@ -40,7 +40,7 @@ spec:
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: minio/minio
+          image: quay.io/minio/minio:latest
           name: minio
           ports:
             - containerPort: 9000

--- a/tests/e2e-openshift/tls-monolithic-singletenant/01-assert.yaml
+++ b/tests/e2e-openshift/tls-monolithic-singletenant/01-assert.yaml
@@ -31,7 +31,11 @@ spec:
         app.kubernetes.io/name: tempo-monolithic
     spec:
       containers:
-      - name: tempo
+      - args:
+        - -config.file=/conf/tempo.yaml
+        - -mem-ballast-size-mbs=1024
+        - -log.level=info
+        name: tempo
         ports:
         - containerPort: 3200
           name: http
@@ -45,6 +49,25 @@ spec:
         - containerPort: 4318
           name: otlp-http
           protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /ready
+            port: tempo-internal
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /conf
           name: tempo-conf
@@ -57,14 +80,80 @@ spec:
         - mountPath: /var/run/tls/receiver/http
           name: tempo-mono-serving-cert
           readOnly: true
-      - name: tempo-query
+      - args:
+        - --query.base-path=/
+        - --span-storage.type=grpc
+        - --grpc-storage.server=localhost:7777
+        - --query.bearer-token-propagation=true
+        name: jaeger-query
+        ports:
+        - containerPort: 16685
+          name: jaeger-grpc
+          protocol: TCP
+        - containerPort: 16686
+          name: jaeger-ui
+          protocol: TCP
+        - containerPort: 16687
+          name: jaeger-metrics
+          protocol: TCP
+        resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /tmp
+          name: tempo-query-tmp
+      - args:
+        - -config=/conf/tempo-query.yaml
+        name: tempo-query
+        ports:
+        - containerPort: 7777
+          name: proxy-grpc
+          protocol: TCP
+        resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /conf
           name: tempo-conf
           readOnly: true
-        - mountPath: /tmp
-          name: tempo-query-tmp
-      - name: oauth-proxy
+      - args:
+        - --cookie-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token
+        - --https-address=:8443
+        - --openshift-service-account=tempo-mono
+        - --provider=openshift
+        - --tls-cert=/etc/tls/private/tls.crt
+        - --tls-key=/etc/tls/private/tls.key
+        - --upstream=http://localhost:16686
+        - '--openshift-sar={"namespace": "chainsaw-tls-mono-st", "resource": "pods",
+          "verb": "get"}'
+        name: oauth-proxy
+        ports:
+        - containerPort: 8443
+          name: oauth-proxy
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /oauth/healthz
+            port: oauth-proxy
+            scheme: HTTPS
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        resources: {}
         volumeMounts:
         - mountPath: /etc/tls/private
           name: mono-ui-oauth-proxy-tls
@@ -101,6 +190,9 @@ metadata:
   namespace: chainsaw-tls-mono-st
 status:
   containerStatuses:
+  - name: jaeger-query
+    ready: true
+    started: true
   - name: oauth-proxy
     ready: true
     started: true

--- a/tests/e2e-openshift/tls-singletenant/00-install-storage.yaml
+++ b/tests/e2e-openshift/tls-singletenant/00-install-storage.yaml
@@ -46,7 +46,7 @@ spec:
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: minio/minio
+          image: quay.io/minio/minio:latest
           name: minio
           ports:
             - containerPort: 9000

--- a/tests/e2e-openshift/tls-singletenant/01-assert.yaml
+++ b/tests/e2e-openshift/tls-singletenant/01-assert.yaml
@@ -17,14 +17,6 @@ status:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: tempo-simplest-querier
-  namespace: chainsaw-tls-singletenant
-status:
-  readyReplicas: 1
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
   labels:
     app.kubernetes.io/component: query-frontend
     app.kubernetes.io/instance: simplest
@@ -33,6 +25,7 @@ metadata:
   name: tempo-simplest-query-frontend
   namespace: chainsaw-tls-singletenant
 spec:
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/component: query-frontend
@@ -67,7 +60,7 @@ spec:
           name: tempo-simplest-ca-bundle
         - mountPath: /var/run/tls/server
           name: tempo-simplest-query-frontend-mtls
-      - name: tempo-query
+      - name: jaeger-query
         ports:
         - containerPort: 16685
           name: jaeger-grpc
@@ -79,15 +72,21 @@ spec:
           name: jaeger-metrics
           protocol: TCP
         volumeMounts:
-        - mountPath: /conf
-          name: tempo-conf
-          readOnly: true
         - mountPath: /tmp
           name: tempo-tmp-storage-query
         - mountPath: /var/run/ca
           name: tempo-simplest-ca-bundle
         - mountPath: /var/run/tls/server
           name: tempo-simplest-query-frontend-mtls
+      - name: tempo-query
+        ports:
+        - containerPort: 7777
+          name: proxy-grpc
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /conf
+          name: tempo-conf
+          readOnly: true
       volumes:
       - configMap:
           defaultMode: 420

--- a/tests/e2e-upgrade/upgrade/00-install-storage.yaml
+++ b/tests/e2e-upgrade/upgrade/00-install-storage.yaml
@@ -38,7 +38,7 @@ spec:
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: minio/minio
+          image: quay.io/minio/minio:latest
           name: minio
           ports:
             - containerPort: 9000

--- a/tests/e2e/compatibility/00-install-storage.yaml
+++ b/tests/e2e/compatibility/00-install-storage.yaml
@@ -38,7 +38,7 @@ spec:
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: minio/minio
+          image: quay.io/minio/minio:latest
           name: minio
           ports:
             - containerPort: 9000

--- a/tests/e2e/custom-ca/00-install-storage.yaml
+++ b/tests/e2e/custom-ca/00-install-storage.yaml
@@ -33,7 +33,7 @@ spec:
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: minio/minio
+          image: quay.io/minio/minio:latest
           name: minio
           ports:
             - containerPort: 9000

--- a/tests/e2e/monolithic-ingestion-mtls/02-install-otel.yaml
+++ b/tests/e2e/monolithic-ingestion-mtls/02-install-otel.yaml
@@ -50,7 +50,7 @@ spec:
         command:
         - /otelcol-contrib
         - --config=/conf/config.yaml
-        image: otel/opentelemetry-collector-contrib:0.82.0
+        image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.107.0
         ports:
         - name: otlp
           containerPort: 4317

--- a/tests/e2e/monolithic-receivers-tls/02-install-otel.yaml
+++ b/tests/e2e/monolithic-receivers-tls/02-install-otel.yaml
@@ -24,6 +24,7 @@ data:
           http:
     extensions:
       health_check:
+        endpoint: 0.0.0.0:13133
     service:
       extensions: [health_check]
       telemetry:
@@ -67,7 +68,7 @@ spec:
           command:
             - /otelcol-contrib
             - --config=/conf/config.yaml
-          image: "otel/opentelemetry-collector-contrib:0.82.0"
+          image: "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.98.0"
           ports:
             - name: otlp
               containerPort: 4317

--- a/tests/e2e/monolithic-s3-tls/00-install-storage.yaml
+++ b/tests/e2e/monolithic-s3-tls/00-install-storage.yaml
@@ -33,7 +33,7 @@ spec:
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: minio/minio
+          image: quay.io/minio/minio:latest
           name: minio
           ports:
             - containerPort: 9000

--- a/tests/e2e/receivers-mtls/00-install-storage.yaml
+++ b/tests/e2e/receivers-mtls/00-install-storage.yaml
@@ -38,7 +38,7 @@ spec:
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: minio/minio
+          image: quay.io/minio/minio:latest
           name: minio
           ports:
             - containerPort: 9000

--- a/tests/e2e/receivers-mtls/02-install-otel.yaml
+++ b/tests/e2e/receivers-mtls/02-install-otel.yaml
@@ -30,6 +30,7 @@ data:
             endpoint: 0.0.0.0:4318
     extensions:
       health_check:
+        endpoint: 0.0.0.0:13133
     service:
       extensions: [health_check]
       pipelines:
@@ -67,7 +68,7 @@ spec:
           command:
             - /otelcol-contrib
             - --config=/conf/config.yaml
-          image: "otel/opentelemetry-collector-contrib:0.82.0"
+          image: "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.107.0"
           ports:
             - name: otlp
               containerPort: 4317

--- a/tests/e2e/receivers-tls/00-install-storage.yaml
+++ b/tests/e2e/receivers-tls/00-install-storage.yaml
@@ -38,7 +38,7 @@ spec:
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: minio/minio
+          image: quay.io/minio/minio:latest
           name: minio
           ports:
             - containerPort: 9000

--- a/tests/e2e/receivers-tls/02-install-otel.yaml
+++ b/tests/e2e/receivers-tls/02-install-otel.yaml
@@ -28,6 +28,7 @@ data:
             endpoint: 0.0.0.0:4318
     extensions:
       health_check:
+        endpoint: 0.0.0.0:13133
     service:
       extensions: [health_check]
       pipelines:
@@ -65,7 +66,7 @@ spec:
           command:
             - /otelcol-contrib
             - --config=/conf/config.yaml
-          image: "otel/opentelemetry-collector-contrib:0.82.0"
+          image: "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.107.0"
           ports:
             - name: otlp
               containerPort: 4317

--- a/tests/e2e/reconcile/00-install-storage.yaml
+++ b/tests/e2e/reconcile/00-install-storage.yaml
@@ -26,7 +26,7 @@ spec:
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: minio/minio
+          image: quay.io/minio/minio:latest
           name: minio
           ports:
             - containerPort: 9000

--- a/tests/e2e/tempostack-extraconfig/install-storage.yaml
+++ b/tests/e2e/tempostack-extraconfig/install-storage.yaml
@@ -38,7 +38,7 @@ spec:
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: minio/minio
+          image: quay.io/minio/minio:latest
           name: minio
           ports:
             - containerPort: 9000


### PR DESCRIPTION
* Update the tests to use quay  and other image registries like ghcr.io instead of Docker images to avoid rate limiting and issues running in IBM env.
* Fixes tests after the Tempo query standalone changes. https://github.com/grafana/tempo-operator/pull/1025 

We have few bugs that need to be fixed. Due to which the tests need to be updated in a seperate PR after the fixes. 
[Upstream] Tempo query frontend failing with error unknown flag: --prometheus.query.support-spanmetrics-connector 
https://issues.redhat.com/browse/TRACING-4702 
[Upstream] Tempo query container crashing with error opening /var/run/ca/service-ca.crt CA https://issues.redhat.com/browse/TRACING-4703 