### PR TITLE
Kubernetes 1.30 enablement

### DIFF
--- a/.chloggen/enable-130.yaml
+++ b/.chloggen/enable-130.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, github action)
+component: operator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Kubernetes 1.30 enablement
+
+# One or more tracking issues related to the change
+issues: [1030]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -21,9 +21,9 @@ jobs:
         # should be compatible with them.
         include:
           - name: min
-            kube-version: 1.25
+            kube-version: "1.25"
           - name: max
-            kube-version: 1.30
+            kube-version: "1.30"
 
     steps:
     - name: Checkout
@@ -51,7 +51,7 @@ jobs:
       matrix:
         include:
           - name: max
-            kube-version: 1.30
+            kube-version: "1.30"
 
     steps:
     - name: Checkout

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -23,7 +23,7 @@ jobs:
           - name: min
             kube-version: 1.25
           - name: max
-            kube-version: 1.29
+            kube-version: 1.30
 
     steps:
     - name: Checkout
@@ -51,7 +51,7 @@ jobs:
       matrix:
         include:
           - name: max
-            kube-version: 1.29
+            kube-version: 1.30
 
     steps:
     - name: Checkout

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -18,9 +18,9 @@ jobs:
       matrix:
         include:
           - name: min
-            kube-version: 1.25
+            kube-version: "1.25"
           - name: max
-            kube-version: 1.30
+            kube-version: "1.30"
 
     steps:
       - name: Checkout

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -20,7 +20,7 @@ jobs:
           - name: min
             kube-version: 1.25
           - name: max
-            kube-version: 1.29
+            kube-version: 1.30
 
     steps:
       - name: Checkout

--- a/kind-1.30.yaml
+++ b/kind-1.30.yaml
@@ -1,0 +1,18 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+    image: kindest/node:v1.30.4@sha256:34cb98a38a57a3357fde925a41d61232bbbbeb411b45a25c0d766635d6c3b975
+    kubeadmConfigPatches:
+      - |
+        kind: InitConfiguration
+        nodeRegistration:
+          kubeletExtraArgs:
+            node-labels: "ingress-ready=true"
+    extraPortMappings:
+      - containerPort: 80
+        hostPort: 80
+        protocol: TCP
+      - containerPort: 443
+        hostPort: 443
+        protocol: TCP


### PR DESCRIPTION
Enabling operator tests to run on Kubernetes 1.30. Referencing the work of https://github.com/grafana/tempo-operator/pull/807.

Closes #1030 