### PR TITLE
Fix: Dont append deprecated span metrics connector flag

### DIFF
--- a/.chloggen/fix_unknown_flag.yaml
+++ b/.chloggen/fix_unknown_flag.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. tempostack, tempomonolithic, github action)
+component: tempostack, tempomonolithic
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: The operator no longer sets the `--prometheus.query.support-spanmetrics-connector` flag that got removed in Jaeger 1.58.
+
+# One or more tracking issues related to the change
+issues: [1036]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: The Flag controled whether the metrics queries should match the OpenTelemetry Collector's spanmetrics connector naming or spanmetrics processor naming.

--- a/internal/manifests/queryfrontend/query_frontend.go
+++ b/internal/manifests/queryfrontend/query_frontend.go
@@ -366,7 +366,6 @@ func enableMonitoringTab(tempo v1alpha1.TempoStack, jaegerQueryContainer corev1.
 			},
 		},
 		Args: []string{
-			"--prometheus.query.support-spanmetrics-connector",
 			// Just a note that normalization needs to be enabled for < 0.80.0 OTEL collector versions
 			// However, we do not intend to support them.
 			// --prometheus.query.normalize-calls

--- a/internal/manifests/queryfrontend/query_frontend_test.go
+++ b/internal/manifests/queryfrontend/query_frontend_test.go
@@ -615,7 +615,7 @@ func TestBuildQueryFrontendWithJaegerMonitorTab(t *testing.T) {
 					},
 				},
 			},
-			args: []string{"--query.base-path=/", "--span-storage.type=grpc", "--grpc-storage.server=localhost:7777", "--query.bearer-token-propagation=true", "--prometheus.query.support-spanmetrics-connector"},
+			args: []string{"--query.base-path=/", "--span-storage.type=grpc", "--grpc-storage.server=localhost:7777", "--query.bearer-token-propagation=true"},
 			env:  []corev1.EnvVar{{Name: "METRICS_STORAGE_TYPE", Value: "prometheus"}, {Name: "PROMETHEUS_SERVER_URL", Value: "http://prometheus:9091"}},
 		},
 		{
@@ -643,7 +643,6 @@ func TestBuildQueryFrontendWithJaegerMonitorTab(t *testing.T) {
 				"--span-storage.type=grpc",
 				"--grpc-storage.server=localhost:7777",
 				"--query.bearer-token-propagation=true",
-				"--prometheus.query.support-spanmetrics-connector",
 				"--prometheus.tls.enabled=true",
 				"--prometheus.token-file=/var/run/secrets/kubernetes.io/serviceaccount/token",
 				"--prometheus.token-override-from-context=false",


### PR DESCRIPTION
Since [Jaeger 1.58.0](https://github.com/jaegertracing/jaeger/releases/tag/v1.58.0) this flag no longer exists.