### PR TITLE
[Chore] Fix RED metrics test case to ensure monitorTab can display data

### DIFF
--- a/tests/e2e-openshift/red-metrics/03-assert.yaml
+++ b/tests/e2e-openshift/red-metrics/03-assert.yaml
@@ -23,6 +23,24 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: tempo-redmetrics-query-frontend
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: query-frontend
+      app.kubernetes.io/instance: redmetrics
+      app.kubernetes.io/managed-by: tempo-operator
+      app.kubernetes.io/name: tempo
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: query-frontend
+        app.kubernetes.io/instance: redmetrics
+        app.kubernetes.io/managed-by: tempo-operator
+        app.kubernetes.io/name: tempo
+        tempo-gossip-member: "true"
+    spec:
+      serviceAccount: tempo-redmetrics-query-frontend
+      serviceAccountName: tempo-redmetrics-query-frontend
 status:
   readyReplicas: 1
 ---
@@ -48,4 +66,15 @@ roleRef:
   name: cluster-monitoring-view
 subjects:
 - kind: ServiceAccount
+  name: tempo-redmetrics-query-frontend
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/instance: redmetrics
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
   name: tempo-redmetrics-query-frontend

--- a/tests/e2e-openshift/red-metrics/06-assert.yaml
+++ b/tests/e2e-openshift/red-metrics/06-assert.yaml
@@ -1,17 +1,3 @@
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: chainsaw-red-metrics-monitoring-view
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cluster-monitoring-view
-subjects:
-- kind: ServiceAccount
-  name: prometheus-user-workload
-  namespace: openshift-user-workload-monitoring
-
----
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/tests/e2e-openshift/red-metrics/06-install-assert-job.yaml
+++ b/tests/e2e-openshift/red-metrics/06-install-assert-job.yaml
@@ -1,20 +1,3 @@
-# Add the cluter role binding required for fetching metrics from Thanos querier. Refer https://issues.redhat.com/browse/MON-3379
-# The ClusterRoleBinding step is not a Tempo requirement and is used only by the test case to check the metrics using the check_metrics.sh script.
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: chainsaw-red-metrics-monitoring-view
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cluster-monitoring-view
-subjects:
-- kind: ServiceAccount
-  name: prometheus-user-workload
-  namespace: openshift-user-workload-monitoring
-
----
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/tests/e2e-openshift/red-metrics/check_metrics.sh
+++ b/tests/e2e-openshift/red-metrics/check_metrics.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-TOKEN=$(oc create token prometheus-user-workload -n openshift-user-workload-monitoring)
+TOKEN=$(oc create token tempo-redmetrics-query-frontend -n $NAMESPACE)
 THANOS_QUERIER_HOST=$(oc get route thanos-querier -n openshift-monitoring -o json | jq -r '.spec.host')
 
 #Check metrics used in the prometheus rules created for TempoStack. Refer issue https://issues.redhat.com/browse/TRACING-3399 for skipped metrics.


### PR DESCRIPTION
The PR fixes the test case to avoid running into issues like https://issues.redhat.com/browse/TRACING-4608 

* The test case was earlier checking only the ClusterRoleBinding with cluster-monitoring-view was attached to the service account used by query frontend. But the test didn't check if the service account is the correct one used by the query frontend deployment. The updated PR ensures that the right service account is created, used by the deployment and has the monitoring view role. 
* Use the tempo-redmetrics-query-frontend SA token to check the metrics from Thanos querier instead of using the prometheus-user-workload-monitoring SA. The query frontend SA has the monitoring view role. 