### PR TITLE
fix: mount cert and ca to tempo-query

### DIFF
--- a/.chloggen/fix_tls_tempo-query.yaml
+++ b/.chloggen/fix_tls_tempo-query.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. tempostack, tempomonolithic, github action)
+component: tempostack, tempomonolithic
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Mount CA and Certs to tempo-query when tls is enabled.
+
+# One or more tracking issues related to the change
+issues: [1038]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/internal/manifests/queryfrontend/query_frontend.go
+++ b/internal/manifests/queryfrontend/query_frontend.go
@@ -48,11 +48,11 @@ func BuildQueryFrontend(params manifestutils.Params) ([]client.Object, error) {
 
 	if gates.HTTPEncryption || gates.GRPCEncryption {
 		caBundleName := naming.SigningCABundleName(tempo.Name)
-		if err := manifestutils.ConfigureServiceCA(&d.Spec.Template.Spec, caBundleName, 0, 1); err != nil {
+		if err := manifestutils.ConfigureServiceCA(&d.Spec.Template.Spec, caBundleName, 0, 2); err != nil {
 			return nil, err
 		}
 
-		err := manifestutils.ConfigureServicePKI(tempo.Name, manifestutils.QueryFrontendComponentName, &d.Spec.Template.Spec, 0, 1)
+		err := manifestutils.ConfigureServicePKI(tempo.Name, manifestutils.QueryFrontendComponentName, &d.Spec.Template.Spec, 0, 2)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/manifests/queryfrontend/query_frontend.go
+++ b/internal/manifests/queryfrontend/query_frontend.go
@@ -30,6 +30,12 @@ const (
 	thanosQuerierOpenShiftMonitoring = "https://thanos-querier.openshift-monitoring.svc.cluster.local:9091"
 )
 
+const (
+	containerNameTempo       = "tempo"
+	containerNameJaegerQuery = "jaeger-query"
+	containerNameTempoQuery  = "tempo-query"
+)
+
 // BuildQueryFrontend creates the query-frontend objects.
 func BuildQueryFrontend(params manifestutils.Params) ([]client.Object, error) {
 	var manifests []client.Object
@@ -48,11 +54,21 @@ func BuildQueryFrontend(params manifestutils.Params) ([]client.Object, error) {
 
 	if gates.HTTPEncryption || gates.GRPCEncryption {
 		caBundleName := naming.SigningCABundleName(tempo.Name)
-		if err := manifestutils.ConfigureServiceCA(&d.Spec.Template.Spec, caBundleName, 0, 2); err != nil {
+		targetContainers := map[string]struct{}{
+			containerNameTempo:      {},
+			containerNameTempoQuery: {},
+		}
+		targets := []int{}
+		for i, c := range d.Spec.Template.Spec.Containers {
+			if _, exists := targetContainers[c.Name]; exists {
+				targets = append(targets, i)
+			}
+		}
+		if err := manifestutils.ConfigureServiceCA(&d.Spec.Template.Spec, caBundleName, targets...); err != nil {
 			return nil, err
 		}
 
-		err := manifestutils.ConfigureServicePKI(tempo.Name, manifestutils.QueryFrontendComponentName, &d.Spec.Template.Spec, 0, 2)
+		err := manifestutils.ConfigureServicePKI(tempo.Name, manifestutils.QueryFrontendComponentName, &d.Spec.Template.Spec, targets...)
 		if err != nil {
 			return nil, err
 		}
@@ -177,7 +193,7 @@ func deployment(params manifestutils.Params) (*appsv1.Deployment, error) {
 					Affinity:           manifestutils.DefaultAffinity(labels),
 					Containers: []corev1.Container{
 						{
-							Name:  "tempo",
+							Name:  containerNameTempo,
 							Image: tempoImage,
 							Env:   proxy.ReadProxyVarsFromEnv(),
 							Args: []string{
@@ -239,7 +255,7 @@ func deployment(params manifestutils.Params) (*appsv1.Deployment, error) {
 
 	if tempo.Spec.Template.QueryFrontend.JaegerQuery.Enabled {
 		jaegerQueryContainer := corev1.Container{
-			Name:  "jaeger-query",
+			Name:  containerNameJaegerQuery,
 			Image: jaegerQueryImage,
 			Env:   proxy.ReadProxyVarsFromEnv(),
 			Args: []string{
@@ -276,7 +292,7 @@ func deployment(params manifestutils.Params) (*appsv1.Deployment, error) {
 		}
 
 		tempoProxyContainer := corev1.Container{
-			Name:  "tempo-query",
+			Name:  containerNameTempoQuery,
 			Image: tempoQueryImage,
 			Env:   proxy.ReadProxyVarsFromEnv(),
 			Args: []string{


### PR DESCRIPTION
Details: https://issues.redhat.com/browse/TRACING-4703

```bash
$ k get pods -n chainsaw-replicas       
NAME                                           READY   STATUS    RESTARTS   AGE
minio-679d9f746b-hngng                         1/1     Running   0          14m
tempo-cmpreps-compactor-bd74cd5c7-mlq2z        1/1     Running   0          6m2s
tempo-cmpreps-distributor-6bc6b5856f-dv92t     1/1     Running   0          6m2s
tempo-cmpreps-gateway-5897b57875-6wltl         2/2     Running   0          6m2s
tempo-cmpreps-ingester-0                       1/1     Running   0          6m2s
tempo-cmpreps-querier-7b74976fd4-d62hd         1/1     Running   0          6m2s
tempo-cmpreps-query-frontend-5558ffd89-5krzk   3/3     Running   0          6m2s
```