### PR TITLE
[Chore] Fix asserts and bump resources for tests

### DIFF
--- a/tests/e2e-openshift/tempo-single-tenant-auth/install-tempo-assert.yaml
+++ b/tests/e2e-openshift/tempo-single-tenant-auth/install-tempo-assert.yaml
@@ -79,10 +79,6 @@ spec:
         volumeMounts:
         - mountPath: /tmp
           name: tempo-tmp-storage-query
-        - mountPath: /var/run/ca
-          name: tempo-tempo-st-ca-bundle
-        - mountPath: /var/run/tls/server
-          name: tempo-tempo-st-query-frontend-mtls
       - name: tempo-query
         ports:
         - containerPort: 7777
@@ -92,6 +88,10 @@ spec:
         - mountPath: /conf
           name: tempo-conf
           readOnly: true
+        - mountPath: /var/run/ca
+          name: tempo-tempo-st-ca-bundle
+        - mountPath: /var/run/tls/server
+          name: tempo-tempo-st-query-frontend-mtls
       - name: oauth-proxy
         ports:
         - containerPort: 8443

--- a/tests/e2e-openshift/tempo-single-tenant-auth/install-tempo.yaml
+++ b/tests/e2e-openshift/tempo-single-tenant-auth/install-tempo.yaml
@@ -12,7 +12,7 @@ spec:
   resources:
     total:
       limits:
-        memory: 2Gi
+        memory: 4Gi
         cpu: 2000m
   template:
     queryFrontend:

--- a/tests/e2e-openshift/tls-singletenant/01-assert.yaml
+++ b/tests/e2e-openshift/tls-singletenant/01-assert.yaml
@@ -74,10 +74,6 @@ spec:
         volumeMounts:
         - mountPath: /tmp
           name: tempo-tmp-storage-query
-        - mountPath: /var/run/ca
-          name: tempo-simplest-ca-bundle
-        - mountPath: /var/run/tls/server
-          name: tempo-simplest-query-frontend-mtls
       - name: tempo-query
         ports:
         - containerPort: 7777
@@ -87,6 +83,10 @@ spec:
         - mountPath: /conf
           name: tempo-conf
           readOnly: true
+        - mountPath: /var/run/ca
+          name: tempo-simplest-ca-bundle
+        - mountPath: /var/run/tls/server
+          name: tempo-simplest-query-frontend-mtls
       volumes:
       - configMap:
           defaultMode: 420

--- a/tests/e2e-openshift/tls-singletenant/01-install-tempo.yaml
+++ b/tests/e2e-openshift/tls-singletenant/01-install-tempo.yaml
@@ -13,7 +13,7 @@ spec:
   resources:
     total:
       limits:
-        memory: 2Gi
+        memory: 4Gi
         cpu: 2000m
   template:
     distributor:


### PR DESCRIPTION
The PR fixes tests after https://github.com/grafana/tempo-operator/pull/1038 change and bumps the resource limits as the distribution of resources among the containers in query frontend pod is reduced after resource allocation and enforcing of limits on Tempo Query container. 