### PR TITLE
[Chore] Test timeout for non-multitenant TempoStack and TempoMonolithic instances.

### DIFF
--- a/tests/e2e-openshift/monolithic-route/chainsaw-test.yaml
+++ b/tests/e2e-openshift/monolithic-route/chainsaw-test.yaml
@@ -1,4 +1,3 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:

--- a/tests/e2e-openshift/monolithic-route/install-tempo-assert.yaml
+++ b/tests/e2e-openshift/monolithic-route/install-tempo-assert.yaml
@@ -130,7 +130,7 @@ spec:
         - --tls-cert=/etc/tls/private/tls.crt
         - --tls-key=/etc/tls/private/tls.key
         - --upstream=http://localhost:16686
-        - --upstream-timeout=70s
+        - --upstream-timeout=2m0s
         - '--openshift-sar={"namespace": "chainsaw-mono-route", "resource": "pods",
           "verb": "get"}'
         name: oauth-proxy
@@ -249,19 +249,59 @@ spec:
     app.kubernetes.io/instance: mono-route
     app.kubernetes.io/managed-by: tempo-operator
     app.kubernetes.io/name: tempo-monolithic
+
+---
+apiVersion: v1
+data:
+  tempo-query.yaml: |
+    address: 127.0.0.1:7777
+    backend: 127.0.0.1:3200
+    tenant_header_key: x-scope-orgid
+    services_query_duration: 72h0m0s
+  tempo.yaml: |
+    server:
+      http_listen_port: 3200
+      http_server_read_timeout: 2m0s
+      http_server_write_timeout: 2m0s
+    internal_server:
+      enable: true
+      http_listen_address: 0.0.0.0
+    storage:
+      trace:
+        backend: local
+        wal:
+          path: /var/tempo/wal
+        local:
+          path: /var/tempo/blocks
+    distributor:
+      receivers:
+        otlp:
+          protocols:
+            grpc: {}
+            http: {}
+    usage_report:
+      reporting_enabled: false
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: config
+    app.kubernetes.io/instance: mono-route
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo-monolithic
+  name: tempo-mono-route-config
+
 ---
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
+  annotations:
+    haproxy.router.openshift.io/timeout: 120s
   labels:
     app.kubernetes.io/component: jaegerui
     app.kubernetes.io/instance: mono-route
     app.kubernetes.io/managed-by: tempo-operator
     app.kubernetes.io/name: tempo-monolithic
-  name: tempo-mono-jaegerui
-  namespace: chainsaw-mono-route
-  annotations:
-    haproxy.router.openshift.io/timeout: 70s
+  name: tempo-mono-route-jaegerui
 spec:
   port:
     targetPort: oauth-proxy
@@ -269,4 +309,6 @@ spec:
     termination: reencrypt
   to:
     kind: Service
-    name: tempo-mono-jaegerui
+    name: tempo-mono-route-jaegerui
+    weight: 100
+  wildcardPolicy: None

--- a/tests/e2e-openshift/monolithic-route/install-tempo.yaml
+++ b/tests/e2e-openshift/monolithic-route/install-tempo.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mono-route
   namespace: chainsaw-mono-route
 spec:
-  timeout: 70s
+  timeout: 2m
   jaegerui:
     enabled: true
     route:

--- a/tests/e2e-openshift/route/chainsaw-test.yaml
+++ b/tests/e2e-openshift/route/chainsaw-test.yaml
@@ -4,10 +4,22 @@ kind: Test
 metadata:
   name: route
 spec:
+  namespace: chainsaw-route
   steps:
+  - name: Install Minio storage
+    try:
+    - apply:
+        file: install-storage.yaml
+    - assert:
+        file: install-storage-assert.yaml
   - name: Install TempoStack with ingress type route
     try:
     - apply:
         file: install-tempo.yaml
     - assert:
         file: install-tempo-assert.yaml
+  - name: Check the status of TempoStack
+    try:
+    - script:
+        timeout: 5m
+        content: kubectl get --namespace $NAMESPACE tempo simplest -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' | grep True

--- a/tests/e2e-openshift/route/install-storage-assert.yaml
+++ b/tests/e2e-openshift/route/install-storage-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+status:
+  readyReplicas: 1

--- a/tests/e2e-openshift/route/install-storage.yaml
+++ b/tests/e2e-openshift/route/install-storage.yaml
@@ -1,0 +1,75 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app.kubernetes.io/name: minio
+  name: minio
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: minio
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: minio
+    spec:
+      containers:
+        - command:
+            - /bin/sh
+            - -c
+            - |
+              mkdir -p /storage/tempo && \
+              minio server /storage
+          env:
+            - name: MINIO_ACCESS_KEY
+              value: tempo
+            - name: MINIO_SECRET_KEY
+              value: supersecret
+          image: quay.io/minio/minio:latest
+          name: minio
+          ports:
+            - containerPort: 9000
+          volumeMounts:
+            - mountPath: /storage
+              name: storage
+      volumes:
+        - name: storage
+          persistentVolumeClaim:
+            claimName: minio
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+spec:
+  ports:
+    - port: 9000
+      protocol: TCP
+      targetPort: 9000
+  selector:
+    app.kubernetes.io/name: minio
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio
+stringData:
+  endpoint: http://minio:9000
+  bucket: tempo
+  access_key_id: tempo
+  access_key_secret: supersecret
+type: Opaque

--- a/tests/e2e-openshift/route/install-tempo-assert.yaml
+++ b/tests/e2e-openshift/route/install-tempo-assert.yaml
@@ -3,7 +3,7 @@ kind: Route
 metadata:
   annotations:
     example_annotation: example_value
-    haproxy.router.openshift.io/timeout: 30s
+    haproxy.router.openshift.io/timeout: 120s
   labels:
     app.kubernetes.io/component: query-frontend
     app.kubernetes.io/instance: simplest
@@ -20,3 +20,337 @@ spec:
     kind: Service
     name: tempo-simplest-query-frontend
     weight: 100
+
+---
+apiVersion: v1
+data:
+  overrides.yaml: |
+    overrides:
+  tempo-query-frontend.yaml: |
+    compactor:
+      compaction:
+        block_retention: 48h0m0s
+      ring:
+        kvstore:
+          store: memberlist
+    distributor:
+      receivers:
+        jaeger:
+          protocols:
+            thrift_http:
+              endpoint: 0.0.0.0:14268
+            thrift_binary:
+              endpoint: 0.0.0.0:6832
+            thrift_compact:
+              endpoint: 0.0.0.0:6831
+            grpc:
+              endpoint: 0.0.0.0:14250
+        zipkin:
+        otlp:
+          protocols:
+            grpc:
+              endpoint: 0.0.0.0:4317
+            http:
+              endpoint: 0.0.0.0:4318
+      ring:
+        kvstore:
+          store: memberlist
+    ingester:
+      lifecycler:
+        ring:
+          kvstore:
+            store: memberlist
+          replication_factor: 1
+        tokens_file_path: /var/tempo/tokens.json
+      max_block_duration: 10m
+    memberlist:
+      abort_if_cluster_join_fails: false
+      join_members:
+      - tempo-simplest-gossip-ring
+    multitenancy_enabled: false
+    querier:
+      max_concurrent_queries: 20
+      frontend_worker:
+        frontend_address: tempo-simplest-query-frontend-discovery:9095
+        grpc_client_config:
+          tls_enabled: true
+          tls_cert_path:  /var/run/tls/server/tls.crt
+          tls_key_path: /var/run/tls/server/tls.key
+          tls_ca_path: /var/run/ca/service-ca.crt
+          tls_server_name: tempo-simplest-query-frontend.chainsaw-route.svc.cluster.local
+          tls_min_version: VersionTLS13
+      search:
+        external_hedge_requests_at: 8s
+        external_hedge_requests_up_to: 2
+    server:
+      grpc_server_max_recv_msg_size: 4194304
+      grpc_server_max_send_msg_size: 4194304
+      http_listen_port: 3200
+      http_server_read_timeout: 2m0s
+      http_server_write_timeout: 2m0s
+      log_format: logfmt
+      tls_min_version: VersionTLS13
+      grpc_tls_config:
+        cert_file:  /var/run/tls/server/tls.crt
+        key_file: /var/run/tls/server/tls.key
+        client_ca_file: /var/run/ca/service-ca.crt
+        client_auth_type: RequireAndVerifyClientCert
+    storage:
+      trace:
+        backend: s3
+        blocklist_poll: 5m
+        cache: none
+        s3:
+          endpoint: minio:9000
+          bucket: tempo
+          insecure: true
+        local:
+          path: /var/tempo/traces
+        wal:
+          path: /var/tempo/wal
+    usage_report:
+      reporting_enabled: false
+    query_frontend:
+      search:
+        concurrent_jobs: 2000
+        max_duration: 0s
+        default_result_limit: 20
+    ingester_client:
+      grpc_client_config:
+        tls_enabled: true
+        tls_cert_path:  /var/run/tls/server/tls.crt
+        tls_key_path: /var/run/tls/server/tls.key
+        tls_ca_path: /var/run/ca/service-ca.crt
+        tls_server_name: tempo-simplest-ingester.chainsaw-route.svc.cluster.local
+        tls_insecure_skip_verify: false
+        tls_min_version: VersionTLS13
+  tempo-query.yaml: |
+    address: 127.0.0.1:7777
+    backend: 127.0.0.1:3200
+    tenant_header_key: x-scope-orgid
+    services_query_duration: 72h0m0s
+  tempo.yaml: |
+    compactor:
+      compaction:
+        block_retention: 48h0m0s
+      ring:
+        kvstore:
+          store: memberlist
+    distributor:
+      receivers:
+        jaeger:
+          protocols:
+            thrift_http:
+              endpoint: 0.0.0.0:14268
+            thrift_binary:
+              endpoint: 0.0.0.0:6832
+            thrift_compact:
+              endpoint: 0.0.0.0:6831
+            grpc:
+              endpoint: 0.0.0.0:14250
+        zipkin:
+        otlp:
+          protocols:
+            grpc:
+              endpoint: 0.0.0.0:4317
+            http:
+              endpoint: 0.0.0.0:4318
+      ring:
+        kvstore:
+          store: memberlist
+    ingester:
+      lifecycler:
+        ring:
+          kvstore:
+            store: memberlist
+          replication_factor: 1
+        tokens_file_path: /var/tempo/tokens.json
+      max_block_duration: 10m
+    memberlist:
+      abort_if_cluster_join_fails: false
+      join_members:
+      - tempo-simplest-gossip-ring
+    multitenancy_enabled: false
+    querier:
+      max_concurrent_queries: 20
+      frontend_worker:
+        frontend_address: tempo-simplest-query-frontend-discovery:9095
+        grpc_client_config:
+          tls_enabled: true
+          tls_cert_path:  /var/run/tls/server/tls.crt
+          tls_key_path: /var/run/tls/server/tls.key
+          tls_ca_path: /var/run/ca/service-ca.crt
+          tls_server_name: tempo-simplest-query-frontend.chainsaw-route.svc.cluster.local
+          tls_min_version: VersionTLS13
+      search:
+        external_hedge_requests_at: 8s
+        external_hedge_requests_up_to: 2
+    internal_server:
+      enable: true
+      http_listen_address: ""
+      tls_min_version: VersionTLS13
+      http_tls_config:
+        cert_file: /var/run/tls/server/tls.crt
+        key_file: /var/run/tls/server/tls.key
+    server:
+      grpc_server_max_recv_msg_size: 4194304
+      grpc_server_max_send_msg_size: 4194304
+      http_listen_port: 3200
+      http_server_read_timeout: 2m0s
+      http_server_write_timeout: 2m0s
+      log_format: logfmt
+      tls_min_version: VersionTLS13
+      grpc_tls_config:
+        cert_file:  /var/run/tls/server/tls.crt
+        key_file: /var/run/tls/server/tls.key
+        client_ca_file: /var/run/ca/service-ca.crt
+        client_auth_type: RequireAndVerifyClientCert
+      http_tls_config:
+        cert_file:  /var/run/tls/server/tls.crt
+        client_auth_type: RequireAndVerifyClientCert
+        key_file: /var/run/tls/server/tls.key
+        client_ca_file: /var/run/ca/service-ca.crt
+    storage:
+      trace:
+        backend: s3
+        blocklist_poll: 5m
+        cache: none
+        s3:
+          endpoint: minio:9000
+          bucket: tempo
+          insecure: true
+        local:
+          path: /var/tempo/traces
+        wal:
+          path: /var/tempo/wal
+    usage_report:
+      reporting_enabled: false
+    query_frontend:
+      search:
+        concurrent_jobs: 2000
+        max_duration: 0s
+        default_result_limit: 20
+    ingester_client:
+      grpc_client_config:
+        tls_enabled: true
+        tls_cert_path:  /var/run/tls/server/tls.crt
+        tls_key_path: /var/run/tls/server/tls.key
+        tls_ca_path: /var/run/ca/service-ca.crt
+        tls_server_name: tempo-simplest-ingester.chainsaw-route.svc.cluster.local
+        tls_insecure_skip_verify: false
+        tls_min_version: VersionTLS13
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: config
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+  name: tempo-simplest
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: compactor
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+  name: tempo-simplest-compactor
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: distributor
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+  name: tempo-simplest-distributor
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: querier
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+  name: tempo-simplest-querier
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+  name: tempo-simplest-query-frontend
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: query-frontend
+      app.kubernetes.io/instance: simplest
+      app.kubernetes.io/managed-by: tempo-operator
+      app.kubernetes.io/name: tempo
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: query-frontend
+        app.kubernetes.io/instance: simplest
+        app.kubernetes.io/managed-by: tempo-operator
+        app.kubernetes.io/name: tempo
+        tempo-gossip-member: "true"
+    spec:
+      containers:
+      - name: tempo
+      - name: jaeger-query
+      - name: tempo-query
+      - args:
+        - --cookie-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token
+        - --https-address=:8443
+        - --openshift-service-account=tempo-simplest-query-frontend
+        - --provider=openshift
+        - --tls-cert=/etc/tls/private/tls.crt
+        - --tls-key=/etc/tls/private/tls.key
+        - --upstream=http://localhost:16686
+        - --upstream-timeout=2m0s
+        - '--openshift-sar={"namespace": "chainsaw-route", "resource": "pods", "verb": "get"}'
+        name: oauth-proxy
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    app.kubernetes.io/component: ingester
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+  name: tempo-simplest-ingester
+status:
+  availableReplicas: 1
+  currentReplicas: 1
+  readyReplicas: 1
+  replicas: 1

--- a/tests/e2e-openshift/route/install-tempo.yaml
+++ b/tests/e2e-openshift/route/install-tempo.yaml
@@ -16,10 +16,10 @@ kind: TempoStack
 metadata:
   name: simplest
 spec:
-  timeout: 70s
+  timeout: 2m
   storage:
     secret:
-      name: minio-test
+      name: minio
       type: s3
   storageSize: 200M
   template:

--- a/tests/e2e-openshift/tls-monolithic-singletenant/01-assert.yaml
+++ b/tests/e2e-openshift/tls-monolithic-singletenant/01-assert.yaml
@@ -276,6 +276,8 @@ spec:
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
+  annotations:
+    haproxy.router.openshift.io/timeout: 30s
   labels:
     app.kubernetes.io/component: jaegerui
     app.kubernetes.io/instance: mono
@@ -291,3 +293,52 @@ spec:
   to:
     kind: Service
     name: tempo-mono-jaegerui
+  
+---
+apiVersion: v1
+data:
+  tempo-query.yaml: |
+    address: 127.0.0.1:7777
+    backend: 127.0.0.1:3200
+    tenant_header_key: x-scope-orgid
+    services_query_duration: 72h0m0s
+  tempo.yaml: |
+    server:
+      http_listen_port: 3200
+      http_server_read_timeout: 30s
+      http_server_write_timeout: 30s
+    internal_server:
+      enable: true
+      http_listen_address: 0.0.0.0
+    storage:
+      trace:
+        backend: local
+        wal:
+          path: /var/tempo/wal
+        local:
+          path: /var/tempo/blocks
+    distributor:
+      receivers:
+        otlp:
+          protocols:
+            grpc:
+              tls:
+                cert_file: /var/run/tls/receiver/grpc/tls.crt
+                key_file: /var/run/tls/receiver/grpc/tls.key
+                min_version: "1.3"
+            http:
+              tls:
+                cert_file: /var/run/tls/receiver/http/tls.crt
+                key_file: /var/run/tls/receiver/http/tls.key
+                min_version: "1.3"
+    usage_report:
+      reporting_enabled: false
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: config
+    app.kubernetes.io/instance: mono
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo-monolithic
+  name: tempo-mono-config
+

--- a/tests/e2e-openshift/tls-singletenant/01-assert.yaml
+++ b/tests/e2e-openshift/tls-singletenant/01-assert.yaml
@@ -87,6 +87,18 @@ spec:
           name: tempo-simplest-ca-bundle
         - mountPath: /var/run/tls/server
           name: tempo-simplest-query-frontend-mtls
+      - args:
+        - --cookie-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token
+        - --https-address=:8443
+        - --openshift-service-account=tempo-simplest-query-frontend
+        - --provider=openshift
+        - --tls-cert=/etc/tls/private/tls.crt
+        - --tls-key=/etc/tls/private/tls.key
+        - --upstream=http://localhost:16686
+        - --upstream-timeout=30s
+        - '--openshift-sar={"namespace": "chainsaw-tls-singletenant", "resource":
+          "pods", "verb": "get"}'
+        name: oauth-proxy
       volumes:
       - configMap:
           defaultMode: 420
@@ -104,15 +116,133 @@ spec:
         secret:
           defaultMode: 420
           secretName: tempo-simplest-query-frontend-mtls
+      - name: simplest-ui-oauth-proxy-tls
+        secret:
+          defaultMode: 420
+          secretName: simplest-ui-oauth-proxy-tls
 status:
   availableReplicas: 1
   readyReplicas: 1
   replicas: 1
+
 ---
-apiVersion: apps/v1
-kind: StatefulSet
+apiVersion: route.openshift.io/v1
+kind: Route
 metadata:
-  name: tempo-simplest-ingester
+  annotations:
+    haproxy.router.openshift.io/timeout: 30s
+  labels:
+    app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+  name: tempo-simplest-query-frontend
+spec:
+  port:
+    targetPort: oauth-proxy
+  tls:
+    termination: reencrypt
+  to:
+    kind: Service
+    name: tempo-simplest-query-frontend
+    weight: 100
+  wildcardPolicy: None
+
+---
+apiVersion: v1
+data:
+  overrides.yaml: |
+    overrides:
+  tempo-query-frontend.yaml: "compactor:\n  compaction:\n    block_retention: 48h0m0s\n
+    \ ring:\n    kvstore:\n      store: memberlist\ndistributor:\n  receivers:\n    jaeger:\n
+    \     protocols:\n        thrift_http:\n          endpoint: 0.0.0.0:14268\n          tls:\n
+    \           cert_file: /var/run/tls/receiver/tls.crt\n            key_file: /var/run/tls/receiver/tls.key\n
+    \           min_version: \n        thrift_binary:\n          endpoint: 0.0.0.0:6832\n
+    \       thrift_compact:\n          endpoint: 0.0.0.0:6831\n        grpc:\n          endpoint:
+    0.0.0.0:14250\n          tls:\n            cert_file: /var/run/tls/receiver/tls.crt\n
+    \           key_file: /var/run/tls/receiver/tls.key\n            min_version:
+    \n    zipkin:\n      tls:\n        cert_file: /var/run/tls/receiver/tls.crt\n
+    \       key_file: /var/run/tls/receiver/tls.key\n        min_version: \n    otlp:\n
+    \     protocols:\n        grpc:\n          endpoint: 0.0.0.0:4317\n          tls:\n
+    \           cert_file: /var/run/tls/receiver/tls.crt\n            key_file: /var/run/tls/receiver/tls.key\n
+    \           min_version: \n        http:\n          endpoint: 0.0.0.0:4318\n          tls:\n
+    \           cert_file: /var/run/tls/receiver/tls.crt\n            key_file: /var/run/tls/receiver/tls.key\n
+    \           min_version: \n  ring:\n    kvstore:\n      store: memberlist\ningester:\n
+    \ lifecycler:\n    ring:\n      kvstore:\n        store: memberlist\n      replication_factor:
+    1\n    tokens_file_path: /var/tempo/tokens.json\n  max_block_duration: 10m\nmemberlist:\n
+    \ abort_if_cluster_join_fails: false\n  join_members:\n  - tempo-simplest-gossip-ring\nmultitenancy_enabled:
+    false\nquerier:\n  max_concurrent_queries: 20\n  frontend_worker:\n    frontend_address:
+    tempo-simplest-query-frontend-discovery:9095\n    grpc_client_config:\n      tls_enabled:
+    true\n      tls_cert_path:  /var/run/tls/server/tls.crt\n      tls_key_path: /var/run/tls/server/tls.key\n
+    \     tls_ca_path: /var/run/ca/service-ca.crt\n      tls_server_name: tempo-simplest-query-frontend.chainsaw-tls-singletenant.svc.cluster.local\n
+    \     tls_min_version: VersionTLS13\n  search:\n    external_hedge_requests_at:
+    8s\n    external_hedge_requests_up_to: 2\nserver:\n  grpc_server_max_recv_msg_size:
+    4194304\n  grpc_server_max_send_msg_size: 4194304\n  http_listen_port: 3200\n
+    \ http_server_read_timeout: 30s\n  http_server_write_timeout: 30s\n  log_format:
+    logfmt\n  tls_min_version: VersionTLS13\n  grpc_tls_config:\n    cert_file:  /var/run/tls/server/tls.crt\n
+    \   key_file: /var/run/tls/server/tls.key\n    client_ca_file: /var/run/ca/service-ca.crt\n
+    \   client_auth_type: RequireAndVerifyClientCert\nstorage:\n  trace:\n    backend:
+    s3\n    blocklist_poll: 5m\n    cache: none\n    s3:\n      endpoint: minio:9000\n
+    \     bucket: tempo\n      insecure: true\n    local:\n      path: /var/tempo/traces\n
+    \   wal:\n      path: /var/tempo/wal\nusage_report:\n  reporting_enabled: false\nquery_frontend:\n
+    \ search:\n    concurrent_jobs: 2000\n    max_duration: 0s\n    default_result_limit:
+    20\ningester_client:\n  grpc_client_config:\n    tls_enabled: true\n    tls_cert_path:
+    \ /var/run/tls/server/tls.crt\n    tls_key_path: /var/run/tls/server/tls.key\n
+    \   tls_ca_path: /var/run/ca/service-ca.crt\n    tls_server_name: tempo-simplest-ingester.chainsaw-tls-singletenant.svc.cluster.local\n
+    \   tls_insecure_skip_verify: false\n    tls_min_version: VersionTLS13\n"
+  tempo-query.yaml: |
+    address: 127.0.0.1:7777
+    backend: 127.0.0.1:3200
+    tenant_header_key: x-scope-orgid
+    services_query_duration: 72h0m0s
+  tempo.yaml: "compactor:\n  compaction:\n    block_retention: 48h0m0s\n  ring:\n
+    \   kvstore:\n      store: memberlist\ndistributor:\n  receivers:\n    jaeger:\n
+    \     protocols:\n        thrift_http:\n          endpoint: 0.0.0.0:14268\n          tls:\n
+    \           cert_file: /var/run/tls/receiver/tls.crt\n            key_file: /var/run/tls/receiver/tls.key\n
+    \           min_version: \n        thrift_binary:\n          endpoint: 0.0.0.0:6832\n
+    \       thrift_compact:\n          endpoint: 0.0.0.0:6831\n        grpc:\n          endpoint:
+    0.0.0.0:14250\n          tls:\n            cert_file: /var/run/tls/receiver/tls.crt\n
+    \           key_file: /var/run/tls/receiver/tls.key\n            min_version:
+    \n    zipkin:\n      tls:\n        cert_file: /var/run/tls/receiver/tls.crt\n
+    \       key_file: /var/run/tls/receiver/tls.key\n        min_version: \n    otlp:\n
+    \     protocols:\n        grpc:\n          endpoint: 0.0.0.0:4317\n          tls:\n
+    \           cert_file: /var/run/tls/receiver/tls.crt\n            key_file: /var/run/tls/receiver/tls.key\n
+    \           min_version: \n        http:\n          endpoint: 0.0.0.0:4318\n          tls:\n
+    \           cert_file: /var/run/tls/receiver/tls.crt\n            key_file: /var/run/tls/receiver/tls.key\n
+    \           min_version: \n  ring:\n    kvstore:\n      store: memberlist\ningester:\n
+    \ lifecycler:\n    ring:\n      kvstore:\n        store: memberlist\n      replication_factor:
+    1\n    tokens_file_path: /var/tempo/tokens.json\n  max_block_duration: 10m\nmemberlist:\n
+    \ abort_if_cluster_join_fails: false\n  join_members:\n  - tempo-simplest-gossip-ring\nmultitenancy_enabled:
+    false\nquerier:\n  max_concurrent_queries: 20\n  frontend_worker:\n    frontend_address:
+    tempo-simplest-query-frontend-discovery:9095\n    grpc_client_config:\n      tls_enabled:
+    true\n      tls_cert_path:  /var/run/tls/server/tls.crt\n      tls_key_path: /var/run/tls/server/tls.key\n
+    \     tls_ca_path: /var/run/ca/service-ca.crt\n      tls_server_name: tempo-simplest-query-frontend.chainsaw-tls-singletenant.svc.cluster.local\n
+    \     tls_min_version: VersionTLS13\n  search:\n    external_hedge_requests_at:
+    8s\n    external_hedge_requests_up_to: 2\ninternal_server:\n  enable: true\n  http_listen_address:
+    \"\"\n  tls_min_version: VersionTLS13\n  http_tls_config:\n    cert_file: /var/run/tls/server/tls.crt\n
+    \   key_file: /var/run/tls/server/tls.key\nserver:\n  grpc_server_max_recv_msg_size:
+    4194304\n  grpc_server_max_send_msg_size: 4194304\n  http_listen_port: 3200\n
+    \ http_server_read_timeout: 30s\n  http_server_write_timeout: 30s\n  log_format:
+    logfmt\n  tls_min_version: VersionTLS13\n  grpc_tls_config:\n    cert_file:  /var/run/tls/server/tls.crt\n
+    \   key_file: /var/run/tls/server/tls.key\n    client_ca_file: /var/run/ca/service-ca.crt\n
+    \   client_auth_type: RequireAndVerifyClientCert\n  http_tls_config:\n    cert_file:
+    \ /var/run/tls/server/tls.crt\n    client_auth_type: RequireAndVerifyClientCert\n
+    \   key_file: /var/run/tls/server/tls.key\n    client_ca_file: /var/run/ca/service-ca.crt\nstorage:\n
+    \ trace:\n    backend: s3\n    blocklist_poll: 5m\n    cache: none\n    s3:\n
+    \     endpoint: minio:9000\n      bucket: tempo\n      insecure: true\n    local:\n
+    \     path: /var/tempo/traces\n    wal:\n      path: /var/tempo/wal\nusage_report:\n
+    \ reporting_enabled: false\nquery_frontend:\n  search:\n    concurrent_jobs: 2000\n
+    \   max_duration: 0s\n    default_result_limit: 20\ningester_client:\n  grpc_client_config:\n
+    \   tls_enabled: true\n    tls_cert_path:  /var/run/tls/server/tls.crt\n    tls_key_path:
+    /var/run/tls/server/tls.key\n    tls_ca_path: /var/run/ca/service-ca.crt\n    tls_server_name:
+    tempo-simplest-ingester.chainsaw-tls-singletenant.svc.cluster.local\n    tls_insecure_skip_verify:
+    false\n    tls_min_version: VersionTLS13\n"
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: config
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+  name: tempo-simplest
   namespace: chainsaw-tls-singletenant
-status:
-  readyReplicas: 1

--- a/tests/e2e-openshift/tls-singletenant/01-install-tempo.yaml
+++ b/tests/e2e-openshift/tls-singletenant/01-install-tempo.yaml
@@ -1,4 +1,3 @@
-# based on config/samples/openshift/tempo_v1alpha1_multitenancy.yaml
 apiVersion: tempo.grafana.com/v1alpha1
 kind:  TempoStack
 metadata:
@@ -22,3 +21,5 @@ spec:
     queryFrontend:
       jaegerQuery:
         enabled: true
+        ingress:
+          type: route


### PR DESCRIPTION
tests/e2e-openshift/route -- Test with custom timeout set to 2m
tests/e2e-openshift/monolithic-route -- Test with custom timeout set to 2m
tests/e2e-openshift/tls-singletenant -- Test default timeout of 30s
tests/e2e-openshift/tls-monolithic-singletenant/ -- Test default timeout of 30s

```
--- PASS: chainsaw (0.00s)
    --- PASS: chainsaw/monolithic-route (55.16s)
    --- PASS: chainsaw/tls-singletenant-monolithic (96.14s)
    --- PASS: chainsaw/route (138.22s)
    --- PASS: chainsaw/tls-singletenant (164.25s)
PASS
Tests Summary...
- Passed  tests 4
- Failed  tests 0
- Skipped tests 0
Done.
```
Once the multitenancy issues are fixed, will add the asserts for the multitenancy tests as well. 