### PR TITLE
jaeger-query: upgrade to version 1.62

### DIFF
--- a/.chloggen/bump_jaeger-to-1.62.yaml
+++ b/.chloggen/bump_jaeger-to-1.62.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. tempostack, tempomonolithic, github action)
+component: tempostack, tempomonolithic
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: bump jaeger to v1.62
+
+# One or more tracking issues related to the change
+issues: [1050]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,7 @@
 OPERATOR_VERSION ?= 0.13.0
 TEMPO_VERSION ?= 2.5.0
 TEMPO_QUERY_VERSION ?= main-2999520
-# TODO change this to a release version. This has https://github.com/jaegertracing/jaeger/commit/d6631f5f2370cfc3a49efce312491031fb387600
-JAEGER_QUERY_VERSION ?= d6631f5f2370cfc3a49efce312491031fb387600
+JAEGER_QUERY_VERSION ?= 1.62.0
 TEMPO_GATEWAY_VERSION ?= main-2024-08-05-11d0d94
 TEMPO_GATEWAY_OPA_VERSION ?= main-2024-04-29-914c13f
 OAUTH_PROXY_VERSION=4.14
@@ -12,7 +11,7 @@ MIN_KUBERNETES_VERSION ?= 1.25.0
 MIN_OPENSHIFT_VERSION ?= 4.12
 
 TEMPO_IMAGE ?= docker.io/grafana/tempo:$(TEMPO_VERSION)
-JAEGER_QUERY_IMAGE ?= docker.io/jaegertracing/jaeger-query-snapshot:$(JAEGER_QUERY_VERSION)
+JAEGER_QUERY_IMAGE ?= docker.io/jaegertracing/jaeger-query:$(JAEGER_QUERY_VERSION)
 TEMPO_QUERY_IMAGE ?= docker.io/grafana/tempo-query:$(TEMPO_QUERY_VERSION)
 TEMPO_GATEWAY_IMAGE ?= quay.io/observatorium/api:$(TEMPO_GATEWAY_VERSION)
 TEMPO_GATEWAY_OPA_IMAGE ?= quay.io/observatorium/opa-openshift:$(TEMPO_GATEWAY_OPA_VERSION)

--- a/bundle/community/manifests/tempo-operator.clusterserviceversion.yaml
+++ b/bundle/community/manifests/tempo-operator.clusterserviceversion.yaml
@@ -1425,7 +1425,7 @@ spec:
                 - name: RELATED_IMAGE_TEMPO
                   value: docker.io/grafana/tempo:2.5.0
                 - name: RELATED_IMAGE_JAEGER_QUERY
-                  value: docker.io/jaegertracing/jaeger-query-snapshot:d6631f5f2370cfc3a49efce312491031fb387600
+                  value: docker.io/jaegertracing/jaeger-query:1.62.0
                 - name: RELATED_IMAGE_TEMPO_QUERY
                   value: docker.io/grafana/tempo-query:main-2999520
                 - name: RELATED_IMAGE_TEMPO_GATEWAY
@@ -1574,7 +1574,7 @@ spec:
   relatedImages:
   - image: docker.io/grafana/tempo:2.5.0
     name: tempo
-  - image: docker.io/jaegertracing/jaeger-query-snapshot:d6631f5f2370cfc3a49efce312491031fb387600
+  - image: docker.io/jaegertracing/jaeger-query:1.62.0
     name: jaeger-query
   - image: docker.io/grafana/tempo-query:main-2999520
     name: tempo-query

--- a/bundle/openshift/manifests/tempo-operator.clusterserviceversion.yaml
+++ b/bundle/openshift/manifests/tempo-operator.clusterserviceversion.yaml
@@ -1435,7 +1435,7 @@ spec:
                 - name: RELATED_IMAGE_TEMPO
                   value: docker.io/grafana/tempo:2.5.0
                 - name: RELATED_IMAGE_JAEGER_QUERY
-                  value: docker.io/jaegertracing/jaeger-query-snapshot:d6631f5f2370cfc3a49efce312491031fb387600
+                  value: docker.io/jaegertracing/jaeger-query:1.62.0
                 - name: RELATED_IMAGE_TEMPO_QUERY
                   value: docker.io/grafana/tempo-query:main-2999520
                 - name: RELATED_IMAGE_TEMPO_GATEWAY
@@ -1595,7 +1595,7 @@ spec:
   relatedImages:
   - image: docker.io/grafana/tempo:2.5.0
     name: tempo
-  - image: docker.io/jaegertracing/jaeger-query-snapshot:d6631f5f2370cfc3a49efce312491031fb387600
+  - image: docker.io/jaegertracing/jaeger-query:1.62.0
     name: jaeger-query
   - image: docker.io/grafana/tempo-query:main-2999520
     name: tempo-query

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -42,7 +42,7 @@ spec:
         - name: RELATED_IMAGE_TEMPO
           value: docker.io/grafana/tempo:2.5.0
         - name: RELATED_IMAGE_JAEGER_QUERY
-          value: docker.io/jaegertracing/jaeger-query-snapshot:d6631f5f2370cfc3a49efce312491031fb387600
+          value: docker.io/jaegertracing/jaeger-query:1.62.0
         - name: RELATED_IMAGE_TEMPO_QUERY
           value: docker.io/grafana/tempo-query:main-2999520
         - name: RELATED_IMAGE_TEMPO_GATEWAY


### PR DESCRIPTION
Jaeger 1.62 released. It includes the multi tenancy fix.

https://github.com/jaegertracing/jaeger/releases/tag/v1.62.0