### PR TITLE
Bump linter to 1.61.0

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -68,4 +68,4 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         with:
           args: -v
-          version: v1.56.1
+          version: v1.61.0

--- a/cmd/gather/cluster/cluster.go
+++ b/cmd/gather/cluster/cluster.go
@@ -29,6 +29,8 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 )
 
+const defaultDirectoryPermissions = 0750
+
 type cluster struct {
 	config               *config.Config
 	apiAvailabilityCache map[schema.GroupVersionResource]bool
@@ -105,7 +107,7 @@ func (c *cluster) getPodLogs(podName, namespace, container string) {
 
 // GetOperatorDeploymentInfo gets the operator deployment info from the cluster.
 func (c *cluster) GetOperatorDeploymentInfo() error {
-	err := os.MkdirAll(c.config.CollectionDir, os.ModePerm)
+	err := os.MkdirAll(c.config.CollectionDir, defaultDirectoryPermissions)
 	if err != nil {
 		return err
 	}
@@ -132,7 +134,7 @@ func (c *cluster) GetOLMInfo() error {
 	}
 
 	outputDir := filepath.Join(c.config.CollectionDir, "olm")
-	err := os.MkdirAll(outputDir, os.ModePerm)
+	err := os.MkdirAll(outputDir, defaultDirectoryPermissions)
 	if err != nil {
 		return err
 	}

--- a/cmd/gather/cluster/write.go
+++ b/cmd/gather/cluster/write.go
@@ -22,7 +22,7 @@ import (
 
 func createTempoStackFolder(collectionDir string, tempoStack *tempov1alpha1.TempoStack) (string, error) {
 	outputDir := filepath.Join(collectionDir, "namespaces", tempoStack.Namespace, "tempostack", tempoStack.Name)
-	err := os.MkdirAll(outputDir, os.ModePerm)
+	err := os.MkdirAll(outputDir, defaultDirectoryPermissions)
 	if err != nil {
 		return "", err
 	}
@@ -31,7 +31,7 @@ func createTempoStackFolder(collectionDir string, tempoStack *tempov1alpha1.Temp
 
 func createTempoMonolithicFolder(collectionDir string, tempoMonolith *tempov1alpha1.TempoMonolithic) (string, error) {
 	outputDir := filepath.Join(collectionDir, "namespaces", tempoMonolith.Namespace, "tempomonolithic", tempoMonolith.Name)
-	err := os.MkdirAll(outputDir, os.ModePerm)
+	err := os.MkdirAll(outputDir, defaultDirectoryPermissions)
 	if err != nil {
 		return "", err
 	}
@@ -72,7 +72,7 @@ func writeLogToFile(outputDir, podName, container string, p cgocorev1.PodInterfa
 		}
 	}()
 
-	err = os.MkdirAll(outputDir, os.ModePerm)
+	err = os.MkdirAll(outputDir, defaultDirectoryPermissions)
 	if err != nil {
 		log.Fatalln(err)
 		return

--- a/cmd/generate/main.go
+++ b/cmd/generate/main.go
@@ -57,7 +57,10 @@ func build(params manifestutils.Params) ([]client.Object, error) {
 
 func toYAMLManifest(scheme *runtime.Scheme, objects []client.Object, out io.Writer) error {
 	for _, obj := range objects {
-		fmt.Fprintln(out, "---")
+		_, err := fmt.Fprintln(out, "---")
+		if err != nil {
+			return err
+		}
 
 		// set Group, Version and Kind
 		types, _, err := scheme.ObjectKinds(obj)

--- a/controllers/tempo/tempostack_controller.go
+++ b/controllers/tempo/tempostack_controller.go
@@ -139,7 +139,7 @@ func (r *TempoStackReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 //
 //   - For any other error: Set the status condition to Failed,
 //     the Reason to "FailedReconciliation" and the message to the error message.
-func (r *TempoStackReconciler) handleReconcileStatus(ctx context.Context, log logr.Logger, tempo v1alpha1.TempoStack, reconcileError error) (ctrl.Result, error) {
+func (r *TempoStackReconciler) handleReconcileStatus(ctx context.Context, log logr.Logger, tempo v1alpha1.TempoStack, reconcileError error) (ctrl.Result, error) { //nolint:unparam
 	// First refresh components
 	newStatus, rerr := status.GetComponentsStatus(ctx, r, tempo)
 	if rerr != nil {


### PR DESCRIPTION
I had to bump the linter because old version got stuck in the actions. Not sure what changed, but bumping the version seems to work.