### PR TITLE
Set HTTP protocol in query-frontend ServiceMonitor

### DIFF
--- a/internal/manifests/servicemonitor/servicemonitor.go
+++ b/internal/manifests/servicemonitor/servicemonitor.go
@@ -23,7 +23,7 @@ func BuildServiceMonitors(params manifestutils.Params) []client.Object {
 		buildServiceMonitor(params, manifestutils.DistributorComponentName, manifestutils.HttpPortName),
 		buildServiceMonitor(params, manifestutils.IngesterComponentName, manifestutils.HttpPortName),
 		buildServiceMonitor(params, manifestutils.QuerierComponentName, manifestutils.HttpPortName),
-		buildServiceMonitor(params, manifestutils.QueryFrontendComponentName, manifestutils.HttpPortName),
+		buildFrontEndServiceMonitor(params, manifestutils.HttpPortName),
 	}
 
 	if params.Tempo.Spec.Template.Gateway.Enabled {
@@ -36,6 +36,13 @@ func BuildServiceMonitors(params manifestutils.Params) []client.Object {
 func buildServiceMonitor(params manifestutils.Params, component string, port string) *monitoringv1.ServiceMonitor {
 	labels := manifestutils.ComponentLabels(component, params.Tempo.Name)
 	return NewServiceMonitor(params.Tempo.Namespace, params.Tempo.Name, labels, params.CtrlConfig.Gates.HTTPEncryption, component, port)
+}
+
+func buildFrontEndServiceMonitor(params manifestutils.Params, port string) *monitoringv1.ServiceMonitor {
+	labels := manifestutils.ComponentLabels(manifestutils.QueryFrontendComponentName, params.Tempo.Name)
+	tls := params.CtrlConfig.Gates.HTTPEncryption && params.Tempo.Spec.Template.Gateway.Enabled
+	return NewServiceMonitor(params.Tempo.Namespace, params.Tempo.Name, labels, tls,
+		manifestutils.QueryFrontendComponentName, port)
 }
 
 // NewServiceMonitor creates a ServiceMonitor.


### PR DESCRIPTION
When the gateway is disabled, the query frontend is not protected by `mTLS`, nor `TLS`. The only case when it is protected is when the gateway is enabled.

Because of that, the SM needs to be created using HTTP instead of HTTPs, 

Same port/endpoint  is used for Tempo API and the metrics. We cannot choose to protect the `/metrics` endpoint without affect the Tempo API.

cc @andreasgerstmayr  WDYT?

Or perhaps  we should take another approach and try to enable only TLS with the internal certs? 
Or `mTLS` and the `oauth-proxy`? not sure if this scenario is supported by `oauth-proxy.`
