### PR TITLE
[Chore] Specify the OLM version to be installed by operator-sdk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -227,6 +227,7 @@ CONTROLLER_GEN_VERSION ?= v0.15.0
 GEN_API_DOCS_VERSION ?= v0.6.0
 ENVTEST_VERSION ?= latest
 OPERATOR_SDK_VERSION ?= 1.32.0
+OLM_VERSION ?= v0.28.0
 CERTMANAGER_VERSION ?= 1.9.1
 CHAINSAW_VERSION ?= v0.2.4
 
@@ -420,7 +421,7 @@ $(OPERATOR_SDK): $(LOCALBIN)
 
 .PHONY: olm-install
 olm-install: operator-sdk ## Install Operator Lifecycle Manager (OLM)
-	$(OPERATOR_SDK) olm install
+	$(OPERATOR_SDK) olm install --version $(OLM_VERSION) --verbose
 
 # go-get-tool will 'go get' any package $2 and install it to $1.
 define go-get-tool


### PR DESCRIPTION
The latest OLM version v0.29.0 has an issue https://github.com/operator-framework/operator-lifecycle-manager/issues/3419 affecting pod deployments on KinD clusters causing failures. This PR pins the OLM version to v0.28.0 to fix the failing upgrade test. 