### PR TITLE
Do not add tracing CLI args to opa-openshift container

### DIFF
--- a/.chloggen/internal_tracing.yaml
+++ b/.chloggen/internal_tracing.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. tempostack, tempomonolithic, github action)
+component: tempostack
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix enabling `.spec.observability.tracing` with multi-tenancy on OpenShift
+
+# One or more tracking issues related to the change
+issues: [1081]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/internal/manifests/gateway/gateway.go
+++ b/internal/manifests/gateway/gateway.go
@@ -376,8 +376,11 @@ func patchTracing(tempo v1alpha1.TempoStack, pod corev1.PodTemplateSpec) (corev1
 	}
 
 	for i := range pod.Spec.Containers {
-		if err := mergo.Merge(&pod.Spec.Containers[i], container, mergo.WithAppendSlice); err != nil {
-			return corev1.PodTemplateSpec{}, err
+		// Only the observatorium-api container is instrumented with traces, not the opa-openshift container.
+		if pod.Spec.Containers[i].Name == containerNameTempoGateway {
+			if err := mergo.Merge(&pod.Spec.Containers[i], container, mergo.WithAppendSlice); err != nil {
+				return corev1.PodTemplateSpec{}, err
+			}
 		}
 	}
 

--- a/internal/manifests/gateway/gateway_test.go
+++ b/internal/manifests/gateway/gateway_test.go
@@ -298,7 +298,7 @@ func TestPatchTracing(t *testing.T) {
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
-							Name: "first",
+							Name: containerNameTempoGateway,
 							Args: []string{
 								"--abc",
 							},
@@ -316,7 +316,7 @@ func TestPatchTracing(t *testing.T) {
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
-							Name: "first",
+							Name: containerNameTempoGateway,
 							Args: []string{
 								"--abc",
 								"--internal.tracing.endpoint=agent:1234",


### PR DESCRIPTION
The opa-openshift container does not support
`--internal.tracing.endpoint` and remains in a crashloop if
```
spec:
  observability:
    tracing:
      jaeger_agent_endpoint: ...
      sampling_fraction: "1"
```
is enabled.