### PR TITLE
Pin markdown-link-check to latest working version

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -76,7 +76,7 @@ jobs:
       - name: Render .chloggen changelog entries
         run: make chlog-preview > changelog_preview.md
       - name: Install markdown-link-check
-        run: npm install -g markdown-link-check
+        run: npm install -g markdown-link-check@3.12.2
       - name: Run markdown-link-check
         run: |
           markdown-link-check \


### PR DESCRIPTION
`markdown-link-check` started to fail on valid markdown files. See https://github.com/tcort/markdown-link-check/issues/369