### PR TITLE
Update release instructions

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -15,8 +15,8 @@ A locally installed [CRC](https://github.com/crc-org/crc) cluster can be used fo
 Note: The e2e tests require [opentelemetry-operator](https://github.com/open-telemetry/opentelemetry-operator) and cluster monitoring operator (`crc config set enable-cluster-monitoring true`).
 
 ```
-kubectl create namespace tempo-operator-system
-IMG_PREFIX=docker.io/your_username OPERATOR_VERSION=x.y.z BUNDLE_VARIANT=openshift make bundle docker-build docker-push bundle-build bundle-push olm-deploy
+kubectl create namespace openshift-tempo-operator
+IMG_PREFIX=docker.io/your_username OPERATOR_VERSION=x.y.z BUNDLE_VARIANT=openshift OPERATOR_NAMESPACE=openshift-tempo-operator make build docker-build docker-push bundle bundle-build bundle-push olm-deploy
 make e2e e2e-openshift
 ```
 

--- a/tests/e2e/generate/chainsaw-test.yaml
+++ b/tests/e2e/generate/chainsaw-test.yaml
@@ -19,8 +19,7 @@ spec:
         - RELATED_IMAGE_TEMPO=docker.io/grafana/tempo:2.2.1 RELATED_IMAGE_TEMPO_QUERY=docker.io/grafana/tempo-query:2.2.1
           RELATED_IMAGE_TEMPO_GATEWAY=quay.io/observatorium/api:main-2023-09-13-14e06c6
           RELATED_IMAGE_TEMPO_GATEWAY_OPA=quay.io/observatorium/opa-openshift:main-2023-05-24-8e91537
-          ../../../bin/manager generate --config config.yaml --cr cr.yaml --output
-          generated.yaml
+          ../../../bin/manager generate --config config.yaml --cr cr.yaml --output generated.yaml
         entrypoint: /bin/sh
     - command:
         timeout: 60s


### PR DESCRIPTION
Use `openshift-tempo-operator` namespace when running the e2e-openshift tests. Also run the `build` task, as the binary is required by the `e2e/generate` test.