### PR TITLE
[Chore] Update asserts for tests to work on OCP 4.18

### DIFF
--- a/tests/e2e-long-running/tempostack-retention-global/03-assert.yaml
+++ b/tests/e2e-long-running/tempostack-retention-global/03-assert.yaml
@@ -3,6 +3,4 @@ kind: Job
 metadata:
   name: generate-traces
 status:
-  conditions:
-    - status: "True"
-      type: Complete
+  succeeded: 1

--- a/tests/e2e-long-running/tempostack-retention-global/05-assert.yaml
+++ b/tests/e2e-long-running/tempostack-retention-global/05-assert.yaml
@@ -3,6 +3,4 @@ kind: Job
 metadata:
   name: verify-traces-grafana
 status:
-  conditions:
-    - status: "True"
-      type: Complete
+  succeeded: 1

--- a/tests/e2e-long-running/tempostack-retention-global/verify-traces-grafana-ret-assert.yaml
+++ b/tests/e2e-long-running/tempostack-retention-global/verify-traces-grafana-ret-assert.yaml
@@ -3,6 +3,4 @@ kind: Job
 metadata:
   name: verify-traces-grafana-ret
 status:
-  conditions:
-    - status: "True"
-      type: Complete
+  succeeded: 1

--- a/tests/e2e-long-running/tempostack-retention-global/verify-traces-jaeger-ret-assert.yaml
+++ b/tests/e2e-long-running/tempostack-retention-global/verify-traces-jaeger-ret-assert.yaml
@@ -3,6 +3,4 @@ kind: Job
 metadata:
   name: verify-traces-jaeger-ret
 status:
-  conditions:
-    - status: "True"
-      type: Complete
+  succeeded: 1

--- a/tests/e2e-openshift-ossm/ossm-monolithic-otel/install-otel-collector.yaml
+++ b/tests/e2e-openshift-ossm/ossm-monolithic-otel/install-otel-collector.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   config: |
     receivers:
-      zipkin:
+      zipkin: {}
       otlp:
         protocols:
           grpc:

--- a/tests/e2e-openshift-ossm/ossm-tempostack-otel/install-otel-collector.yaml
+++ b/tests/e2e-openshift-ossm/ossm-tempostack-otel/install-otel-collector.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   config: |
     receivers:
-      zipkin:
+      zipkin: {}
       otlp:
         protocols:
           grpc:

--- a/tests/e2e-openshift-serverless/otel-tempo-serverless/create-otel-collector.yaml
+++ b/tests/e2e-openshift-serverless/otel-tempo-serverless/create-otel-collector.yaml
@@ -7,7 +7,7 @@ spec:
   mode: deployment
   config: |
     receivers:
-      zipkin:
+      zipkin: {}
     processors:
     exporters:
       otlp:

--- a/tests/e2e-openshift-serverless/otel-tempo-serverless/verify-traces-assert.yaml
+++ b/tests/e2e-openshift-serverless/otel-tempo-serverless/verify-traces-assert.yaml
@@ -4,6 +4,4 @@ metadata:
   name: verify-traces
   namespace: chainsaw-otel-tempo-serverless
 status:
-  conditions:
-    - status: "True"
-      type: Complete
+  succeeded: 1

--- a/tests/e2e-openshift-serverless/tempo-serverless/verify-traces-assert.yaml
+++ b/tests/e2e-openshift-serverless/tempo-serverless/verify-traces-assert.yaml
@@ -4,6 +4,4 @@ metadata:
   name: verify-traces
   namespace: chainsaw-tempo-serverless
 status:
-  conditions:
-    - status: "True"
-      type: Complete
+  succeeded: 1

--- a/tests/e2e-openshift/component-replicas/generate-traces-assert.yaml
+++ b/tests/e2e-openshift/component-replicas/generate-traces-assert.yaml
@@ -4,9 +4,7 @@ metadata:
   name: generate-traces-grpc
   namespace: chainsaw-replicas
 status:
-  conditions:
-    - status: "True"
-      type: Complete
+  succeeded: 1
 ---
 apiVersion: batch/v1
 kind: Job
@@ -14,6 +12,4 @@ metadata:
   name: generate-traces-http
   namespace: chainsaw-replicas
 status:
-  conditions:
-    - status: "True"
-      type: Complete
+  succeeded: 1

--- a/tests/e2e-openshift/component-replicas/verify-traces-assert.yaml
+++ b/tests/e2e-openshift/component-replicas/verify-traces-assert.yaml
@@ -4,9 +4,7 @@ metadata:
   name: verify-traces-grpc
   namespace: chainsaw-replicas
 status:
-  conditions:
-    - status: "True"
-      type: Complete
+  succeeded: 1
 ---
 apiVersion: batch/v1
 kind: Job
@@ -14,9 +12,7 @@ metadata:
   name: verify-traces-traceql-grpc
   namespace: chainsaw-replicas
 status:
-  conditions:
-    - status: "True"
-      type: Complete
+  succeeded: 1
 ---
 apiVersion: batch/v1
 kind: Job
@@ -24,9 +20,7 @@ metadata:
   name: verify-traces-http
   namespace: chainsaw-replicas
 status:
-  conditions:
-    - status: "True"
-      type: Complete
+  succeeded: 1
 ---
 apiVersion: batch/v1
 kind: Job
@@ -34,6 +28,4 @@ metadata:
   name: verify-traces-traceql-http
   namespace: chainsaw-replicas
 status:
-  conditions:
-    - status: "True"
-      type: Complete
+  succeeded: 1

--- a/tests/e2e-openshift/monitoring-monolithic/chainsaw-test.yaml
+++ b/tests/e2e-openshift/monitoring-monolithic/chainsaw-test.yaml
@@ -29,8 +29,8 @@ spec:
     try:
     - apply:
         file: verify-traces.yaml
-    - apply:
-        file: workload-monitoring-assert.yaml
+    - assert:
+        file: verify-traces-assert.yaml
   - name: Check Tempo Monolithc metrics scraped by user workload monitoring
     try:
     - script:

--- a/tests/e2e-openshift/monitoring-monolithic/verify-traces-assert.yaml
+++ b/tests/e2e-openshift/monitoring-monolithic/verify-traces-assert.yaml
@@ -1,6 +1,6 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: verify-traces-jaeger
+  name: verify-traces
 status:
-  succeeded: 1
+  succeeded: 1  

--- a/tests/e2e-openshift/monitoring/04-assert.yaml
+++ b/tests/e2e-openshift/monitoring/04-assert.yaml
@@ -17,6 +17,4 @@ kind: Job
 metadata:
   name: verify-traces
 status:
-  conditions:
-    - status: "True"
-      type: Complete
+  succeeded: 1

--- a/tests/e2e-openshift/monolithic-multitenancy-openshift/03-assert.yaml
+++ b/tests/e2e-openshift/monolithic-multitenancy-openshift/03-assert.yaml
@@ -3,15 +3,11 @@ kind: Job
 metadata:
   name: generate-traces-grpc
 status:
-  conditions:
-  - status: "True"
-    type: Complete
+  succeeded: 1
 ---
 apiVersion: batch/v1
 kind: Job
 metadata:
   name: generate-traces-http
 status:
-  conditions:
-    - status: "True"
-      type: Complete
+  succeeded: 1

--- a/tests/e2e-openshift/monolithic-multitenancy-openshift/04-assert.yaml
+++ b/tests/e2e-openshift/monolithic-multitenancy-openshift/04-assert.yaml
@@ -3,33 +3,25 @@ kind: Job
 metadata:
   name: verify-traces-jaegerui-grpc
 status:
-  conditions:
-  - status: "True"
-    type: Complete
+  succeeded: 1
 ---
 apiVersion: batch/v1
 kind: Job
 metadata:
   name: verify-traces-traceql-grpc
 status:
-  conditions:
-  - status: "True"
-    type: Complete
+  succeeded: 1
 ---
 apiVersion: batch/v1
 kind: Job
 metadata:
   name: verify-traces-jaegerui-http
 status:
-  conditions:
-    - status: "True"
-      type: Complete
+  succeeded: 1
 ---
 apiVersion: batch/v1
 kind: Job
 metadata:
   name: verify-traces-traceql-http
 status:
-  conditions:
-    - status: "True"
-      type: Complete
+  succeeded: 1

--- a/tests/e2e-openshift/monolithic-multitenancy-static/01-assert.yaml
+++ b/tests/e2e-openshift/monolithic-multitenancy-static/01-assert.yaml
@@ -3,6 +3,4 @@ kind: Job
 metadata:
   name: setup-hydra
 status:
-  conditions:
-  - status: "True"
-    type: Complete
+  succeeded: 1

--- a/tests/e2e-openshift/monolithic-multitenancy-static/04-assert.yaml
+++ b/tests/e2e-openshift/monolithic-multitenancy-static/04-assert.yaml
@@ -3,6 +3,4 @@ kind: Job
 metadata:
   name: generate-traces
 status:
-  conditions:
-  - status: "True"
-    type: Complete
+  succeeded: 1

--- a/tests/e2e-openshift/monolithic-multitenancy-static/05-assert.yaml
+++ b/tests/e2e-openshift/monolithic-multitenancy-static/05-assert.yaml
@@ -3,6 +3,4 @@ kind: Job
 metadata:
   name: verify-traces-traceql
 status:
-  conditions:
-  - status: "True"
-    type: Complete
+  succeeded: 1

--- a/tests/e2e-openshift/monolithic-route/check-must-gather.sh
+++ b/tests/e2e-openshift/monolithic-route/check-must-gather.sh
@@ -15,7 +15,7 @@ REQUIRED_ITEMS=(
   "*sha*/olm/clusterserviceversion-tempo-operator-*.yaml"
   "*sha*/olm/operator-opentelemetry-product-openshift-opentelemetry-operator.yaml"
   "*sha*/olm/operator-tempo-*-tempo-operator.yaml"
-  "*sha*/olm/subscription-tempo-operator-*-sub.yaml"
+  "*sha*/olm/subscription-tempo-*.yaml"
   "*sha*/namespaces/chainsaw-mono-route/tempomonolithic/mono-route/tempomonolithic-mono-route.yaml"
   "*sha*/namespaces/chainsaw-mono-route/tempomonolithic/mono-route/service-tempo-mono-route-jaegerui.yaml"
   "*sha*/namespaces/chainsaw-mono-route/tempomonolithic/mono-route/configmap-tempo-mono-route-serving-cabundle.yaml"

--- a/tests/e2e-openshift/monolithic-single-tenant-auth/generate-traces-assert.yaml
+++ b/tests/e2e-openshift/monolithic-single-tenant-auth/generate-traces-assert.yaml
@@ -4,6 +4,4 @@ metadata:
   name: generate-traces
   namespace: chainsaw-mst
 status:
-  conditions:
-    - status: "True"
-      type: Complete
+  succeeded: 1

--- a/tests/e2e-openshift/monolithic-single-tenant-auth/verify-traces-jaeger-assert.yaml
+++ b/tests/e2e-openshift/monolithic-single-tenant-auth/verify-traces-jaeger-assert.yaml
@@ -4,6 +4,4 @@ metadata:
   name: verify-traces-jaeger
   namespace: chainsaw-mst
 status:
-  conditions:
-    - status: "True"
-      type: Complete
+  succeeded: 1

--- a/tests/e2e-openshift/monolithic-single-tenant-auth/verify-traces-traceql-assert.yaml
+++ b/tests/e2e-openshift/monolithic-single-tenant-auth/verify-traces-traceql-assert.yaml
@@ -4,6 +4,4 @@ metadata:
   name: verify-traces-traceql
   namespace: chainsaw-mst
 status:
-  conditions:
-    - status: "True"
-      type: Complete
+  succeeded: 1

--- a/tests/e2e-openshift/multitenancy/03-assert.yaml
+++ b/tests/e2e-openshift/multitenancy/03-assert.yaml
@@ -4,9 +4,7 @@ metadata:
   name: generate-traces-grpc
   namespace: chainsaw-multitenancy
 status:
-  conditions:
-    - status: "True"
-      type: Complete
+  succeeded: 1
 ---
 apiVersion: batch/v1
 kind: Job
@@ -14,6 +12,4 @@ metadata:
   name: generate-traces-http
   namespace: chainsaw-multitenancy
 status:
-  conditions:
-    - status: "True"
-      type: Complete
+  succeeded: 1

--- a/tests/e2e-openshift/multitenancy/04-assert.yaml
+++ b/tests/e2e-openshift/multitenancy/04-assert.yaml
@@ -4,9 +4,7 @@ metadata:
   name: verify-traces-grpc
   namespace: chainsaw-multitenancy
 status:
-  conditions:
-    - status: "True"
-      type: Complete
+  succeeded: 1
 ---
 apiVersion: batch/v1
 kind: Job
@@ -14,9 +12,7 @@ metadata:
   name: verify-traces-traceql-grpc
   namespace: chainsaw-multitenancy
 status:
-  conditions:
-    - status: "True"
-      type: Complete
+  succeeded: 1
 ---
 apiVersion: batch/v1
 kind: Job
@@ -24,9 +20,7 @@ metadata:
   name: verify-traces-http
   namespace: chainsaw-multitenancy
 status:
-  conditions:
-    - status: "True"
-      type: Complete
+  succeeded: 1
 ---
 apiVersion: batch/v1
 kind: Job
@@ -34,6 +28,4 @@ metadata:
   name: verify-traces-traceql-http
   namespace: chainsaw-multitenancy
 status:
-  conditions:
-    - status: "True"
-      type: Complete
+  succeeded: 1

--- a/tests/e2e-openshift/red-metrics/02-install-otel-collector.yaml
+++ b/tests/e2e-openshift/red-metrics/02-install-otel-collector.yaml
@@ -34,7 +34,7 @@ spec:
         resource_to_telemetry_conversion: 
           enabled: true # by default resource attributes are dropped
 
-      logging:
+      debug:
 
       otlp:
         endpoint: tempo-redmetrics-distributor:4317
@@ -53,7 +53,7 @@ spec:
           exporters: [otlp, spanmetrics]
         metrics:
           receivers: [spanmetrics]
-          exporters: [prometheus, logging]
+          exporters: [prometheus, debug]
 
 ---
 apiVersion: monitoring.coreos.com/v1

--- a/tests/e2e-openshift/red-metrics/06-assert.yaml
+++ b/tests/e2e-openshift/red-metrics/06-assert.yaml
@@ -3,6 +3,4 @@ kind: Job
 metadata:
   name: verify-metrics
 status:
-  conditions:
-  - status: "True"
-    type: Complete
+  succeeded: 1

--- a/tests/e2e-openshift/route/check-must-gather.sh
+++ b/tests/e2e-openshift/route/check-must-gather.sh
@@ -15,7 +15,7 @@ REQUIRED_ITEMS=(
   "*sha*/olm/clusterserviceversion-tempo-operator-*.yaml"
   "*sha*/olm/operator-opentelemetry-product-openshift-opentelemetry-operator.yaml"
   "*sha*/olm/operator-*-tempo-operator.yaml"
-  "*sha*/olm/subscription-tempo-operator-*-sub.yaml"
+  "*sha*/olm/subscription-tempo-*.yaml"
   "*sha*/namespaces/chainsaw-route/tempostack/simplest/service-tempo-simplest-distributor.yaml"
   "*sha*/namespaces/chainsaw-route/tempostack/simplest/service-tempo-simplest-ingester.yaml"
   "*sha*/namespaces/chainsaw-route/tempostack/simplest/deployment-tempo-simplest-distributor.yaml"

--- a/tests/e2e-openshift/tempo-single-tenant-auth/generate-traces-assert.yaml
+++ b/tests/e2e-openshift/tempo-single-tenant-auth/generate-traces-assert.yaml
@@ -4,6 +4,4 @@ metadata:
   name: generate-traces
   namespace: chainsaw-tst
 status:
-  conditions:
-    - status: "True"
-      type: Complete
+  succeeded: 1

--- a/tests/e2e-openshift/tempo-single-tenant-auth/verify-traces-jaeger-assert.yaml
+++ b/tests/e2e-openshift/tempo-single-tenant-auth/verify-traces-jaeger-assert.yaml
@@ -4,6 +4,4 @@ metadata:
   name: verify-traces-jaeger
   namespace: chainsaw-tst
 status:
-  conditions:
-    - status: "True"
-      type: Complete
+  succeeded: 1

--- a/tests/e2e-openshift/tempo-single-tenant-auth/verify-traces-traceql-assert.yaml
+++ b/tests/e2e-openshift/tempo-single-tenant-auth/verify-traces-traceql-assert.yaml
@@ -4,6 +4,4 @@ metadata:
   name: verify-traces-traceql
   namespace: chainsaw-tst
 status:
-  conditions:
-    - status: "True"
-      type: Complete
+  succeeded: 1

--- a/tests/e2e-openshift/tls-monolithic-singletenant/03-assert.yaml
+++ b/tests/e2e-openshift/tls-monolithic-singletenant/03-assert.yaml
@@ -4,9 +4,7 @@ metadata:
   name: generate-traces-grpc
   namespace: chainsaw-tls-mono-st
 status:
-  conditions:
-    - status: "True"
-      type: Complete
+  succeeded: 1
 ---
 apiVersion: batch/v1
 kind: Job
@@ -14,6 +12,4 @@ metadata:
   name: generate-traces-http
   namespace: chainsaw-tls-mono-st
 status:
-  conditions:
-    - status: "True"
-      type: Complete
+  succeeded: 1

--- a/tests/e2e-openshift/tls-monolithic-singletenant/04-assert.yaml
+++ b/tests/e2e-openshift/tls-monolithic-singletenant/04-assert.yaml
@@ -4,9 +4,7 @@ metadata:
   name: verify-traces-grpc
   namespace: chainsaw-tls-mono-st
 status:
-  conditions:
-    - status: "True"
-      type: Complete
+  succeeded: 1
 ---
 apiVersion: batch/v1
 kind: Job
@@ -14,6 +12,4 @@ metadata:
   name: verify-traces-http
   namespace: chainsaw-tls-mono-st
 status:
-  conditions:
-    - status: "True"
-      type: Complete
+  succeeded: 1

--- a/tests/e2e-openshift/tls-singletenant/03-assert.yaml
+++ b/tests/e2e-openshift/tls-singletenant/03-assert.yaml
@@ -4,9 +4,7 @@ metadata:
   name: generate-traces-grpc
   namespace: chainsaw-tls-singletenant
 status:
-  conditions:
-    - status: "True"
-      type: Complete
+  succeeded: 1
 ---
 apiVersion: batch/v1
 kind: Job
@@ -14,6 +12,4 @@ metadata:
   name: generate-traces-http
   namespace: chainsaw-tls-singletenant
 status:
-  conditions:
-    - status: "True"
-      type: Complete
+  succeeded: 1

--- a/tests/e2e-openshift/tls-singletenant/04-assert.yaml
+++ b/tests/e2e-openshift/tls-singletenant/04-assert.yaml
@@ -4,9 +4,7 @@ metadata:
   name: verify-traces-grpc
   namespace: chainsaw-tls-singletenant
 status:
-  conditions:
-    - status: "True"
-      type: Complete
+  succeeded: 1
 ---
 apiVersion: batch/v1
 kind: Job
@@ -14,6 +12,4 @@ metadata:
   name: verify-traces-http
   namespace: chainsaw-tls-singletenant
 status:
-  conditions:
-    - status: "True"
-      type: Complete
+  succeeded: 1

--- a/tests/e2e-upgrade/upgrade/40-assert.yaml
+++ b/tests/e2e-upgrade/upgrade/40-assert.yaml
@@ -3,6 +3,4 @@ kind: Job
 metadata:
   name: generate-traces
 status:
-  conditions:
-    - status: "True"
-      type: Complete
+  succeeded: 1

--- a/tests/e2e-upgrade/upgrade/50-assert.yaml
+++ b/tests/e2e-upgrade/upgrade/50-assert.yaml
@@ -3,6 +3,4 @@ kind: Job
 metadata:
   name: verify-traces
 status:
-  conditions:
-    - status: "True"
-      type: Complete
+  succeeded: 1

--- a/tests/e2e-upgrade/upgrade/70-assert.yaml
+++ b/tests/e2e-upgrade/upgrade/70-assert.yaml
@@ -3,6 +3,4 @@ kind: Job
 metadata:
   name: verify-traces-after-upgrade
 status:
-  conditions:
-    - status: "True"
-      type: Complete
+  succeeded: 1

--- a/tests/e2e/compatibility/03-assert.yaml
+++ b/tests/e2e/compatibility/03-assert.yaml
@@ -3,6 +3,4 @@ kind: Job
 metadata:
   name: generate-traces
 status:
-  conditions:
-    - status: "True"
-      type: Complete
+  succeeded: 1

--- a/tests/e2e/compatibility/04-assert.yaml
+++ b/tests/e2e/compatibility/04-assert.yaml
@@ -3,6 +3,4 @@ kind: Job
 metadata:
   name: verify-traces-jaeger
 status:
-  conditions:
-    - status: "True"
-      type: Complete
+  succeeded: 1

--- a/tests/e2e/compatibility/05-assert.yaml
+++ b/tests/e2e/compatibility/05-assert.yaml
@@ -3,6 +3,4 @@ kind: Job
 metadata:
   name: verify-traces-grafana
 status:
-  conditions:
-    - status: "True"
-      type: Complete
+  succeeded: 1

--- a/tests/e2e/custom-ca/02-assert.yaml
+++ b/tests/e2e/custom-ca/02-assert.yaml
@@ -3,6 +3,4 @@ kind: Job
 metadata:
   name: generate-traces
 status:
-  conditions:
-    - status: "True"
-      type: Complete
+  succeeded: 1

--- a/tests/e2e/custom-ca/03-assert.yaml
+++ b/tests/e2e/custom-ca/03-assert.yaml
@@ -3,6 +3,4 @@ kind: Job
 metadata:
   name: verify-traces
 status:
-  conditions:
-    - status: "True"
-      type: Complete
+  succeeded: 1

--- a/tests/e2e/monolithic-ingestion-mtls/03-assert.yaml
+++ b/tests/e2e/monolithic-ingestion-mtls/03-assert.yaml
@@ -3,6 +3,4 @@ kind: Job
 metadata:
   name: generate-traces
 status:
-  conditions:
-  - status: "True"
-    type: Complete
+  succeeded: 1

--- a/tests/e2e/monolithic-ingestion-mtls/04-assert.yaml
+++ b/tests/e2e/monolithic-ingestion-mtls/04-assert.yaml
@@ -3,6 +3,4 @@ kind: Job
 metadata:
   name: verify-traces
 status:
-  conditions:
-  - status: "True"
-    type: Complete
+  succeeded: 1

--- a/tests/e2e/monolithic-memory/03-assert.yaml
+++ b/tests/e2e/monolithic-memory/03-assert.yaml
@@ -3,6 +3,4 @@ kind: Job
 metadata:
   name: generate-traces
 status:
-  conditions:
-    - status: "True"
-      type: Complete
+  succeeded: 1

--- a/tests/e2e/monolithic-memory/04-assert.yaml
+++ b/tests/e2e/monolithic-memory/04-assert.yaml
@@ -3,6 +3,4 @@ kind: Job
 metadata:
   name: verify-traces-jaeger
 status:
-  conditions:
-    - status: "True"
-      type: Complete
+  succeeded: 1

--- a/tests/e2e/monolithic-memory/05-assert.yaml
+++ b/tests/e2e/monolithic-memory/05-assert.yaml
@@ -3,6 +3,4 @@ kind: Job
 metadata:
   name: verify-traces-grafana
 status:
-  conditions:
-    - status: "True"
-      type: Complete
+  succeeded: 1

--- a/tests/e2e/monolithic-pv/03-assert.yaml
+++ b/tests/e2e/monolithic-pv/03-assert.yaml
@@ -3,6 +3,4 @@ kind: Job
 metadata:
   name: generate-traces
 status:
-  conditions:
-    - status: "True"
-      type: Complete
+  succeeded: 1

--- a/tests/e2e/monolithic-pv/04-assert.yaml
+++ b/tests/e2e/monolithic-pv/04-assert.yaml
@@ -3,6 +3,4 @@ kind: Job
 metadata:
   name: verify-traces
 status:
-  conditions:
-  - status: "True"
-    type: Complete
+  succeeded: 1

--- a/tests/e2e/monolithic-receivers-tls/03-assert.yaml
+++ b/tests/e2e/monolithic-receivers-tls/03-assert.yaml
@@ -3,15 +3,11 @@ kind: Job
 metadata:
   name: generate-traces-http
 status:
-  conditions:
-    - status: "True"
-      type: Complete
+  succeeded: 1
 ---
 apiVersion: batch/v1
 kind: Job
 metadata:
   name: generate-traces-grpc
 status:
-  conditions:
-    - status: "True"
-      type: Complete
+  succeeded: 1

--- a/tests/e2e/monolithic-receivers-tls/04-assert.yaml
+++ b/tests/e2e/monolithic-receivers-tls/04-assert.yaml
@@ -3,15 +3,11 @@ kind: Job
 metadata:
   name: verify-traces-http
 status:
-  conditions:
-    - status: "True"
-      type: Complete
+  succeeded: 1
 ---
 apiVersion: batch/v1
 kind: Job
 metadata:
   name: verify-traces-grpc
 status:
-  conditions:
-    - status: "True"
-      type: Complete
+  succeeded: 1

--- a/tests/e2e/monolithic-s3-tls/03-assert.yaml
+++ b/tests/e2e/monolithic-s3-tls/03-assert.yaml
@@ -3,6 +3,4 @@ kind: Job
 metadata:
   name: generate-traces
 status:
-  conditions:
-    - status: "True"
-      type: Complete
+  succeeded: 1

--- a/tests/e2e/monolithic-s3-tls/04-assert.yaml
+++ b/tests/e2e/monolithic-s3-tls/04-assert.yaml
@@ -3,6 +3,4 @@ kind: Job
 metadata:
   name: verify-traces
 status:
-  conditions:
-  - status: "True"
-    type: Complete
+  succeeded: 1

--- a/tests/e2e/receivers-mtls/03-assert.yaml
+++ b/tests/e2e/receivers-mtls/03-assert.yaml
@@ -3,6 +3,4 @@ kind: Job
 metadata:
   name: generate-traces
 status:
-  conditions:
-    - status: "True"
-      type: Complete
+  succeeded: 1

--- a/tests/e2e/receivers-mtls/04-assert.yaml
+++ b/tests/e2e/receivers-mtls/04-assert.yaml
@@ -3,6 +3,4 @@ kind: Job
 metadata:
   name: verify-traces
 status:
-  conditions:
-    - status: "True"
-      type: Complete
+  succeeded: 1

--- a/tests/e2e/receivers-tls/03-assert.yaml
+++ b/tests/e2e/receivers-tls/03-assert.yaml
@@ -3,6 +3,4 @@ kind: Job
 metadata:
   name: generate-traces
 status:
-  conditions:
-    - status: "True"
-      type: Complete
+  succeeded: 1

--- a/tests/e2e/receivers-tls/04-assert.yaml
+++ b/tests/e2e/receivers-tls/04-assert.yaml
@@ -3,6 +3,4 @@ kind: Job
 metadata:
   name: verify-traces
 status:
-  conditions:
-    - status: "True"
-      type: Complete
+  succeeded: 1

--- a/tests/operator-metrics/max-loops/01-assert-job.yaml
+++ b/tests/operator-metrics/max-loops/01-assert-job.yaml
@@ -4,6 +4,4 @@ metadata:
   name: verify-metrics
   namespace: ($TEMPO_NAMESPACE)
 status:
-  conditions:
-    - status: "True"
-      type: Complete
+  succeeded: 1


### PR DESCRIPTION
The Kubernetes job completion status has changed in OCP 4.18

```
status:
  completionTime: "2024-11-21T05:35:45Z"
  conditions:
  - lastProbeTime: "2024-11-21T05:35:45Z"
    lastTransitionTime: "2024-11-21T05:35:45Z"
    message: Reached expected number of succeeded pods
    reason: CompletionsReached
    status: "True"
    type: SuccessCriteriaMet
  - lastProbeTime: "2024-11-21T05:35:45Z"
    lastTransitionTime: "2024-11-21T05:35:45Z"
    message: Reached expected number of succeeded pods
    reason: CompletionsReached
    status: "True"
    type: Complete
  ready: 0
  startTime: "2024-11-21T05:35:41Z"
  succeeded: 1
  terminating: 0
  uncountedTerminatedPods: {} 
```
This condition is not available anymore:

```
status:
  conditions:
    - status: "True"
      type: Complete 
```
      
The PR updates the test to use an assert which works both with OCP 4.18 and older OCP versions.

Tested on OCP 4.18

```
--- PASS: chainsaw (2025.02s)
    --- PASS: chainsaw/ossm-monolithic-otel (333.40s)
    --- PASS: chainsaw/ossm-tempostack (308.51s)
    --- PASS: chainsaw/ossm-tempostack-otel (344.82s)
    --- PASS: chainsaw/otel-tempo-serverless (321.28s)
    --- PASS: chainsaw/tempo-serverless (283.34s)
    --- PASS: chainsaw/monitoring (138.44s)
    --- PASS: chainsaw/monolithic-monitoring (78.07s)
    --- PASS: chainsaw/red-metrics (217.16s)
    --- PASS: chainsaw/gateway (42.39s)
    --- PASS: chainsaw/operator-metrics (17.94s)
    --- PASS: chainsaw/monolithic-single-tenant-auth (77.74s)
    --- PASS: chainsaw/custom-ca (125.00s)
    --- PASS: chainsaw/multitenancy (130.03s)
    --- PASS: chainsaw/compatibility (130.04s)
    --- PASS: chainsaw/tempo-single-tenant-auth (130.68s)
    --- PASS: chainsaw/route (137.07s)
    --- PASS: chainsaw/tempostack-extraconfig (112.89s)
    --- PASS: chainsaw/reconcile (116.98s)
    --- PASS: chainsaw/component-replicas (219.76s)
    --- PASS: chainsaw/monolithic-pv (85.36s)
    --- PASS: chainsaw/monolithic-s3-tls (94.64s)
    --- PASS: chainsaw/generate (11.13s)
    --- PASS: chainsaw/monolithic-receivers-tls (106.51s)
    --- PASS: chainsaw/receivers-tls (125.20s)
    --- PASS: chainsaw/monolithic-memory (78.82s)
    --- PASS: chainsaw/receivers-mtls (131.88s)
    --- PASS: chainsaw/monolithic-ingestion-mtls (71.68s)
    --- PASS: chainsaw/monolithic-extraconfig (52.32s)
    --- PASS: chainsaw/tls-singletenant-monolithic (83.11s)
    --- PASS: chainsaw/monolithic-route (76.91s)
    --- PASS: chainsaw/monolithic-multitenancy-static (84.88s)
    --- PASS: chainsaw/monolithic-multitenancy-openshift (91.09s)
    --- PASS: chainsaw/tls-singletenant (132.01s)
    --- PASS: chainsaw/tempostack-resources (185.62s)
PASS
Tests Summary...
- Passed  tests 34
- Failed  tests 0
- Skipped tests 0
```