### PR TITLE
Update red-metrics e2e test for OTEL v0.113.0

### DIFF
--- a/tests/e2e-openshift/red-metrics/02-assert.yaml
+++ b/tests/e2e-openshift/red-metrics/02-assert.yaml
@@ -20,7 +20,7 @@ spec:
         description: '{{$labels.instance}} has 95th request latency above 2s (current
           value: {{$value}}s)'
         summary: High request latency on {{$labels.service_name}} and {{$labels.span_name}}
-      expr: histogram_quantile(0.95, sum(rate(duration_bucket{service_name="frontend",
+      expr: histogram_quantile(0.95, sum(rate(traces_span_metrics_duration_bucket{service_name="frontend",
         span_kind="SPAN_KIND_SERVER"}[1m])) by (le, service_name, span_name)) > 1000
       labels:
         severity: Warning

--- a/tests/e2e-openshift/red-metrics/02-install-otel-collector.yaml
+++ b/tests/e2e-openshift/red-metrics/02-install-otel-collector.yaml
@@ -34,7 +34,7 @@ spec:
         resource_to_telemetry_conversion: 
           enabled: true # by default resource attributes are dropped
 
-      logging:
+      debug:
 
       otlp:
         endpoint: tempo-redmetrics-distributor:4317
@@ -53,7 +53,7 @@ spec:
           exporters: [otlp, spanmetrics]
         metrics:
           receivers: [spanmetrics]
-          exporters: [prometheus, logging]
+          exporters: [prometheus, debug]
 
 ---
 apiVersion: monitoring.coreos.com/v1
@@ -65,7 +65,7 @@ spec:
   - name: server-side-latency
     rules:
     - alert: SpanREDFrontendAPIRequestLatency
-      expr: histogram_quantile(0.95, sum(rate(duration_bucket{service_name="frontend", span_kind="SPAN_KIND_SERVER"}[1m])) by (le, service_name, span_name)) > 1000
+      expr: histogram_quantile(0.95, sum(rate(traces_span_metrics_duration_bucket{service_name="frontend", span_kind="SPAN_KIND_SERVER"}[1m])) by (le, service_name, span_name)) > 1000
       labels:
         severity: Warning
       annotations:

--- a/tests/e2e-openshift/red-metrics/03-install-tempo.yaml
+++ b/tests/e2e-openshift/red-metrics/03-install-tempo.yaml
@@ -28,6 +28,6 @@ spec:
         monitorTab:
           enabled: true
           prometheusEndpoint: https://thanos-querier.openshift-monitoring.svc.cluster.local:9091
-          redMetricsNamespace: ""
+          redMetricsNamespace: traces_span_metrics
         ingress:
           type: route

--- a/tests/e2e-openshift/red-metrics/check_metrics.sh
+++ b/tests/e2e-openshift/red-metrics/check_metrics.sh
@@ -4,7 +4,7 @@ TOKEN=$(oc create token tempo-redmetrics-query-frontend -n $NAMESPACE)
 THANOS_QUERIER_HOST=$(oc get route thanos-querier -n openshift-monitoring -o json | jq -r '.spec.host')
 
 #Check metrics used in the prometheus rules created for TempoStack. Refer issue https://issues.redhat.com/browse/TRACING-3399 for skipped metrics.
-metrics="duration_bucket duration_count duration_sum calls"
+metrics="traces_span_metrics_duration_bucket traces_span_metrics_duration_count traces_span_metrics_duration_sum traces_span_metrics_calls"
 
 for metric in $metrics; do
 query="$metric"


### PR DESCRIPTION
Update test to use the new `traces_span_metrics` namespace for the RED metrics (default namespace for the spanmetrics connector in OTEL v0.113.0).