### PR TITLE
Fix metrics TLS certificate parameters

### DIFF
--- a/bundle/community/manifests/tempo-operator.clusterserviceversion.yaml
+++ b/bundle/community/manifests/tempo-operator.clusterserviceversion.yaml
@@ -74,7 +74,7 @@ metadata:
     capabilities: Deep Insights
     categories: Logging & Tracing,Monitoring
     containerImage: ghcr.io/grafana/tempo-operator/tempo-operator:v0.15.1
-    createdAt: "2025-02-17T13:21:50Z"
+    createdAt: "2025-02-20T06:15:35Z"
     description: Create and manage deployments of Tempo, a high-scale distributed
       tracing backend.
     operatorframework.io/cluster-monitoring: "true"

--- a/bundle/openshift/manifests/tempo-operator.clusterserviceversion.yaml
+++ b/bundle/openshift/manifests/tempo-operator.clusterserviceversion.yaml
@@ -74,7 +74,7 @@ metadata:
     capabilities: Deep Insights
     categories: Logging & Tracing,Monitoring
     containerImage: ghcr.io/grafana/tempo-operator/tempo-operator:v0.15.1
-    createdAt: "2025-02-17T13:21:48Z"
+    createdAt: "2025-02-20T06:15:33Z"
     description: Create and manage deployments of Tempo, a high-scale distributed
       tracing backend.
     operatorframework.io/cluster-monitoring: "true"
@@ -1516,8 +1516,7 @@ spec:
                 - --zap-log-level=info
                 - start
                 - --config=controller_manager_config.yaml
-                - --metrics-tls-private-key-file=/var/run/tls/server/tls.key
-                - --metrics-tls-cert-file=/var/run/tls/server/tls.crt
+                - --metrics-tls-cert-dir=/var/run/tls/server/
                 env:
                 - name: RELATED_IMAGE_TEMPO
                   value: docker.io/grafana/tempo:2.7.1

--- a/cmd/start/main.go
+++ b/cmd/start/main.go
@@ -32,8 +32,13 @@ func start(c *cobra.Command, args []string) {
 	version := version.Get()
 
 	options.PprofBindAddress, _ = c.Flags().GetString("pprof-addr")
-	options.Metrics.CertName, _ = c.Flags().GetString("metrics-tls-cert-file")
-	options.Metrics.KeyName, _ = c.Flags().GetString("metrics-tls-private-key-file")
+
+	certDir, _ := c.Flags().GetString("metrics-tls-cert-dir")
+	if certDir != "" {
+		options.Metrics.CertDir = certDir
+		options.Metrics.CertName, _ = c.Flags().GetString("metrics-tls-cert-file")
+		options.Metrics.KeyName, _ = c.Flags().GetString("metrics-tls-private-key-file")
+	}
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), options)
 	if err != nil {
@@ -162,7 +167,8 @@ func NewStartCommand() *cobra.Command {
 		Run:   start,
 	}
 	cmd.Flags().String("pprof-addr", "", "The address the pprof server binds to. Default is empty string which disables the pprof server.")
-	cmd.Flags().String("metrics-tls-cert-file", "", "TLS certificate used by metrics server")
-	cmd.Flags().String("metrics-tls-private-key-file", "", "TLS key used by metrics server")
+	cmd.Flags().String("metrics-tls-cert-dir", "", "TLS certificate used by metrics server")
+	cmd.Flags().String("metrics-tls-cert-file", "tls.crt", "TLS certificate used by metrics server")
+	cmd.Flags().String("metrics-tls-private-key-file", "tls.key", "TLS key used by metrics server")
 	return cmd
 }

--- a/config/overlays/openshift/patch_tls_metrics_args.yaml
+++ b/config/overlays/openshift/patch_tls_metrics_args.yaml
@@ -1,10 +1,6 @@
 - op: add
   path: /spec/template/spec/containers/0/args/-
-  value: --metrics-tls-private-key-file=/var/run/tls/server/tls.key
-
-- op: add
-  path: /spec/template/spec/containers/0/args/-
-  value: --metrics-tls-cert-file=/var/run/tls/server/tls.crt
+  value: --metrics-tls-cert-dir=/var/run/tls/server/
 
 - op: add
   path: /spec/template/spec/volumes/-


### PR DESCRIPTION
`CertName` and `KeyName` are only the name of the files, we also need to specify the full path in which those files exists. This PR fix that.

When the certificate file doesn't exist it will self-sign one with _localhost_. Because the path were wrong, it always generate the self signed.

This PR also add a cert-dir flag to specify the path