### PR TITLE
fix upgrade e2e test

### DIFF
--- a/tests/e2e-upgrade/upgrade/20-assert.yaml
+++ b/tests/e2e-upgrade/upgrade/20-assert.yaml
@@ -23,6 +23,4 @@ metadata:
     control-plane: controller-manager
 status:
   containerStatuses:
-  # assert that the readiness probes of both containers (kube-rbac-proxy and tempo-operator) are successful
-  - ready: true
   - ready: true


### PR DESCRIPTION
The kube-rbac-proxy got removed.