### PR TITLE
Add support for renant retention overrides and fix limit overrides after tempo 2.3

### DIFF
--- a/.chloggen/fix-overrides.yaml
+++ b/.chloggen/fix-overrides.yaml
@@ -8,7 +8,7 @@ component: tempostack
 note: Fix unimplemented per tenant retention and fix per tenant overrides after tempo 2.3
 
 # One or more tracking issues related to the change
-issues: []
+issues: [1134]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/fix-overrides.yaml
+++ b/.chloggen/fix-overrides.yaml
@@ -1,0 +1,20 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. tempostack, tempomonolithic, github action)
+component: tempostack
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix unimplemented per tenant retention and fix per tenant overrides after tempo 2.3
+
+# One or more tracking issues related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  In tempo 2.3 https://github.com/grafana/tempo/blob/main/CHANGELOG.md#v230--2023-10-30 they changes the overrides config
+  which was not properly implemented in the operator.
+  
+  This patch also adds support for per tenant retention which was not implemented.

--- a/internal/manifests/config/options.go
+++ b/internal/manifests/config/options.go
@@ -12,7 +12,7 @@ type options struct {
 	GlobalRetention        string
 	QueryFrontendDiscovery string
 	StorageParams          manifestutils.StorageParams
-	GlobalRateLimits       rateLimitsOptions
+	GlobalRateLimits       tenantOverrides
 	TenantRateLimitsPath   string
 	TLS                    tlsOptions
 	MemberList             memberlistOptions
@@ -42,16 +42,17 @@ type featureGates struct {
 }
 
 type tenantOptions struct {
-	RateLimits map[string]rateLimitsOptions
+	TenantOverrides map[string]tenantOverrides
 }
 
-type rateLimitsOptions struct {
+type tenantOverrides struct {
 	IngestionBurstSizeBytes *int
 	IngestionRateLimitBytes *int
 	MaxBytesPerTrace        *int
 	MaxTracesPerUser        *int
 	MaxBytesPerTagValues    *int
 	MaxSearchDuration       string
+	BlockRetention          *time.Duration
 }
 
 type searchOptions struct {

--- a/internal/manifests/config/tempo-overrides.yaml
+++ b/internal/manifests/config/tempo-overrides.yaml
@@ -1,22 +1,28 @@
 overrides:
-{{- range $name, $value := .RateLimits }}
+{{- range $name, $value := .TenantOverrides }}
   "{{ $name }}":
+    ingestion:
 {{- if $value.IngestionBurstSizeBytes }}
-    ingestion_burst_size_bytes: {{ $value.IngestionBurstSizeBytes }}
+      burst_size_bytes: {{ $value.IngestionBurstSizeBytes }}
 {{- end }}
 {{- if $value.IngestionRateLimitBytes }}
-    ingestion_rate_limit_bytes: {{ $value.IngestionRateLimitBytes }}
+      rate_limit_bytes: {{ $value.IngestionRateLimitBytes }}
 {{- end }}
 {{- if $value.MaxTracesPerUser }}
-    max_traces_per_user: {{ $value.MaxTracesPerUser }}
+      max_traces_per_user: {{ $value.MaxTracesPerUser }}
 {{- end }}
 {{- if $value.MaxBytesPerTrace }}
-    max_bytes_per_trace: {{ $value.MaxBytesPerTrace }}
+      max_bytes_per_trace: {{ $value.MaxBytesPerTrace }}
 {{- end }}
+    read:
 {{- if $value.MaxBytesPerTagValues }}
-    max_bytes_per_tag_values_query: {{ $value.MaxBytesPerTagValues }}
+      max_bytes_per_tag_values_query: {{ $value.MaxBytesPerTagValues }}
 {{- end }}
 {{- if ne $value.MaxSearchDuration "0s" }}
-    max_search_duration: {{ $value.MaxSearchDuration }}
+      max_search_duration: {{ $value.MaxSearchDuration }}
+{{- end }}
+{{- if $value.BlockRetention  }}
+    compaction:
+      block_retention: {{ $value.BlockRetention }}
 {{- end }}
 {{- end }}

--- a/tests/e2e-openshift/multitenancy/01-install-tempo.yaml
+++ b/tests/e2e-openshift/multitenancy/01-install-tempo.yaml
@@ -5,6 +5,19 @@ metadata:
   name: simplest
   namespace: chainsaw-multitenancy
 spec:
+  retention:
+    global:
+      traces: 20h
+    perTenant:
+      dev:
+        traces: 10h
+  limits:
+    perTenant:
+      dev:
+        ingestion:
+          ingestionBurstSizeBytes: 1000000
+        query:
+          maxSearchDuration: 1h
   storage:
     secret:
       name: minio


### PR DESCRIPTION
We forgot to adapt to a breaking change in Tempo 2.3 https://github.com/grafana/tempo/blob/main/CHANGELOG.md#v230--2023-10-30 


Adds support for tenant retention overrides https://issues.redhat.com/browse/TRACING-5120 


https://grafana.com/docs/tempo/v2.0.x/configuration/#overrides

https://grafana.com/docs/tempo/v2.7.x/configuration/