### PR TITLE
Fix CVE-2025-2842: Limit granted permissions of the Tempo Service Account when enabling the Jaeger UI Monitor tab on OpenShift

### DIFF
--- a/.chloggen/thanos_tenancy_port.yaml
+++ b/.chloggen/thanos_tenancy_port.yaml
@@ -5,7 +5,7 @@ change_type: bug_fix
 component: tempostack
 
 # A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Limit granted permissions of the Tempo Service Account when enabling the Jaeger UI Monitor tab on OpenShift
+note: Limit granted permissions of the Tempo Service Account when enabling the Jaeger UI Monitor tab on OpenShift (resolves CVE-2025-2842)
 
 # One or more tracking issues related to the change
 issues: []

--- a/.chloggen/thanos_tenancy_port.yaml
+++ b/.chloggen/thanos_tenancy_port.yaml
@@ -1,0 +1,24 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. tempostack, tempomonolithic, github action)
+component: tempostack
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Limit granted permissions of the Tempo Service Account when enabling the Jaeger UI Monitor tab on OpenShift
+
+# One or more tracking issues related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Previously, the operator assigned the `cluster-monitoring-view` ClusterRole to the Tempo Service Account
+  when the Prometheus endpoint of the Jaeger UI Monitor tab is set to the Thanos Querier on OpenShift.
+
+  With this change, the operator limits the granted permissions to only view metrics of the namespace of the Tempo instance.
+  Additionally, the recommended port of the Thanos Querier service changed from `9091` to `9092` (tenancy-aware port):
+  `.spec.template.queryFrontend.jaegerQuery.monitorTab.prometheusEndpoint: https://thanos-querier.openshift-monitoring.svc.cluster.local:9092`.
+
+  All existing installations, which have the Thanos Querier configured at port 9091, will be upgraded automatically to use port 9092.

--- a/bundle/community/manifests/tempo-operator.clusterserviceversion.yaml
+++ b/bundle/community/manifests/tempo-operator.clusterserviceversion.yaml
@@ -74,7 +74,7 @@ metadata:
     capabilities: Deep Insights
     categories: Logging & Tracing,Monitoring
     containerImage: ghcr.io/grafana/tempo-operator/tempo-operator:v0.15.3
-    createdAt: "2025-02-25T15:23:55Z"
+    createdAt: "2025-03-25T14:45:36Z"
     description: Create and manage deployments of Tempo, a high-scale distributed
       tracing backend.
     operatorframework.io/cluster-monitoring: "true"
@@ -1389,6 +1389,13 @@ spec:
           - update
           - watch
         - apiGroups:
+          - metrics.k8s.io
+          resources:
+          - pods
+          verbs:
+          - create
+          - get
+        - apiGroups:
           - monitoring.coreos.com
           resources:
           - prometheusrules
@@ -1426,6 +1433,8 @@ spec:
           resources:
           - clusterrolebindings
           - clusterroles
+          - rolebindings
+          - roles
           verbs:
           - create
           - delete

--- a/bundle/openshift/manifests/tempo-operator.clusterserviceversion.yaml
+++ b/bundle/openshift/manifests/tempo-operator.clusterserviceversion.yaml
@@ -74,7 +74,7 @@ metadata:
     capabilities: Deep Insights
     categories: Logging & Tracing,Monitoring
     containerImage: ghcr.io/grafana/tempo-operator/tempo-operator:v0.15.3
-    createdAt: "2025-02-25T15:23:53Z"
+    createdAt: "2025-03-25T14:45:34Z"
     description: Create and manage deployments of Tempo, a high-scale distributed
       tracing backend.
     operatorframework.io/cluster-monitoring: "true"
@@ -1399,6 +1399,13 @@ spec:
           - update
           - watch
         - apiGroups:
+          - metrics.k8s.io
+          resources:
+          - pods
+          verbs:
+          - create
+          - get
+        - apiGroups:
           - monitoring.coreos.com
           resources:
           - prometheusrules
@@ -1436,6 +1443,8 @@ spec:
           resources:
           - clusterrolebindings
           - clusterroles
+          - rolebindings
+          - roles
           verbs:
           - create
           - delete

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -91,6 +91,13 @@ rules:
   - update
   - watch
 - apiGroups:
+  - metrics.k8s.io
+  resources:
+  - pods
+  verbs:
+  - create
+  - get
+- apiGroups:
   - monitoring.coreos.com
   resources:
   - prometheusrules
@@ -128,6 +135,8 @@ rules:
   resources:
   - clusterrolebindings
   - clusterroles
+  - rolebindings
+  - roles
   verbs:
   - create
   - delete

--- a/internal/controller/tempo/tempostack_controller.go
+++ b/internal/controller/tempo/tempostack_controller.go
@@ -12,6 +12,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -53,7 +54,8 @@ type TempoStackReconciler struct {
 // +kubebuilder:rbac:groups=apps,resources=deployments;statefulsets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps,resources=deployments/finalizers,verbs=update
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings;clusterroles,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings;clusterroles;rolebindings;roles,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=metrics.k8s.io,resources=pods,verbs=create;get
 // +kubebuilder:rbac:groups=route.openshift.io,resources=routes;routes/custom-host,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=operator.openshift.io,resources=ingresscontrollers,verbs=get;list;watch
 // +kubebuilder:rbac:groups=config.openshift.io,resources=dnses,verbs=get;list;watch
@@ -207,6 +209,10 @@ func (r *TempoStackReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&appsv1.StatefulSet{}).
 		Owns(&appsv1.Deployment{}).
 		Owns(&networkingv1.Ingress{}).
+		Owns(&rbacv1.ClusterRole{}).
+		Owns(&rbacv1.ClusterRoleBinding{}).
+		Owns(&rbacv1.Role{}).
+		Owns(&rbacv1.RoleBinding{}).
 		Watches(
 			&corev1.Secret{},
 			handler.EnqueueRequestsFromMapFunc(r.findTempoStackForStorageSecret),

--- a/internal/manifests/queryfrontend/query_frontend.go
+++ b/internal/manifests/queryfrontend/query_frontend.go
@@ -27,7 +27,7 @@ import (
 const (
 	grpclbPortName                   = "grpclb"
 	portGRPCLBServer                 = 9096
-	thanosQuerierOpenShiftMonitoring = "https://thanos-querier.openshift-monitoring.svc.cluster.local:9091"
+	thanosQuerierOpenShiftMonitoring = "https://thanos-querier.openshift-monitoring.svc.cluster.local:9092"
 )
 
 const (
@@ -113,8 +113,8 @@ func BuildQueryFrontend(params manifestutils.Params) ([]client.Object, error) {
 
 	if tempo.Spec.Template.QueryFrontend.JaegerQuery.Enabled && tempo.Spec.Template.QueryFrontend.JaegerQuery.MonitorTab.Enabled &&
 		tempo.Spec.Template.QueryFrontend.JaegerQuery.MonitorTab.PrometheusEndpoint == thanosQuerierOpenShiftMonitoring {
-		clusterRoleBinding := openShiftMonitoringClusterRoleBinding(tempo, d)
-		manifests = append(manifests, &clusterRoleBinding)
+		rbac := openShiftMonitoringRBAC(tempo, d)
+		manifests = append(manifests, rbac...)
 	}
 
 	return manifests, nil
@@ -412,7 +412,9 @@ func enableMonitoringTab(tempo v1alpha1.TempoStack, jaegerQueryContainer corev1.
 			// enabled bearer token propagation, overrides the settings and token from the context (incoming) request is used.
 			"--prometheus.token-file=/var/run/secrets/kubernetes.io/serviceaccount/token",
 			"--prometheus.token-override-from-context=false",
-			"--prometheus.tls.ca=/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt")
+			"--prometheus.tls.ca=/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt",
+			fmt.Sprintf("--prometheus.query.extra-query-params=namespace=%s", tempo.Namespace),
+		)
 	}
 
 	if tempo.Spec.Template.QueryFrontend.JaegerQuery.MonitorTab.REDMetricsNamespace != nil {
@@ -431,12 +433,33 @@ func enableMonitoringTab(tempo v1alpha1.TempoStack, jaegerQueryContainer corev1.
 	return jaegerQueryContainer, nil
 }
 
-func openShiftMonitoringClusterRoleBinding(tempo v1alpha1.TempoStack, d *appsv1.Deployment) rbacv1.ClusterRoleBinding {
+// Grant the jaeger-query container access to read metrics from the namespace of the Tempo instance
+// This is required to access the RED metrics in the Monitor tab of Jaeger UI
+func openShiftMonitoringRBAC(tempo v1alpha1.TempoStack, d *appsv1.Deployment) []client.Object {
+	name := naming.Name("metrics-reader", tempo.Name)
 	labels := manifestutils.ComponentLabels(manifestutils.QueryFrontendComponentName, tempo.Name)
-	return rbacv1.ClusterRoleBinding{
+
+	// Same role as https://github.com/openshift/cluster-monitoring-operator/pull/2475
+	// The pod-metrics-reader role is available since OCP 4.18
+	role := &rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   naming.Name("cluster-monitoring-view", tempo.Name),
-			Labels: labels,
+			Name:      name,
+			Namespace: tempo.Namespace,
+			Labels:    labels,
+		},
+		Rules: []rbacv1.PolicyRule{{
+			APIGroups: []string{"metrics.k8s.io"},
+			Resources: []string{"pods"},
+			// 'create' is required because the Prometheus client uses POST for queries
+			Verbs: []string{"get", "create"},
+		}},
+	}
+
+	roleBinding := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: tempo.Namespace,
+			Labels:    labels,
 		},
 		Subjects: []rbacv1.Subject{
 			{
@@ -447,10 +470,12 @@ func openShiftMonitoringClusterRoleBinding(tempo v1alpha1.TempoStack, d *appsv1.
 		},
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",
-			Kind:     "ClusterRole",
-			Name:     "cluster-monitoring-view",
+			Kind:     "Role",
+			Name:     name,
 		},
 	}
+
+	return []client.Object{role, roleBinding}
 }
 
 func services(params manifestutils.Params) []*corev1.Service {

--- a/internal/upgrade/v0_15_4.go
+++ b/internal/upgrade/v0_15_4.go
@@ -1,0 +1,15 @@
+package upgrade
+
+import (
+	"context"
+
+	"github.com/grafana/tempo-operator/api/tempo/v1alpha1"
+)
+
+// Switch thanos-querier port to tenancy-enabled port
+func upgrade0_15_4(ctx context.Context, u Upgrade, tempo *v1alpha1.TempoStack) error {
+	if tempo.Spec.Template.QueryFrontend.JaegerQuery.MonitorTab.PrometheusEndpoint == "https://thanos-querier.openshift-monitoring.svc.cluster.local:9091" {
+		tempo.Spec.Template.QueryFrontend.JaegerQuery.MonitorTab.PrometheusEndpoint = "https://thanos-querier.openshift-monitoring.svc.cluster.local:9092"
+	}
+	return nil
+}

--- a/internal/upgrade/versions.go
+++ b/internal/upgrade/versions.go
@@ -50,5 +50,9 @@ var (
 			upgradeTempoStack:      upgrade0_11_0,
 			upgradeTempoMonolithic: upgrade0_11_0_monolithic,
 		},
+		{
+			version:           *semver.MustParse("0.15.4"),
+			upgradeTempoStack: upgrade0_15_4,
+		},
 	}
 )

--- a/tests/e2e-openshift/monitoring-monolithic/check_metrics.sh
+++ b/tests/e2e-openshift/monitoring-monolithic/check_metrics.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-TOKEN=$(oc create token prometheus-user-workload -n openshift-user-workload-monitoring)
+oc create serviceaccount e2e-test-metrics-reader -n $NAMESPACE
+oc adm policy add-cluster-role-to-user cluster-monitoring-view system:serviceaccount:$NAMESPACE:e2e-test-metrics-reader
+
+TOKEN=$(oc create token e2e-test-metrics-reader -n $NAMESPACE)
 THANOS_QUERIER_HOST=$(oc get route thanos-querier -n openshift-monitoring -o json | jq -r '.spec.host')
 
 #Check TempoMonolithc metircs

--- a/tests/e2e-openshift/monitoring-monolithic/generate-traces-assert.yaml
+++ b/tests/e2e-openshift/monitoring-monolithic/generate-traces-assert.yaml
@@ -3,4 +3,4 @@ kind: Job
 metadata:
   name: generate-traces
 status:
-  active: 1
+  succeeded: 1

--- a/tests/e2e-openshift/monitoring/03-assert.yaml
+++ b/tests/e2e-openshift/monitoring/03-assert.yaml
@@ -3,4 +3,4 @@ kind: Job
 metadata:
   name: generate-traces
 status:
-  active: 1
+  succeeded: 1

--- a/tests/e2e-openshift/monitoring/check_metrics.sh
+++ b/tests/e2e-openshift/monitoring/check_metrics.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-TOKEN=$(oc create token prometheus-user-workload -n openshift-user-workload-monitoring)
+oc create serviceaccount e2e-test-metrics-reader -n $NAMESPACE
+oc adm policy add-cluster-role-to-user cluster-monitoring-view system:serviceaccount:$NAMESPACE:e2e-test-metrics-reader
+
+TOKEN=$(oc create token e2e-test-metrics-reader -n $NAMESPACE)
 THANOS_QUERIER_HOST=$(oc get route thanos-querier -n openshift-monitoring -o json | jq -r '.spec.host')
 
 #Check metrics used in the prometheus rules created for TempoStack. Refer issue https://issues.redhat.com/browse/TRACING-3399 for skipped metrics.

--- a/tests/e2e-openshift/monitoring/check_operator_servicemonitor.yaml
+++ b/tests/e2e-openshift/monitoring/check_operator_servicemonitor.yaml
@@ -6,7 +6,6 @@ metadata:
     app.kubernetes.io/name: tempo-operator
     app.kubernetes.io/part-of: tempo-operator
     control-plane: controller-manager
-    olm.managed: "true"
   name: tempo-operator-controller-manager-metrics-service
   namespace: ($TEMPO_NAMESPACE)
 spec:

--- a/tests/e2e-openshift/multitenancy/01-assert.yaml
+++ b/tests/e2e-openshift/multitenancy/01-assert.yaml
@@ -117,6 +117,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: tempo-simplest-gateway
+    namespace: chainsaw-multitenancy
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/tests/e2e-openshift/red-metrics/03-assert.yaml
+++ b/tests/e2e-openshift/red-metrics/03-assert.yaml
@@ -52,18 +52,32 @@ status:
   readyReplicas: 1
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: Role
 metadata:
   labels:
     app.kubernetes.io/component: query-frontend
     app.kubernetes.io/instance: redmetrics
     app.kubernetes.io/managed-by: tempo-operator
     app.kubernetes.io/name: tempo
-  name: tempo-redmetrics-cluster-monitoring-view
+  name: tempo-redmetrics-metrics-reader
+rules:
+- apiGroups: [metrics.k8s.io]
+  resources: [pods]
+  verbs: [get, create]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/instance: redmetrics
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+  name: tempo-redmetrics-metrics-reader
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cluster-monitoring-view
+  kind: Role
+  name: tempo-redmetrics-metrics-reader
 subjects:
 - kind: ServiceAccount
   name: tempo-redmetrics-query-frontend

--- a/tests/e2e-openshift/red-metrics/03-install-tempo.yaml
+++ b/tests/e2e-openshift/red-metrics/03-install-tempo.yaml
@@ -27,6 +27,6 @@ spec:
         enabled: true
         monitorTab:
           enabled: true
-          prometheusEndpoint: https://thanos-querier.openshift-monitoring.svc.cluster.local:9091
+          prometheusEndpoint: https://thanos-querier.openshift-monitoring.svc.cluster.local:9092
         ingress:
           type: route

--- a/tests/e2e-openshift/red-metrics/05-assert.yaml
+++ b/tests/e2e-openshift/red-metrics/05-assert.yaml
@@ -3,4 +3,4 @@ kind: Job
 metadata:
   name: hotrod-curl
 status:
-  active: 1
+  succeeded: 1

--- a/tests/e2e-openshift/red-metrics/chainsaw-test.yaml
+++ b/tests/e2e-openshift/red-metrics/chainsaw-test.yaml
@@ -5,6 +5,7 @@ metadata:
   creationTimestamp: null
   name: red-metrics
 spec:
+  namespace: chainsaw-redmetrics
   # Avoid running this test case in parallel to prevent the deletion of shared resources used by multiple tests, specifically in the context of OpenShift user workload monitoring.
   concurrent: false
   steps:

--- a/tests/e2e-openshift/red-metrics/check_metrics.sh
+++ b/tests/e2e-openshift/red-metrics/check_metrics.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-TOKEN=$(oc create token tempo-redmetrics-query-frontend -n $NAMESPACE)
+oc create serviceaccount e2e-test-metrics-reader -n $NAMESPACE
+oc adm policy add-cluster-role-to-user cluster-monitoring-view system:serviceaccount:$NAMESPACE:e2e-test-metrics-reader
+
+TOKEN=$(oc create token e2e-test-metrics-reader -n $NAMESPACE)
 THANOS_QUERIER_HOST=$(oc get route thanos-querier -n openshift-monitoring -o json | jq -r '.spec.host')
 
 #Check metrics used in the prometheus rules created for TempoStack. Refer issue https://issues.redhat.com/browse/TRACING-3399 for skipped metrics.


### PR DESCRIPTION
Previously, the operator assigned the `cluster-monitoring-view` ClusterRole to the Tempo Service Account when the Prometheus endpoint of the Jaeger UI Monitor tab is set to the Thanos Querier on OpenShift.

With this change, the operator limits the granted permissions to only view metrics of the namespace of the Tempo instance. Additionally, the recommended port of the Thanos Querier service changed from `9091` to `9092` (tenancy-aware port): `.spec.template.queryFrontend.jaegerQuery.monitorTab.prometheusEndpoint: https://thanos-querier.openshift-monitoring.svc.cluster.local:9092`

All existing installations, which have the Thanos Querier configured at port 9091, will be upgraded automatically to use port 9092.

Resolves CVE-2025-2842