### PR TITLE
Fix CVE-2025-2786: Ensure the operator does not grant additional permissions when enabling OpenShift tenancy mode

### DIFF
--- a/.chloggen/ensure_permissions.yaml
+++ b/.chloggen/ensure_permissions.yaml
@@ -8,7 +8,7 @@ component: tempostack, tempomonolithic
 note: Ensure the operator does not grant additional permissions when enabling OpenShift tenancy mode (resolves CVE-2025-2786)
 
 # One or more tracking issues related to the change
-issues: []
+issues: [1145]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/ensure_permissions.yaml
+++ b/.chloggen/ensure_permissions.yaml
@@ -1,0 +1,19 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. tempostack, tempomonolithic, github action)
+component: tempostack, tempomonolithic
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Ensure the operator does not grant additional permissions when enabling OpenShift tenancy mode
+
+# One or more tracking issues related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Ensure the permissions the operator is granting to the Tempo Service Account
+  do not exceed the permissions of the user creating (or modifying) the Tempo instance
+  when enabling OpenShift tenancy mode.

--- a/.chloggen/ensure_permissions.yaml
+++ b/.chloggen/ensure_permissions.yaml
@@ -1,5 +1,5 @@
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: bug_fix
+change_type: breaking
 
 # The name of the component, or a single word describing the area of concern, (e.g. tempostack, tempomonolithic, github action)
 component: tempostack, tempomonolithic
@@ -17,3 +17,5 @@ subtext: |
   Ensure the permissions the operator is granting to the Tempo Service Account
   do not exceed the permissions of the user creating (or modifying) the Tempo instance
   when enabling OpenShift tenancy mode.
+
+  To enable the OpenShift tenancy mode, the user must have permissions to create `TokenReview` and `SubjectAccessReview`.

--- a/.chloggen/ensure_permissions.yaml
+++ b/.chloggen/ensure_permissions.yaml
@@ -5,7 +5,7 @@ change_type: breaking
 component: tempostack, tempomonolithic
 
 # A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Ensure the operator does not grant additional permissions when enabling OpenShift tenancy mode
+note: Ensure the operator does not grant additional permissions when enabling OpenShift tenancy mode (resolves CVE-2025-2786)
 
 # One or more tracking issues related to the change
 issues: []

--- a/.chloggen/ensure_permissions.yaml
+++ b/.chloggen/ensure_permissions.yaml
@@ -19,3 +19,6 @@ subtext: |
   when enabling OpenShift tenancy mode.
 
   To enable the OpenShift tenancy mode, the user must have permissions to create `TokenReview` and `SubjectAccessReview`.
+
+  This breaking change does not affect existing Tempo instances in the cluster.
+  However, the required permissions are now mandatory when creating or modifying a TempoStack or TempoMonolithic CR.

--- a/internal/webhooks/tempomonolithic_webhook_test.go
+++ b/internal/webhooks/tempomonolithic_webhook_test.go
@@ -6,6 +6,7 @@ import (
 
 	configv1alpha1 "github.com/grafana/tempo-operator/api/config/v1alpha1"
 	"github.com/grafana/tempo-operator/api/tempo/v1alpha1"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	authorizationv1 "k8s.io/api/authorization/v1"

--- a/internal/webhooks/tempomonolithic_webhook_test.go
+++ b/internal/webhooks/tempomonolithic_webhook_test.go
@@ -4,20 +4,22 @@ import (
 	"context"
 	"testing"
 
+	configv1alpha1 "github.com/grafana/tempo-operator/api/config/v1alpha1"
+	"github.com/grafana/tempo-operator/api/tempo/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	authorizationv1 "k8s.io/api/authorization/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
-
-	configv1alpha1 "github.com/grafana/tempo-operator/api/config/v1alpha1"
-	"github.com/grafana/tempo-operator/api/tempo/v1alpha1"
 )
 
 func TestMonolithicValidate(t *testing.T) {
+	ctx := admission.NewContextWithRequest(context.Background(), admission.Request{})
+
 	tests := []struct {
 		name       string
 		ctrlConfig configv1alpha1.ProjectConfig
@@ -405,13 +407,19 @@ func TestMonolithicValidate(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			client := &k8sFake{}
+			client := &k8sFake{
+				subjectAccessReview: &authorizationv1.SubjectAccessReview{
+					Status: authorizationv1.SubjectAccessReviewStatus{
+						Allowed: true,
+					},
+				},
+			}
 			v := &monolithicValidator{
 				client:     client,
 				ctrlConfig: test.ctrlConfig,
 			}
 
-			warnings, errors := v.validateTempoMonolithic(context.Background(), test.tempo)
+			warnings, errors := v.validateTempoMonolithic(ctx, test.tempo)
 			require.Equal(t, test.warnings, warnings)
 			require.Equal(t, test.errors, errors)
 		})

--- a/internal/webhooks/validations.go
+++ b/internal/webhooks/validations.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/grafana/tempo-operator/internal/manifests/gateway"
+
 	authenticationv1 "k8s.io/api/authentication/v1"
 	authorizationv1 "k8s.io/api/authorization/v1"
 	rbacv1 "k8s.io/api/rbac/v1"

--- a/internal/webhooks/validations.go
+++ b/internal/webhooks/validations.go
@@ -1,10 +1,17 @@
 package webhooks
 
 import (
+	"context"
 	"fmt"
 
+	"github.com/grafana/tempo-operator/internal/manifests/gateway"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	authorizationv1 "k8s.io/api/authorization/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 const maxLabelLength = 63
@@ -41,4 +48,60 @@ func validateTempoNameConflict(getFn func() error, instanceName string, to strin
 		))
 	}
 	return allErrs
+}
+
+func subjectAccessReviewsForClusterRole(user authenticationv1.UserInfo, clusterRole rbacv1.ClusterRole) []authorizationv1.SubjectAccessReview {
+	reviews := []authorizationv1.SubjectAccessReview{}
+	for _, rule := range clusterRole.Rules {
+		for _, apiGroup := range rule.APIGroups {
+			for _, resource := range rule.Resources {
+				for _, verb := range rule.Verbs {
+					reviews = append(reviews, authorizationv1.SubjectAccessReview{
+						Spec: authorizationv1.SubjectAccessReviewSpec{
+							UID:    user.UID,
+							User:   user.Username,
+							Groups: user.Groups,
+							ResourceAttributes: &authorizationv1.ResourceAttributes{
+								Group:    apiGroup,
+								Resource: resource,
+								Verb:     verb,
+							},
+						},
+					})
+				}
+			}
+		}
+	}
+
+	return reviews
+}
+
+// validateGatewayOpenShiftModeRBAC checks if the user requesting the change on the CR
+// has already the permissions which the operator would grant to the ServiceAccount of the Tempo instance
+// when enabling the OpenShift tenancy mode.
+//
+// In other words, the operator should not grant e.g. TokenReview permissions to the ServiceAccount of the Tempo instance
+// if the user creating or modifying the TempoStack or TempoMonolithic doesn't have these permissions.
+func validateGatewayOpenShiftModeRBAC(ctx context.Context, client client.Client) error {
+	req, err := admission.RequestFromContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	user := req.UserInfo
+	clusterRole := gateway.NewAccessReviewClusterRole("", map[string]string{})
+	reviews := subjectAccessReviewsForClusterRole(user, *clusterRole)
+
+	for _, sar := range reviews {
+		err := client.Create(ctx, &sar)
+		if err != nil {
+			return fmt.Errorf("failed to create subject access review: %w", err)
+		}
+
+		if !sar.Status.Allowed {
+			return fmt.Errorf("user %s does not have permission to %s %s.%s", user.Username, sar.Spec.ResourceAttributes.Verb, sar.Spec.ResourceAttributes.Resource, sar.Spec.ResourceAttributes.Group)
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
Ensure the permissions the operator is granting to the Tempo Service Account do not exceed the permissions of the user creating (or modifying) the Tempo instance when enabling OpenShift tenancy mode.

To enable the OpenShift tenancy mode, the user must have permissions to create `TokenReview` and `SubjectAccessReview`.

Resolves CVE-2025-2786