### PR TITLE
Add namespace suffix to ClusterRole and ClusterRoleBinding of gateway

### DIFF
--- a/.chloggen/clusterrole_suffix.yaml
+++ b/.chloggen/clusterrole_suffix.yaml
@@ -1,0 +1,18 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. tempostack, tempomonolithic, github action)
+component: tempostack, tempomonolithic
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add namespace suffix to ClusterRole and ClusterRoleBinding of gateway
+
+# One or more tracking issues related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  This resolves a naming conflict of the ClusterRole and ClusterRoleBinding when two TempoStack/TempoMonolithic instances with the same name, but in different namespaces are created.
+  Only relevant when using multi-tenancy with OpenShift mode.

--- a/internal/manifests/gateway/gateway.go
+++ b/internal/manifests/gateway/gateway.go
@@ -81,11 +81,13 @@ func BuildGateway(params manifestutils.Params) ([]client.Object, error) {
 
 		objs = append(objs, []client.Object{
 			NewAccessReviewClusterRole(
-				gatewayObjectName,
+				// ClusterRole is a cluster scoped resource, therefore we need to add the namespace to the name
+				fmt.Sprintf("%s-%s", gatewayObjectName, tempo.Namespace),
 				manifestutils.ComponentLabels(manifestutils.GatewayComponentName, tempo.Name),
 			),
 			NewAccessReviewClusterRoleBinding(
-				gatewayObjectName,
+				// ClusterRole is a cluster scoped resource, therefore we need to add the namespace to the name
+				fmt.Sprintf("%s-%s", gatewayObjectName, tempo.Namespace),
 				manifestutils.ComponentLabels(manifestutils.GatewayComponentName, tempo.Name),
 				tempo.Namespace,
 				gatewayObjectName,

--- a/internal/manifests/gateway/gateway_test.go
+++ b/internal/manifests/gateway/gateway_test.go
@@ -227,13 +227,13 @@ func TestBuildGateway_openshift(t *testing.T) {
 	obj = getObjectByTypeAndName(objects, "tempo-simplest-gateway", reflect.TypeOf(&corev1.ServiceAccount{}))
 	require.NotNil(t, obj)
 
-	obj = getObjectByTypeAndName(objects, "tempo-simplest-gateway", reflect.TypeOf(&rbacv1.ClusterRole{}))
+	obj = getObjectByTypeAndName(objects, "tempo-simplest-gateway-observability", reflect.TypeOf(&rbacv1.ClusterRole{}))
 	require.NotNil(t, obj)
 	clusterRole, ok := obj.(*rbacv1.ClusterRole)
 	require.True(t, ok)
 	assert.Equal(t, 2, len(clusterRole.Rules))
 
-	obj = getObjectByTypeAndName(objects, "tempo-simplest-gateway", reflect.TypeOf(&rbacv1.ClusterRoleBinding{}))
+	obj = getObjectByTypeAndName(objects, "tempo-simplest-gateway-observability", reflect.TypeOf(&rbacv1.ClusterRoleBinding{}))
 	require.NotNil(t, obj)
 	clusterRoleBinding, ok := obj.(*rbacv1.ClusterRoleBinding)
 	require.True(t, ok)

--- a/internal/manifests/monolithic/gateway.go
+++ b/internal/manifests/monolithic/gateway.go
@@ -1,6 +1,8 @@
 package monolithic
 
 import (
+	"fmt"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/grafana/tempo-operator/api/tempo/v1alpha1"
@@ -58,12 +60,14 @@ func BuildGatewayObjects(opts Options) ([]client.Object, map[string]string, erro
 
 	if tempo.Spec.Multitenancy.TenantsSpec.Mode == v1alpha1.ModeOpenShift {
 		manifests = append(manifests, gateway.NewAccessReviewClusterRole(
-			gatewayObjectName,
+			// ClusterRole is a cluster scoped resource, therefore we need to add the namespace to the name
+			fmt.Sprintf("%s-%s", gatewayObjectName, tempo.Namespace),
 			ComponentLabels(manifestutils.GatewayComponentName, tempo.Name),
 		))
 
 		manifests = append(manifests, gateway.NewAccessReviewClusterRoleBinding(
-			gatewayObjectName,
+			// ClusterRole is a cluster scoped resource, therefore we need to add the namespace to the name
+			fmt.Sprintf("%s-%s", gatewayObjectName, tempo.Namespace),
 			ComponentLabels(manifestutils.GatewayComponentName, tempo.Name),
 			tempo.Namespace,
 			naming.DefaultServiceAccountName(tempo.Name),

--- a/tests/e2e-openshift/monolithic-multitenancy-openshift/01-assert.yaml
+++ b/tests/e2e-openshift/monolithic-multitenancy-openshift/01-assert.yaml
@@ -48,3 +48,45 @@ spec:
     port: 4317
     protocol: TCP
     targetPort: grpc-public
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: gateway
+    app.kubernetes.io/instance: monolithic-multitenancy-openshift
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo-monolithic
+  name: tempo-monolithic-multitenancy-openshift-gateway-chainsaw-monolithic-multitenancy
+rules:
+- apiGroups:
+    - authentication.k8s.io
+  resources:
+    - tokenreviews
+  verbs:
+    - create
+- apiGroups:
+    - authorization.k8s.io
+  resources:
+    - subjectaccessreviews
+  verbs:
+    - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: gateway
+    app.kubernetes.io/instance: monolithic-multitenancy-openshift
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo-monolithic
+  name: tempo-monolithic-multitenancy-openshift-gateway-chainsaw-monolithic-multitenancy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tempo-monolithic-multitenancy-openshift-gateway-chainsaw-monolithic-multitenancy
+subjects:
+- kind: ServiceAccount
+  name: tempo-monolithic-multitenancy-openshift
+  namespace: chainsaw-monolithic-multitenancy

--- a/tests/e2e-openshift/multitenancy/01-assert.yaml
+++ b/tests/e2e-openshift/multitenancy/01-assert.yaml
@@ -86,7 +86,7 @@ metadata:
     app.kubernetes.io/instance: simplest
     app.kubernetes.io/managed-by: tempo-operator
     app.kubernetes.io/name: tempo
-  name: tempo-simplest-gateway
+  name: tempo-simplest-gateway-chainsaw-multitenancy
 rules:
   - apiGroups:
       - authentication.k8s.io
@@ -109,14 +109,15 @@ metadata:
     app.kubernetes.io/instance: simplest
     app.kubernetes.io/managed-by: tempo-operator
     app.kubernetes.io/name: tempo
-  name: tempo-simplest-gateway
+  name: tempo-simplest-gateway-chainsaw-multitenancy
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: tempo-simplest-gateway
+  name: tempo-simplest-gateway-chainsaw-multitenancy
 subjects:
   - kind: ServiceAccount
     name: tempo-simplest-gateway
+    namespace: chainsaw-multitenancy
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
This resolves a naming conflict of the ClusterRole and ClusterRoleBinding when two TempoStack/TempoMonolithic instances with the same name, but in different namespaces are created.

Only relevant when using multi-tenancy with OpenShift mode.