### PR TITLE
Fix pruning of cluster-scoped resources

### DIFF
--- a/.chloggen/clusterscope_label.yaml
+++ b/.chloggen/clusterscope_label.yaml
@@ -8,7 +8,7 @@ component: tempostack, tempomonolithic
 note: Fix pruning of cluster-scoped resources
 
 # One or more tracking issues related to the change
-issues: []
+issues: [1168]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/clusterscope_label.yaml
+++ b/.chloggen/clusterscope_label.yaml
@@ -1,0 +1,19 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. tempostack, tempomonolithic, github action)
+component: tempostack, tempomonolithic
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix pruning of cluster-scoped resources
+
+# One or more tracking issues related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Previously, when a non-multitenant TempoStack instance was created using the same name as an existing multitenant TempoStack instance, the operator erroneously deleted the Gateway ClusterRole and ClusterRoleBinding associated with the multitenant instance.
+
+  With this change, cluster-scoped resources get an additional label `app.kubernetes.io/namespace` to signify the namespace of the TempoStack owning this cluster-scoped resource.

--- a/internal/controller/tempo/tempomonolithic_controller.go
+++ b/internal/controller/tempo/tempomonolithic_controller.go
@@ -160,7 +160,7 @@ func (r *TempoMonolithicReconciler) getOwnedObjects(ctx context.Context, tempo v
 		LabelSelector: labels.SelectorFromSet(monolithic.CommonLabels(tempo.Name)),
 	}
 	clusterWideListOps := &client.ListOptions{
-		LabelSelector: labels.SelectorFromSet(monolithic.CommonLabels(tempo.Name)),
+		LabelSelector: labels.SelectorFromSet(monolithic.ClusterScopedCommonLabels(tempo.ObjectMeta)),
 	}
 
 	// Add all resources where the operator can conditionally create an object.

--- a/internal/controller/tempo/tempostack_create_or_update.go
+++ b/internal/controller/tempo/tempostack_create_or_update.go
@@ -91,7 +91,7 @@ func (r *TempoStackReconciler) findObjectsOwnedByTempoOperator(ctx context.Conte
 		LabelSelector: labels.SelectorFromSet(manifestutils.CommonLabels(tempo.Name)),
 	}
 	clusterWideListOps := &client.ListOptions{
-		LabelSelector: labels.SelectorFromSet(manifestutils.CommonLabels(tempo.Name)),
+		LabelSelector: labels.SelectorFromSet(manifestutils.ClusterScopedCommonLabels(tempo.ObjectMeta)),
 	}
 
 	// Add all resources where the operator can conditionally create an object.

--- a/internal/manifests/gateway/gateway.go
+++ b/internal/manifests/gateway/gateway.go
@@ -83,12 +83,12 @@ func BuildGateway(params manifestutils.Params) ([]client.Object, error) {
 			NewAccessReviewClusterRole(
 				// ClusterRole is a cluster scoped resource, therefore we need to add the namespace to the name
 				fmt.Sprintf("%s-%s", gatewayObjectName, tempo.Namespace),
-				manifestutils.ComponentLabels(manifestutils.GatewayComponentName, tempo.Name),
+				manifestutils.ClusterScopedComponentLabels(tempo.ObjectMeta, manifestutils.GatewayComponentName),
 			),
 			NewAccessReviewClusterRoleBinding(
 				// ClusterRole is a cluster scoped resource, therefore we need to add the namespace to the name
 				fmt.Sprintf("%s-%s", gatewayObjectName, tempo.Namespace),
-				manifestutils.ComponentLabels(manifestutils.GatewayComponentName, tempo.Name),
+				manifestutils.ClusterScopedComponentLabels(tempo.ObjectMeta, manifestutils.GatewayComponentName),
 				tempo.Namespace,
 				gatewayObjectName,
 			),

--- a/internal/manifests/manifestutils/labels.go
+++ b/internal/manifests/manifestutils/labels.go
@@ -1,6 +1,7 @@
 package manifestutils
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 )
 
@@ -18,6 +19,21 @@ func CommonLabels(instanceName string) map[string]string {
 		"app.kubernetes.io/instance":   instanceName,
 		"app.kubernetes.io/managed-by": "tempo-operator",
 	}
+}
+
+// ClusterScopedCommonLabels returns common labels for cluster-scoped resouces, for example ClusterRole.
+func ClusterScopedCommonLabels(instance metav1.ObjectMeta) map[string]string {
+	return labels.Merge(CommonLabels(instance.Name), map[string]string{
+		"app.kubernetes.io/namespace": instance.Namespace,
+	})
+}
+
+// ClusterScopedCommonLabels returns common labels for cluster-scoped resouces (e.g. ClusterRole)
+// including the app.kubernetes.io/component:<component> label.
+func ClusterScopedComponentLabels(instance metav1.ObjectMeta, component string) map[string]string {
+	return labels.Merge(ClusterScopedCommonLabels(instance), map[string]string{
+		"app.kubernetes.io/component": component,
+	})
 }
 
 // CommonOperatorLabels returns the common labels for operator components.

--- a/internal/manifests/manifestutils/labels.go
+++ b/internal/manifests/manifestutils/labels.go
@@ -28,7 +28,7 @@ func ClusterScopedCommonLabels(instance metav1.ObjectMeta) map[string]string {
 	})
 }
 
-// ClusterScopedCommonLabels returns common labels for cluster-scoped resouces (e.g. ClusterRole)
+// ClusterScopedComponentLabels returns common labels for cluster-scoped resouces (e.g. ClusterRole)
 // including the app.kubernetes.io/component:<component> label.
 func ClusterScopedComponentLabels(instance metav1.ObjectMeta, component string) map[string]string {
 	return labels.Merge(ClusterScopedCommonLabels(instance), map[string]string{

--- a/internal/manifests/monolithic/gateway.go
+++ b/internal/manifests/monolithic/gateway.go
@@ -62,13 +62,13 @@ func BuildGatewayObjects(opts Options) ([]client.Object, map[string]string, erro
 		manifests = append(manifests, gateway.NewAccessReviewClusterRole(
 			// ClusterRole is a cluster scoped resource, therefore we need to add the namespace to the name
 			fmt.Sprintf("%s-%s", gatewayObjectName, tempo.Namespace),
-			ComponentLabels(manifestutils.GatewayComponentName, tempo.Name),
+			ClusterScopedComponentLabels(tempo.ObjectMeta, manifestutils.GatewayComponentName),
 		))
 
 		manifests = append(manifests, gateway.NewAccessReviewClusterRoleBinding(
 			// ClusterRole is a cluster scoped resource, therefore we need to add the namespace to the name
 			fmt.Sprintf("%s-%s", gatewayObjectName, tempo.Namespace),
-			ComponentLabels(manifestutils.GatewayComponentName, tempo.Name),
+			ClusterScopedComponentLabels(tempo.ObjectMeta, manifestutils.GatewayComponentName),
 			tempo.Namespace,
 			naming.DefaultServiceAccountName(tempo.Name),
 		))

--- a/internal/manifests/monolithic/gateway_test.go
+++ b/internal/manifests/monolithic/gateway_test.go
@@ -50,4 +50,13 @@ func TestGateway(t *testing.T) {
 
 	require.Contains(t, annotations, "tempo.grafana.com/rbacConfig.hash")
 	require.Contains(t, annotations, "tempo.grafana.com/tenantsConfig.hash")
+
+	require.Equal(t, "tempo-sample-gateway-default", objs[2].GetName())
+	require.Equal(t, map[string]string{
+		"app.kubernetes.io/component":  "gateway",
+		"app.kubernetes.io/instance":   "sample",
+		"app.kubernetes.io/managed-by": "tempo-operator",
+		"app.kubernetes.io/name":       "tempo-monolithic",
+		"app.kubernetes.io/namespace":  "default",
+	}, objs[2].GetLabels())
 }

--- a/internal/manifests/monolithic/labels.go
+++ b/internal/manifests/monolithic/labels.go
@@ -28,7 +28,7 @@ func ClusterScopedCommonLabels(instance metav1.ObjectMeta) map[string]string {
 	})
 }
 
-// ClusterScopedCommonLabels returns common labels for cluster-scoped resouces (e.g. ClusterRole)
+// ClusterScopedComponentLabels returns common labels for cluster-scoped resouces (e.g. ClusterRole)
 // including the app.kubernetes.io/component:<component> label.
 func ClusterScopedComponentLabels(instance metav1.ObjectMeta, component string) map[string]string {
 	return labels.Merge(ClusterScopedCommonLabels(instance), map[string]string{

--- a/internal/manifests/monolithic/labels.go
+++ b/internal/manifests/monolithic/labels.go
@@ -1,6 +1,7 @@
 package monolithic
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 )
 
@@ -16,6 +17,21 @@ func CommonLabels(instanceName string) map[string]string {
 // ComponentLabels is a list of all commonLabels including the app.kubernetes.io/component:<component> label.
 func ComponentLabels(component, instanceName string) labels.Set {
 	return labels.Merge(CommonLabels(instanceName), map[string]string{
+		"app.kubernetes.io/component": component,
+	})
+}
+
+// ClusterScopedCommonLabels returns common labels for cluster-scoped resouces, for example ClusterRole.
+func ClusterScopedCommonLabels(instance metav1.ObjectMeta) map[string]string {
+	return labels.Merge(CommonLabels(instance.Name), map[string]string{
+		"app.kubernetes.io/namespace": instance.Namespace,
+	})
+}
+
+// ClusterScopedCommonLabels returns common labels for cluster-scoped resouces (e.g. ClusterRole)
+// including the app.kubernetes.io/component:<component> label.
+func ClusterScopedComponentLabels(instance metav1.ObjectMeta, component string) map[string]string {
+	return labels.Merge(ClusterScopedCommonLabels(instance), map[string]string{
 		"app.kubernetes.io/component": component,
 	})
 }

--- a/tests/e2e-openshift/monolithic-multitenancy-openshift/01-assert.yaml
+++ b/tests/e2e-openshift/monolithic-multitenancy-openshift/01-assert.yaml
@@ -58,6 +58,7 @@ metadata:
     app.kubernetes.io/instance: mmo
     app.kubernetes.io/managed-by: tempo-operator
     app.kubernetes.io/name: tempo-monolithic
+    app.kubernetes.io/namespace: chainsaw-monolithic-multitenancy
   name: tempo-mmo-gateway-chainsaw-monolithic-multitenancy
 rules:
 - apiGroups:
@@ -81,6 +82,7 @@ metadata:
     app.kubernetes.io/instance: mmo
     app.kubernetes.io/managed-by: tempo-operator
     app.kubernetes.io/name: tempo-monolithic
+    app.kubernetes.io/namespace: chainsaw-monolithic-multitenancy
   name: tempo-mmo-gateway-chainsaw-monolithic-multitenancy
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/e2e-openshift/multitenancy/01-assert.yaml
+++ b/tests/e2e-openshift/multitenancy/01-assert.yaml
@@ -86,6 +86,7 @@ metadata:
     app.kubernetes.io/instance: simplest
     app.kubernetes.io/managed-by: tempo-operator
     app.kubernetes.io/name: tempo
+    app.kubernetes.io/namespace: chainsaw-multitenancy
   name: tempo-simplest-gateway-chainsaw-multitenancy
 rules:
   - apiGroups:
@@ -109,6 +110,7 @@ metadata:
     app.kubernetes.io/instance: simplest
     app.kubernetes.io/managed-by: tempo-operator
     app.kubernetes.io/name: tempo
+    app.kubernetes.io/namespace: chainsaw-multitenancy
   name: tempo-simplest-gateway-chainsaw-multitenancy
 roleRef:
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
This PR adds a `app.kubernetes.io/namespace` label to cluster-scoped resources, to filter them by the pruning code.
See https://issues.redhat.com/browse/TRACING-5355.

Alternatively, we could
* add this label to all components
* add the namespace to the instance label (OTEL operator does that: https://github.com/open-telemetry/opentelemetry-operator/blob/02e42e5db45616e982343a87cc6519df1c21578c/internal/manifests/manifestutils/labels.go#L71)

However, both alternatives would change the immutable `selector` field of the `Deployment` and `StatefulSet` resources, requiring to delete and recreate all Deployments and StatefulSets.