### PR TITLE
Harden CI: resolve zizmor alerts

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -21,6 +21,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   changelog:
     runs-on: ubuntu-22.04
@@ -35,6 +37,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@v5

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -10,6 +10,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   unit-tests:
     name: Unit tests
@@ -19,6 +21,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -29,7 +32,7 @@ jobs:
         run: make ci
 
       - name: "upload coverage report"
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
         with:
           files: cover.out
           flags: unittests
@@ -45,6 +48,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
@@ -63,9 +68,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.1
         with:
           args: -v
           version: v1.61.0

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -10,6 +10,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   e2e-tests:
     name: End-to-end tests ${{ matrix.name }}
@@ -28,6 +30,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     - name: Set up Go
       uses: actions/setup-go@v5
@@ -59,6 +63,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        persist-credentials: false
 
     - name: Set up Go
       uses: actions/setup-go@v5

--- a/.github/workflows/olm.yaml
+++ b/.github/workflows/olm.yaml
@@ -2,6 +2,8 @@ name: "Publish to operatorHUB"
 on:
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   operator-hub-prod-release:
     uses: ./.github/workflows/reusable-operator-hub-release.yaml

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -8,6 +8,8 @@ on:
 env:
   OPERATOR_BOT_USER: tempooperatorbot
 
+permissions: {}
+
 jobs:
   prepare-release:
     runs-on: ubuntu-22.04
@@ -16,19 +18,21 @@ jobs:
       - name: Sync fork
         env:
           GH_TOKEN: ${{ secrets.TEMPOOPERATORBOT_GITHUB_TOKEN }}
+          REPOSITORY_NAME: ${{ github.event.repository.name }}
         run: |
           # synchronizing the fork is fast, and avoids the need to fetch the full upstream repo
           # (fetching the upstream repo with "--depth 1" would lead to "shallow update not allowed"
           #  error when pushing back to the origin repo)
-          gh repo sync $OPERATOR_BOT_USER/${{ github.event.repository.name }} \
+          gh repo sync $OPERATOR_BOT_USER/${REPOSITORY_NAME} \
               --source ${{ github.repository }} \
               --force
 
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          repository: ${{ env.OPERATOR_BOT_USER }}/${{ github.event.repository.name }}
+          repository: ${{ OPERATOR_BOT_USER }}/${{ github.event.repository.name }}
           token: ${{ secrets.TEMPOOPERATORBOT_GITHUB_TOKEN }}
+          persist-credentials: false
 
 
       - name: Set up Go
@@ -57,14 +61,16 @@ jobs:
         run: |
           git config user.name "$OPERATOR_BOT_USER"
           git config user.email "41898282+$OPERATOR_BOT_USER@users.noreply.github.com"
-          git checkout -b releases/${{ inputs.version }}
+          git checkout -b releases/${VERSION}
           git add -A
-          git commit -m "Prepare Release ${{inputs.version}}" --author="${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>"
-          git push -f --set-upstream origin releases/${{ inputs.version }}
+          git commit -m "Prepare Release ${VERSION}" --author="${ACTOR} <${ACTOR}@users.noreply.github.com>"
+          git push -f --set-upstream origin releases/${VERSION}
           gh pr create \
-              --title='Prepare release v${{ inputs.version }}' \
-              --body='v${{ inputs.version }}'\
+              --title='Prepare release v${VERSION}' \
+              --body='v${VERSION}'\
               --repo ${{ github.repository }}
 
         env:
           GITHUB_TOKEN: ${{ secrets.TEMPOOPERATORBOT_GITHUB_TOKEN }}
+          VERSION: ${{ inputs.version }}
+          ACTOR: ${{ github.actor }}

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          repository: ${{ OPERATOR_BOT_USER }}/${{ github.event.repository.name }}
+          repository: ${{ env.OPERATOR_BOT_USER }}/${{ github.event.repository.name }}
           token: ${{ secrets.TEMPOOPERATORBOT_GITHUB_TOKEN }}
           persist-credentials: false
 

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -1,5 +1,7 @@
 name: "Publish operator"
 
+permissions: {}
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/publish-test-utils-image.yaml
+++ b/.github/workflows/publish-test-utils-image.yaml
@@ -56,5 +56,3 @@ jobs:
           platforms: linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
           push: ${{ github.event_name == 'push' }}
           tags: ${{ steps.meta.outputs.tags }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache

--- a/.github/workflows/publish-test-utils-image.yaml
+++ b/.github/workflows/publish-test-utils-image.yaml
@@ -17,6 +17,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   test-utils:
     runs-on: ubuntu-20.04
@@ -24,36 +26,30 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         with:
           images: ghcr.io/${{ github.repository }}/test-utils
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Cache Docker layers
-        uses: actions/cache@v4
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
       - name: Login to GitHub Package Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 #v3.4.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 #v6.16.0
         with:
           context: tests/
           file: tests/Dockerfile.utils

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,8 @@ on:
     paths:
       - CHANGELOG.md
 
+permissions: {}
+
 jobs:
   release:
     runs-on: ubuntu-22.04
@@ -17,6 +19,7 @@ jobs:
       with:
         ref: main
         token: ${{ secrets.GITHUB_TOKEN }}
+        persist-credentials: false
 
     - name: Determine operator version to release
       id: operator-version

--- a/.github/workflows/reusable-operator-hub-release.yaml
+++ b/.github/workflows/reusable-operator-hub-release.yaml
@@ -21,6 +21,9 @@ on:
     secrets:
       TEMPOOPERATORBOT_GITHUB_TOKEN:
         required: true
+
+permissions: {}
+
 jobs:
   create-operator-pull-request:
     runs-on: ubuntu-latest
@@ -28,12 +31,14 @@ jobs:
       - name: Sync fork
         env:
           GH_TOKEN: ${{ secrets.TEMPOOPERATORBOT_GITHUB_TOKEN }}
+          ORG: ${{ inputs.org }}
+          REPO: ${{ inputs.repo }}
         run: |
           # synchronizing the fork is fast, and avoids the need to fetch the full upstream repo
           # (fetching the upstream repo with "--depth 1" would lead to "shallow update not allowed"
           #  error when pushing back to the origin repo)
-          gh repo sync tempooperatorbot/${{ inputs.repo }} \
-              --source ${{ inputs.org }}/${{ inputs.repo }} \
+          gh repo sync tempooperatorbot/${REPO} \
+              --source ${ORG}/${REPO} \
               --force
 
       - name: Checkout operatorhub repo
@@ -41,6 +46,7 @@ jobs:
         with:
           repository: tempooperatorbot/${{ inputs.repo }}
           token: ${{ secrets.TEMPOOPERATORBOT_GITHUB_TOKEN }}
+          persist-credentials: false
 
       - name: Checkout tempo-operator to tmp/ directory
         uses: actions/checkout@v4
@@ -48,6 +54,7 @@ jobs:
           repository: ${{ inputs.oprepo }}
           token: ${{ secrets.TEMPOOPERATORBOT_GITHUB_TOKEN }}
           path: tmp/
+          persist-credentials: false
 
       - name: Determine operator version to release
         id: operator-version
@@ -71,6 +78,8 @@ jobs:
         env:
           VERSION: ${{ steps.operator-version.outputs.version }}
           GH_TOKEN: ${{ secrets.TEMPOOPERATORBOT_GITHUB_TOKEN }}
+          ORG: ${{ inputs.org }}
+          REPO: ${{ inputs.repo }}
         run: |
           message="Update the tempo to $VERSION"
           body="Release tempo-operator \`$VERSION\`.
@@ -89,5 +98,5 @@ jobs:
           git push -f --set-upstream origin $branch
           gh pr create --title "$message" \
                        --body "$body" \
-                       --repo ${{ inputs.org }}/${{ inputs.repo }} \
+                       --repo ${ORG}/${REPO} \
                        --base main

--- a/.github/workflows/reusable-publish-images.yaml
+++ b/.github/workflows/reusable-publish-images.yaml
@@ -12,6 +12,9 @@ on:
       push:
         type: boolean
         required: true
+
+permissions: {}
+
 jobs:
   publish:
     name: Publish container images
@@ -19,6 +22,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Unshallow
         run: git fetch --prune --unshallow
@@ -28,7 +33,7 @@ jobs:
 
       - name: Docker meta
         id: docker_meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         with:
           images: ghcr.io/${{ github.repository }}/tempo-operator
           tags: |
@@ -38,28 +43,20 @@ jobs:
             type=ref,event=branch
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Cache Docker layers
-        uses: actions/cache@v4
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
       - name: Login to GitHub Package Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 #v3.4.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Operator image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 #v6.16.0
         with:
           context: .
           file: ./Dockerfile
@@ -86,7 +83,7 @@ jobs:
 
       - name: Build and push must-gather image
         if: ${{ inputs.publish_bundle }}
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 #v6.16.0
         with:
           context: ./cmd/gather
           file: ./Dockerfile

--- a/.github/workflows/reusable-publish-images.yaml
+++ b/.github/workflows/reusable-publish-images.yaml
@@ -64,16 +64,6 @@ jobs:
           push: ${{ inputs.push }}
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-      - name: Move cache
-        # Temp fix
-        # https://github.com/docker/build-push-action/issues/252
-        # https://github.com/moby/buildkit/issues/1896
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
-        shell: bash
 
       - name: Publish operator bundle and catalog
         if: ${{ inputs.publish_bundle }}
@@ -91,15 +81,3 @@ jobs:
           push: ${{ inputs.push }}
           tags: ${{ github.repository }}/must-gather:${{ inputs.version_tag }}
           labels: ${{ steps.docker_meta.outputs.labels }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-
-      - name: Move cache again for must-gather
-        # Temp fix
-        # https://github.com/docker/build-push-action/issues/252
-        # https://github.com/moby/buildkit/issues/1896
-        if: ${{ inputs.publish_bundle }}
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
-        shell: bash

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -10,6 +10,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   scorecard-tests:
     name: Scorecard test ${{ matrix.name }}
@@ -25,6 +27,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@v5


### PR DESCRIPTION
changed based on audit using zizmor: https://woodruffw.github.io/zizmor/audits/


see more: https://grafana.com/blog/2025/04/27/grafana-security-update-no-customer-impact-from-github-workflow-vulnerability/
