### PR TITLE
Add required permissions to CodeQL workflow

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -45,6 +45,9 @@ jobs:
   security:
     name: Security
     runs-on: ubuntu-22.04
+    permissions:
+      security-events: write
+      actions: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
See: https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/running-codeql-code-scanning-in-a-container#example-workflow