### PR TITLE
RBAC: allow cluster admins to see all attributes

### DIFF
--- a/.chloggen/fix-cluster-admin-filtering.yaml
+++ b/.chloggen/fix-cluster-admin-filtering.yaml
@@ -1,0 +1,19 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. tempostack, tempomonolithic, github action)
+component: tempostack, tempomonolithic
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Allow OpenShift cluster admins to see all attributes when RBAC is enabled.
+
+# One or more tracking issues related to the change
+issues: [1185]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: | 
+  This change removes `--opa.admin-groups=system:cluster-admins,cluster-admin,dedicated-admin`
+  from the OpenShift OPA configuration. This configures the OPA to always return
+  all user's accessible namespaces required by the RBAC feature.

--- a/internal/manifests/gateway/openshift.go
+++ b/internal/manifests/gateway/openshift.go
@@ -221,7 +221,6 @@ func patchOCPOPAContainer(params manifestutils.Params, dep *v1.Deployment) (*v1.
 func NewOpaContainer(ctrlConfig configv1alpha1.ProjectConfig, tenants v1alpha1.TenantsSpec, rbac bool, opaPackage string, resources corev1.ResourceRequirements) corev1.Container {
 	var args = []string{
 		"--log.level=warn",
-		"--opa.admin-groups=system:cluster-admins,cluster-admin,dedicated-admin",
 		fmt.Sprintf("--web.listen=:%d", gatewayOPAHTTPPort),
 		fmt.Sprintf("--web.internal.listen=:%d", gatewayOPAInternalPort),
 		fmt.Sprintf("--web.healthchecks.url=http://localhost:%d", gatewayOPAHTTPPort),

--- a/internal/manifests/gateway/openshift_test.go
+++ b/internal/manifests/gateway/openshift_test.go
@@ -42,7 +42,6 @@ func TestPatchOPAContainer(t *testing.T) {
 	require.Equal(t, 1, len(dep.Spec.Template.Spec.Containers))
 	assert.Equal(t, []string{
 		"--log.level=warn",
-		"--opa.admin-groups=system:cluster-admins,cluster-admin,dedicated-admin",
 		"--web.listen=:8082", "--web.internal.listen=:8083",
 		"--web.healthchecks.url=http://localhost:8082",
 		"--opa.package=tempostack",

--- a/internal/manifests/monolithic/statefulset_test.go
+++ b/internal/manifests/monolithic/statefulset_test.go
@@ -939,7 +939,6 @@ func TestStatefulsetGateway(t *testing.T) {
 		Image: "quay.io/observatorium/opa-openshift:x.y.z",
 		Args: []string{
 			"--log.level=warn",
-			"--opa.admin-groups=system:cluster-admins,cluster-admin,dedicated-admin",
 			"--web.listen=:8082",
 			"--web.internal.listen=:8083",
 			"--web.healthchecks.url=http://localhost:8082",
@@ -1224,7 +1223,6 @@ func TestStatefulsetGatewayRBAC(t *testing.T) {
 		Image: "quay.io/observatorium/opa-openshift:x.y.z",
 		Args: []string{
 			"--log.level=warn",
-			"--opa.admin-groups=system:cluster-admins,cluster-admin,dedicated-admin",
 			"--web.listen=:8082",
 			"--web.internal.listen=:8083",
 			"--web.healthchecks.url=http://localhost:8082",

--- a/tests/e2e-openshift/component-replicas/install-tempo-assert.yaml
+++ b/tests/e2e-openshift/component-replicas/install-tempo-assert.yaml
@@ -232,7 +232,6 @@ spec:
           readOnly: true
       - args:
         - --log.level=warn
-        - --opa.admin-groups=system:cluster-admins,cluster-admin,dedicated-admin
         - --web.listen=:8082
         - --web.internal.listen=:8083
         - --web.healthchecks.url=http://localhost:8082

--- a/tests/e2e-openshift/component-replicas/scale-tempo-assert.yaml
+++ b/tests/e2e-openshift/component-replicas/scale-tempo-assert.yaml
@@ -232,7 +232,6 @@ spec:
           readOnly: true
       - args:
         - --log.level=warn
-        - --opa.admin-groups=system:cluster-admins,cluster-admin,dedicated-admin
         - --web.listen=:8082
         - --web.internal.listen=:8083
         - --web.healthchecks.url=http://localhost:8082

--- a/tests/e2e-openshift/multitenancy-rbac/01-assert.yaml
+++ b/tests/e2e-openshift/multitenancy-rbac/01-assert.yaml
@@ -182,7 +182,6 @@ spec:
           protocol: TCP
       - args:
         - --log.level=warn
-        - --opa.admin-groups=system:cluster-admins,cluster-admin,dedicated-admin
         - --web.listen=:8082
         - --web.internal.listen=:8083
         - --web.healthchecks.url=http://localhost:8082

--- a/tests/e2e-openshift/multitenancy/01-assert.yaml
+++ b/tests/e2e-openshift/multitenancy/01-assert.yaml
@@ -237,7 +237,6 @@ spec:
           readOnly: true
       - args:
         - --log.level=warn
-        - --opa.admin-groups=system:cluster-admins,cluster-admin,dedicated-admin
         - --web.listen=:8082
         - --web.internal.listen=:8083
         - --web.healthchecks.url=http://localhost:8082


### PR DESCRIPTION
Resolves https://issues.redhat.com/browse/TRACING-5354 