### PR TITLE
[chore] Move image push permissions to reusable-publish-images workflow

### DIFF
--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -1,7 +1,6 @@
 name: "Publish operator"
 
-permissions:
-  packages: write # push container image
+permissions: {}
 
 on:
   push:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,8 +50,6 @@ jobs:
   publish-images:
     needs: release
     uses: ./.github/workflows/reusable-publish-images.yaml
-    permissions:
-      packages: write # push container image
     with:
       publish_bundle: true
       version_tag: v${{ needs.release.outputs.operator_version }}

--- a/.github/workflows/reusable-publish-images.yaml
+++ b/.github/workflows/reusable-publish-images.yaml
@@ -13,7 +13,8 @@ on:
         type: boolean
         required: true
 
-permissions: {}
+permissions:
+  packages: write # push container image
 
 jobs:
   publish:


### PR DESCRIPTION
Looks like the permissions have to be set on the reusable workflow instead of the workflow which triggers the reusable workflow.

Follow-up from #1184