### PR TITLE
[chore] add permissions on job level

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -1,8 +1,8 @@
 # This was original taken from: https://raw.githubusercontent.com/open-telemetry/opentelemetry-operator/main/.github/workflows/changelog.yaml
 # This action requires that any PR targeting the main branch should add a
 # yaml file to the ./.chloggen/ directory. If a CHANGELOG entry is not required,
-# or if performing maintance on the Changelog, add either \"[chore]\" to the title of
-# the pull request or add the \"Skip Changelog\" label to disable this action.
+# or if performing maintance on the Changelog, add either "[chore]" to the title of
+# the pull request or add the "Skip Changelog" label to disable this action.
 
 name: changelog
 

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -13,6 +13,8 @@ on:
 jobs:
   publish-images:
     uses: ./.github/workflows/reusable-publish-images.yaml
+    permissions:
+      packages: write # push container image
     with:
       publish_bundle: false
       version_tag: ${{ github.ref }}

--- a/.github/workflows/publish-test-utils-image.yaml
+++ b/.github/workflows/publish-test-utils-image.yaml
@@ -17,12 +17,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
-permissions:
-  packages: write # push container image
+permissions: {}
 
 jobs:
   test-utils:
     runs-on: ubuntu-22.04
+    permissions:
+      packages: write # push container image
 
     steps:
       - name: Checkout

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,6 +50,8 @@ jobs:
   publish-images:
     needs: release
     uses: ./.github/workflows/reusable-publish-images.yaml
+    permissions:
+      packages: write # push container image
     with:
       publish_bundle: true
       version_tag: v${{ needs.release.outputs.operator_version }}

--- a/.github/workflows/reusable-publish-images.yaml
+++ b/.github/workflows/reusable-publish-images.yaml
@@ -13,13 +13,14 @@ on:
         type: boolean
         required: true
 
-permissions:
-  packages: write # push container image
+permissions: {}
 
 jobs:
   publish:
     name: Publish container images
     runs-on: ubuntu-22.04
+    permissions:
+      packages: write # push container image
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Both the "root" workflow and the reusable workflow have to have the permissions set. Additionally, I moved the permissions on the job level instead of the root level (which would apply to all jobs).