### PR TITLE
Explicit add persist-credentials=true for release flows

### DIFF
--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -32,7 +32,7 @@ jobs:
         with:
           repository: ${{ env.OPERATOR_BOT_USER }}/${{ github.event.repository.name }}
           token: ${{ secrets.TEMPOOPERATORBOT_GITHUB_TOKEN }}
-          persist-credentials: false
+          persist-credentials: true
 
 
       - name: Set up Go
@@ -65,10 +65,7 @@ jobs:
           git add -A
           git commit -m "Prepare Release ${VERSION}" --author="${ACTOR} <${ACTOR}@users.noreply.github.com>"
           git push -f --set-upstream origin releases/${VERSION}
-          gh pr create \
-              --title='Prepare release v${VERSION}' \
-              --body='v${VERSION}'\
-              --repo ${{ github.repository }}
+          gh pr create --title="Prepare release v${VERSION}" --body=v${VERSION} --repo ${{ github.repository }}
 
         env:
           GITHUB_TOKEN: ${{ secrets.TEMPOOPERATORBOT_GITHUB_TOKEN }}

--- a/.github/workflows/reusable-operator-hub-release.yaml
+++ b/.github/workflows/reusable-operator-hub-release.yaml
@@ -46,7 +46,7 @@ jobs:
         with:
           repository: tempooperatorbot/${{ inputs.repo }}
           token: ${{ secrets.TEMPOOPERATORBOT_GITHUB_TOKEN }}
-          persist-credentials: false
+          persist-credentials: true
 
       - name: Checkout tempo-operator to tmp/ directory
         uses: actions/checkout@v4
@@ -96,7 +96,4 @@ jobs:
           git add -A
           git commit -s -m "$message"
           git push -f --set-upstream origin $branch
-          gh pr create --title "$message" \
-                       --body "$body" \
-                       --repo ${ORG}/${REPO} \
-                       --base main
+          gh pr create --title "$message" --body "$body" --repo ${ORG}/${REPO} --base main


### PR DESCRIPTION
In this PR https://github.com/grafana/tempo-operator/pull/1169 `persist-credentials ` is set to false, but we need it because this flow executes a git push operation on the bot repository.

According to this documentation https://docs.zizmor.sh/audits/#remediation should be set explicity to false, unless needed for git operations. Which is the case for this github action flow.

Same case for reusable-operator-hub-release flow
