### PR TITLE
Allow manual re-trigger release in case of failures

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,7 @@ on:
       - 'main'
     paths:
       - CHANGELOG.md
+  workflow_dispatch:
 
 permissions: {}
 


### PR DESCRIPTION
This is useful only in emergencies when release fails and we need to retry.