### PR TITLE
Remove deprecated storage.trace.cache setting

### DIFF
--- a/.chloggen/remove_deprecated_cache_settting.yaml
+++ b/.chloggen/remove_deprecated_cache_settting.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. tempostack, tempomonolithic, github action)
+component: tempostack
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove deprecated `storage.trace.cache` setting
+
+# One or more tracking issues related to the change
+issues: [1136]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/internal/manifests/config/build_test.go
+++ b/internal/manifests/config/build_test.go
@@ -82,7 +82,6 @@ storage:
   trace:
     backend: s3
     blocklist_poll: 5m
-    cache: none
     local:
       path: /var/tempo/traces
     s3:
@@ -207,7 +206,6 @@ storage:
   trace:
     backend: s3
     blocklist_poll: 5m
-    cache: none
     local:
       path: /var/tempo/traces
     s3:
@@ -298,7 +296,6 @@ storage:
   trace:
     backend: s3
     blocklist_poll: 5m
-    cache: none
     local:
       path: /var/tempo/traces
     s3:
@@ -388,7 +385,6 @@ storage:
   trace:
     backend: s3
     blocklist_poll: 5m
-    cache: none
     local:
       path: /var/tempo/traces
     s3:
@@ -479,7 +475,6 @@ storage:
   trace:
     backend: s3
     blocklist_poll: 5m
-    cache: none
     local:
       path: /var/tempo/traces
     s3:
@@ -570,7 +565,6 @@ storage:
   trace:
     backend: s3
     blocklist_poll: 5m
-    cache: none
     local:
       path: /var/tempo/traces
     s3:
@@ -661,7 +655,6 @@ storage:
   trace:
     backend: s3
     blocklist_poll: 5m
-    cache: none
     local:
       path: /var/tempo/traces
     s3:
@@ -752,7 +745,6 @@ storage:
   trace:
     backend: s3
     blocklist_poll: 5m
-    cache: none
     local:
       path: /var/tempo/traces
     s3:
@@ -855,7 +847,6 @@ storage:
   trace:
     backend: s3
     blocklist_poll: 5m
-    cache: none
     local:
       path: /var/tempo/traces
     s3:
@@ -956,7 +947,6 @@ storage:
   trace:
     backend: s3
     blocklist_poll: 5m
-    cache: none
     local:
       path: /var/tempo/traces
     s3:
@@ -1150,7 +1140,6 @@ storage:
   trace:
     backend: gcs
     blocklist_poll: 5m
-    cache: none
     local:
       path: /var/tempo/traces
     gcs:
@@ -1267,7 +1256,6 @@ storage:
   trace:
     backend: azure
     blocklist_poll: 5m
-    cache: none
     local:
       path: /var/tempo/traces
     azure:
@@ -1374,7 +1362,6 @@ storage:
   trace:
     backend: s3
     blocklist_poll: 5m
-    cache: none
     local:
       path: /var/tempo/traces
     s3:
@@ -1534,7 +1521,6 @@ storage:
   trace:
     backend: s3
     blocklist_poll: 5m
-    cache: none
     local:
       path: /var/tempo/traces
     s3:
@@ -1654,7 +1640,6 @@ storage:
   trace:
     backend: s3
     blocklist_poll: 5m
-    cache: none
     local:
       path: /var/tempo/traces
     s3:
@@ -1819,7 +1804,6 @@ storage:
   trace:
     backend: s3
     blocklist_poll: 5m
-    cache: none
     local:
       path: /var/tempo/traces
     s3:
@@ -1974,7 +1958,6 @@ storage:
   trace:
     backend: s3
     blocklist_poll: 5m
-    cache: none
     local:
       path: /var/tempo/traces
     s3:
@@ -2084,7 +2067,6 @@ storage:
   trace:
     backend: s3
     blocklist_poll: 5m
-    cache: none
     local:
       path: /var/tempo/traces
     s3:
@@ -2200,7 +2182,6 @@ storage:
   trace:
     backend: s3
     blocklist_poll: 5m
-    cache: none
     local:
       path: /var/tempo/traces
     s3:
@@ -2335,7 +2316,6 @@ storage:
   trace:
     backend: s3
     blocklist_poll: 5m
-    cache: none
     local:
       path: /var/tempo/traces
     s3:
@@ -2420,7 +2400,6 @@ storage:
   trace:
     backend: s3
     blocklist_poll: 5m
-    cache: none
     local:
       path: /var/tempo/traces
     s3:
@@ -2546,7 +2525,6 @@ storage:
   trace:
     backend: s3
     blocklist_poll: 5m
-    cache: none
     local:
       path: /var/tempo/traces
     s3:
@@ -2662,7 +2640,6 @@ storage:
   trace:
     backend: s3
     blocklist_poll: 5m
-    cache: none
     local:
       path: /var/tempo/traces
     s3:
@@ -2781,7 +2758,6 @@ storage:
   trace:
     backend: s3
     blocklist_poll: 5m
-    cache: none
     local:
       path: /var/tempo/traces
     s3:

--- a/internal/manifests/config/tempo-config.yaml
+++ b/internal/manifests/config/tempo-config.yaml
@@ -219,7 +219,6 @@ storage:
   trace:
     backend: {{ .StorageType }}
     blocklist_poll: 5m
-    cache: none
     {{- with .StorageParams.AzureStorage }}
     azure:
       container_name: {{ .Container }}

--- a/tests/e2e-openshift/route/install-tempo-assert.yaml
+++ b/tests/e2e-openshift/route/install-tempo-assert.yaml
@@ -100,7 +100,6 @@ data:
       trace:
         backend: s3
         blocklist_poll: 5m
-        cache: none
         s3:
           endpoint: minio:9000
           bucket: tempo
@@ -218,7 +217,6 @@ data:
       trace:
         backend: s3
         blocklist_poll: 5m
-        cache: none
         s3:
           endpoint: minio:9000
           bucket: tempo

--- a/tests/e2e-openshift/tls-singletenant/01-assert.yaml
+++ b/tests/e2e-openshift/tls-singletenant/01-assert.yaml
@@ -283,7 +283,6 @@ data:
       trace:
         backend: s3
         blocklist_poll: 5m
-        cache: none
         s3:
           endpoint: minio:9000
           bucket: tempo
@@ -421,7 +420,6 @@ data:
       trace:
         backend: s3
         blocklist_poll: 5m
-        cache: none
         s3:
           endpoint: minio:9000
           bucket: tempo

--- a/tests/e2e/tempostack-extraconfig/install-tempostack-assert.yaml
+++ b/tests/e2e/tempostack-extraconfig/install-tempostack-assert.yaml
@@ -466,7 +466,6 @@ data:
         trace:
             backend: s3
             blocklist_poll: 5m
-            cache: none
             local:
                 path: /var/tempo/traces
             s3:
@@ -586,7 +585,6 @@ data:
         trace:
             backend: s3
             blocklist_poll: 5m
-            cache: none
             local:
                 path: /var/tempo/traces
             s3:


### PR DESCRIPTION
Resolves #1136

cc @rubenvp8510 do you remember why we had `cache: none` in the config? I'd assume that's the default setting anyway?