### PR TITLE
enable operator network policies on all OpenShift/k8s versions by default

### DIFF
--- a/bundle/community/manifests/tempo-operator-manager-config_v1_configmap.yaml
+++ b/bundle/community/manifests/tempo-operator-manager-config_v1_configmap.yaml
@@ -49,6 +49,7 @@ data:
         metrics:
           createServiceMonitors: false
           createPrometheusRules: false
+      networkPolicies: true
 kind: ConfigMap
 metadata:
   labels:

--- a/config/overlays/community/controller_manager_config.yaml
+++ b/config/overlays/community/controller_manager_config.yaml
@@ -46,3 +46,4 @@ featureGates:
     metrics:
       createServiceMonitors: false
       createPrometheusRules: false
+  networkPolicies: true

--- a/internal/manifests/networking/policies.go
+++ b/internal/manifests/networking/policies.go
@@ -129,7 +129,7 @@ func policyIngressToMetrics(instanceName, namespace string, labels map[string]st
 					Ports: []networkingv1.NetworkPolicyPort{
 						{
 							Protocol: ptr.To(corev1.ProtocolTCP),
-							Port:     ptr.To(intstr.FromString("metrics")),
+							Port:     ptr.To(intstr.FromInt(8443)),
 						},
 					},
 				},

--- a/internal/manifests/operator/manifests.go
+++ b/internal/manifests/operator/manifests.go
@@ -3,8 +3,6 @@ package operator
 import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"k8s.io/apimachinery/pkg/util/version"
-
 	configv1alpha1 "github.com/grafana/tempo-operator/api/config/v1alpha1"
 	"github.com/grafana/tempo-operator/internal/manifests/networking"
 	"github.com/grafana/tempo-operator/internal/manifests/operator/prometheus"
@@ -18,17 +16,7 @@ func BuildAll(featureGates configv1alpha1.FeatureGates, namespace, k8sVersion st
 		manifests = append(manifests, prometheus.ServiceMonitor(featureGates, namespace))
 	}
 
-	discovered, err := version.Parse(k8sVersion)
-	if err != nil {
-		return nil, err
-	}
-
-	const minVersion = "1.32" // NOTE: Start support on OpenShift 4.19.
-	minimum := version.MustParse(minVersion)
-	// NOTE: This feature is always enabled on OpenShift.
-	isOpenShift := featureGates.OpenShift.ServingCertsService
-
-	if featureGates.NetworkPolicies && (!isOpenShift || discovered.AtLeast(minimum)) {
+	if featureGates.NetworkPolicies {
 		manifests = append(manifests, networking.GenerateOperatorPolicies(namespace)...)
 	}
 

--- a/tests/e2e/networking/00-asserts.yaml
+++ b/tests/e2e/networking/00-asserts.yaml
@@ -59,7 +59,7 @@ spec:
     - namespaceSelector: {}
       podSelector: {}
     ports:
-    - port: metrics
+    - port: 8443
       protocol: TCP
   podSelector:
     matchLabels:

--- a/tests/e2e/networking/chainsaw-test.yaml
+++ b/tests/e2e/networking/chainsaw-test.yaml
@@ -5,6 +5,8 @@ metadata:
   creationTimestamp: null
   name: operator-networking
 spec:
+  timeouts:
+    assert: 120s
   steps:
   - name: step-00
     try:


### PR DESCRIPTION
Since we did not release, I assume we can skip the changelog?