### PR TITLE
remove operator's dns network policy

### DIFF
--- a/internal/manifests/networking/operator.go
+++ b/internal/manifests/networking/operator.go
@@ -16,7 +16,6 @@ func GenerateOperatorPolicies(namespace string) []client.Object {
 		policyAPIServer(instanceName, namespace),
 		policyDenyAll(instanceName, namespace, labels),
 		policyIngressToMetrics(instanceName, namespace, labels),
-		policyEgressAllowDNS(instanceName, namespace, labels),
 	}
 	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
 		objs = append(objs, policyWebhook(instanceName, namespace))

--- a/internal/manifests/networking/policies.go
+++ b/internal/manifests/networking/policies.go
@@ -138,6 +138,10 @@ func policyIngressToMetrics(instanceName, namespace string, labels map[string]st
 	}
 }
 
+// policyEgressAllowDNS is used on the operands.
+// TODO: remove nolint:unused once implemented.
+// https://github.com/grafana/tempo-operator/pull/1246
+// nolint:unused
 func policyEgressAllowDNS(instanceName, namespace string, labels map[string]string) *networkingv1.NetworkPolicy {
 	return &networkingv1.NetworkPolicy{
 		TypeMeta: metav1.TypeMeta{

--- a/tests/e2e/networking/00-asserts.yaml
+++ b/tests/e2e/networking/00-asserts.yaml
@@ -78,45 +78,6 @@ metadata:
     app.kubernetes.io/name: tempo-operator
     app.kubernetes.io/part-of: tempo-operator
     control-plane: controller-manager
-  name: tempo-operator-allow-dns
-  namespace: ($TEMPO_NAMESPACE)
-spec:
-  egress:
-  - ports:
-    - port: 53
-      protocol: TCP
-    - port: 53
-      protocol: UDP
-    to:
-    - namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: openshift-dns
-      podSelector:
-        matchLabels:
-          dns.operator.openshift.io/daemonset-dns: default
-    - namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: kube-system
-      podSelector:
-        matchLabels:
-          k8s-app: kube-dns
-  podSelector:
-    matchLabels:
-      app.kubernetes.io/managed-by: operator-lifecycle-manager
-      app.kubernetes.io/name: tempo-operator
-      app.kubernetes.io/part-of: tempo-operator
-      control-plane: controller-manager
-  policyTypes:
-  - Egress
----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  labels:
-    app.kubernetes.io/managed-by: operator-lifecycle-manager
-    app.kubernetes.io/name: tempo-operator
-    app.kubernetes.io/part-of: tempo-operator
-    control-plane: controller-manager
   name: tempo-operator-ingress-webhook
   namespace: ($TEMPO_NAMESPACE)
 spec:


### PR DESCRIPTION
Only needed for the operands. The Operator seems to work fine without DNS.

Updates #1250 

cc @IshwarKanse 