### PR TITLE
Fix flaky e2e/reconcile test

### DIFF
--- a/tests/e2e/reconcile/03-assert.yaml
+++ b/tests/e2e/reconcile/03-assert.yaml
@@ -1,10 +1,18 @@
 # An update of the storage secret triggers an update of
 # the configuration, which triggers a restart of the pods.
+#
+# The following changes trigger a new generation of the manifests:
+# * initial deployment
+# * secret change in step 03-update-storage-secret.yaml
+# * annotation change by the certrotation controller
+#
+# Depending on the timing, we observe either three generations or two generations in case
+# the changes by the tempostack controller and certrotation controller are batched into a single update.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: tempo-simplest-compactor
-  generation: 3
+  (generation >= `2`): true
 status:
   readyReplicas: 1
 ---
@@ -12,7 +20,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: tempo-simplest-distributor
-  generation: 3
+  (generation >= `2`): true
 status:
   readyReplicas: 1
 ---
@@ -20,7 +28,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: tempo-simplest-ingester
-  generation: 3
+  (generation >= `2`): true
 status:
   readyReplicas: 1
 ---
@@ -28,7 +36,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: tempo-simplest-querier
-  generation: 3
+  (generation >= `2`): true
 status:
   readyReplicas: 1
 ---
@@ -36,6 +44,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: tempo-simplest-query-frontend
-  generation: 3
+  (generation >= `2`): true
 status:
   readyReplicas: 1


### PR DESCRIPTION
The following changes trigger a new generation of the manifests:
* initial deployment
* secret change in step 03-update-storage-secret.yaml
* annotation change by the certrotation controller

Depending on the timing, we observe either three generations or two generations in case the changes by the tempostack controller and certrotation controller are batched into a single update.