### PR TITLE
Force HTTPS for object storage when using AWS token-based authentication

### DIFF
--- a/.chloggen/force_https_token_aws.yaml
+++ b/.chloggen/force_https_token_aws.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. tempostack, tempomonolithic, github action)
+component: tempostack
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Always use HTTPS for S3 storage when token-based authentication is enabled
+
+# One or more tracking issues related to the change
+issues: [1410]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/internal/handlers/storage/storage.go
+++ b/internal/handlers/storage/storage.go
@@ -58,7 +58,13 @@ func GetStorageParamsForTempoStack(ctx context.Context, client client.Client, te
 			return manifestutils.StorageParams{}, errs
 		}
 
-		storageParams.S3.Insecure = !tempo.Spec.Storage.TLS.Enabled
+		// Token-based auth (STS/IRSA) requires HTTPS to communicate with AWS endpoints.
+		// Only fall back to the user-controlled TLS toggle for static credentials.
+		if credentialMode == v1alpha1.CredentialModeToken || credentialMode == v1alpha1.CredentialModeTokenCCO {
+			storageParams.S3.Insecure = false
+		} else {
+			storageParams.S3.Insecure = !tempo.Spec.Storage.TLS.Enabled
+		}
 
 		if tempo.Spec.Storage.TLS.Enabled {
 			storageParams.S3.TLS, errs = getTLSParams(ctx, client, tempo.Namespace, tempo.Spec.Storage.TLS, tlsPath.Child("caName"))

--- a/internal/handlers/storage/storage_test.go
+++ b/internal/handlers/storage/storage_test.go
@@ -1,0 +1,153 @@
+package storage
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/grafana/tempo-operator/api/tempo/v1alpha1"
+)
+
+func TestGetStorageParamsForTempoStack_S3TokenModeAlwaysHTTPS(t *testing.T) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "storage-secret",
+			Namespace: "default",
+		},
+		Data: map[string][]byte{
+			"bucket":   []byte("my-bucket"),
+			"region":   []byte("us-east-1"),
+			"role_arn": []byte("arn:aws:iam::123456789012:role/my-role"),
+		},
+	}
+
+	tests := []struct {
+		name           string
+		credentialMode v1alpha1.CredentialMode
+		tlsEnabled     bool
+		wantInsecure   bool
+	}{
+		{
+			name:           "token mode without TLS enabled uses HTTPS",
+			credentialMode: v1alpha1.CredentialModeToken,
+			tlsEnabled:     false,
+			wantInsecure:   false,
+		},
+		{
+			name:           "token mode with TLS enabled uses HTTPS",
+			credentialMode: v1alpha1.CredentialModeToken,
+			tlsEnabled:     true,
+			wantInsecure:   false,
+		},
+		{
+			name:           "token-cco mode without TLS enabled uses HTTPS",
+			credentialMode: v1alpha1.CredentialModeTokenCCO,
+			tlsEnabled:     false,
+			wantInsecure:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := runtime.NewScheme()
+			err := scheme.AddToScheme(s)
+			require.NoError(t, err)
+
+			cl := fake.NewClientBuilder().WithScheme(s).WithObjects(secret.DeepCopy()).Build()
+
+			tempo := v1alpha1.TempoStack{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "default",
+				},
+				Spec: v1alpha1.TempoStackSpec{
+					Storage: v1alpha1.ObjectStorageSpec{
+						Secret: v1alpha1.ObjectStorageSecretSpec{
+							Name:           "storage-secret",
+							Type:           v1alpha1.ObjectStorageSecretS3,
+							CredentialMode: tt.credentialMode,
+						},
+						TLS: v1alpha1.TLSSpec{
+							Enabled: tt.tlsEnabled,
+						},
+					},
+				},
+			}
+
+			params, errs := GetStorageParamsForTempoStack(context.Background(), cl, tempo)
+			require.Empty(t, errs)
+			require.Equal(t, tt.wantInsecure, params.S3.Insecure)
+		})
+	}
+}
+
+func TestGetStorageParamsForTempoStack_S3StaticModeRespectsStorageTLS(t *testing.T) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "storage-secret",
+			Namespace: "default",
+		},
+		Data: map[string][]byte{
+			"bucket":            []byte("my-bucket"),
+			"endpoint":          []byte("https://minio:9000"),
+			"access_key_id":     []byte("key"),
+			"access_key_secret": []byte("secret"),
+		},
+	}
+
+	tests := []struct {
+		name         string
+		tlsEnabled   bool
+		wantInsecure bool
+	}{
+		{
+			name:         "static mode with TLS enabled uses HTTPS",
+			tlsEnabled:   true,
+			wantInsecure: false,
+		},
+		{
+			name:         "static mode without TLS enabled uses HTTP",
+			tlsEnabled:   false,
+			wantInsecure: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := runtime.NewScheme()
+			err := scheme.AddToScheme(s)
+			require.NoError(t, err)
+
+			cl := fake.NewClientBuilder().WithScheme(s).WithObjects(secret.DeepCopy()).Build()
+
+			tempo := v1alpha1.TempoStack{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "default",
+				},
+				Spec: v1alpha1.TempoStackSpec{
+					Storage: v1alpha1.ObjectStorageSpec{
+						Secret: v1alpha1.ObjectStorageSecretSpec{
+							Name:           "storage-secret",
+							Type:           v1alpha1.ObjectStorageSecretS3,
+							CredentialMode: v1alpha1.CredentialModeStatic,
+						},
+						TLS: v1alpha1.TLSSpec{
+							Enabled: tt.tlsEnabled,
+						},
+					},
+				},
+			}
+
+			params, errs := GetStorageParamsForTempoStack(context.Background(), cl, tempo)
+			require.Empty(t, errs)
+			require.Equal(t, tt.wantInsecure, params.S3.Insecure)
+		})
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/grafana/tempo-operator/issues/1410