### PR TITLE
Add env and envFrom fields to TempoStack and TempoMonolithic CRDs

### DIFF
--- a/.chloggen/inject_secret_envs.yaml
+++ b/.chloggen/inject_secret_envs.yaml
@@ -1,0 +1,42 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. tempostack, tempomonolithic, github action)
+component: tempostack, tempomonolithic
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add env and envFrom fields to inject environment variables into Tempo containers from Kubernetes Secrets or ConfigMaps.
+
+# One or more tracking issues related to the change
+issues: [1135]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The new `spec.env` and `spec.envFrom` fields allow injecting environment variables into all Tempo containers.
+  Combined with `spec.extraConfig` and the `-config.expand-env=true` flag, this enables referencing sensitive
+  values (e.g. a Redis cache password) stored in Kubernetes Secrets using `${VAR_NAME}` syntax in the Tempo configuration.
+  The `-config.expand-env=true` flag has also been added to TempoMonolithic for feature parity with TempoStack.
+
+  Example TempoStack CR with a password-protected Redis cache:
+  ```yaml
+  apiVersion: tempo.grafana.com/v1alpha1
+  kind: TempoStack
+  metadata:
+    name: tempo
+  spec:
+    env:
+      - name: REDIS_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: redis-creds
+            key: password
+    extraConfig:
+      tempo:
+        cache:
+          caches:
+            - redis:
+                endpoint: "redis.host"
+                password: "${REDIS_PASSWORD}"
+  ```

--- a/api/tempo/v1alpha1/tempomonolithic_types.go
+++ b/api/tempo/v1alpha1/tempomonolithic_types.go
@@ -74,6 +74,24 @@ type TempoMonolithicSpec struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Extra Configuration",xDescriptors="urn:alm:descriptor:com.tectonic.ui:advanced"
 	ExtraConfig *ExtraConfigSpec `json:"extraConfig,omitempty"`
 
+	// Env defines additional environment variables for the Tempo container.
+	// These environment variables can be used together with extraConfig and the -config.expand-env=true flag
+	// to reference Kubernetes Secrets or ConfigMaps in the Tempo configuration,
+	// for example for a password-protected Redis cache.
+	//
+	// +optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Environment Variables",xDescriptors="urn:alm:descriptor:com.tectonic.ui:advanced"
+	Env []corev1.EnvVar `json:"env,omitempty"`
+
+	// EnvFrom defines additional environment variable sources for the Tempo container.
+	// These environment variables can be used together with extraConfig and the -config.expand-env=true flag
+	// to reference Kubernetes Secrets or ConfigMaps in the Tempo configuration,
+	// for example for a password-protected Redis cache.
+	//
+	// +optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Environment Variable Sources",xDescriptors="urn:alm:descriptor:com.tectonic.ui:advanced"
+	EnvFrom []corev1.EnvFromSource `json:"envFrom,omitempty"`
+
 	// Query defines query configuration.
 	//
 	// +kubebuilder:validation:Optional

--- a/api/tempo/v1alpha1/tempostack_types.go
+++ b/api/tempo/v1alpha1/tempostack_types.go
@@ -173,6 +173,24 @@ type TempoStackSpec struct {
 	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Extra Configurations"
 	ExtraConfig *ExtraConfigSpec `json:"extraConfig,omitempty"`
+
+	// Env defines additional environment variables for the Tempo containers of all components.
+	// These environment variables can be used together with extraConfig and the -config.expand-env=true flag
+	// to reference Kubernetes Secrets or ConfigMaps in the Tempo configuration,
+	// for example for a password-protected Redis cache.
+	//
+	// +optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Environment Variables",xDescriptors="urn:alm:descriptor:com.tectonic.ui:advanced"
+	Env []corev1.EnvVar `json:"env,omitempty"`
+
+	// EnvFrom defines additional environment variable sources for the Tempo containers of all components.
+	// These environment variables can be used together with extraConfig and the -config.expand-env=true flag
+	// to reference Kubernetes Secrets or ConfigMaps in the Tempo configuration,
+	// for example for a password-protected Redis cache.
+	//
+	// +optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Environment Variable Sources",xDescriptors="urn:alm:descriptor:com.tectonic.ui:advanced"
+	EnvFrom []corev1.EnvFromSource `json:"envFrom,omitempty"`
 }
 
 // NetworkPolicySpec defines how network policies are handled.

--- a/api/tempo/v1alpha1/zz_generated.deepcopy.go
+++ b/api/tempo/v1alpha1/zz_generated.deepcopy.go
@@ -1498,6 +1498,20 @@ func (in *TempoMonolithicSpec) DeepCopyInto(out *TempoMonolithicSpec) {
 		*out = new(ExtraConfigSpec)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Env != nil {
+		in, out := &in.Env, &out.Env
+		*out = make([]v1.EnvVar, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.EnvFrom != nil {
+		in, out := &in.EnvFrom, &out.EnvFrom
+		*out = make([]v1.EnvFromSource, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.Query != nil {
 		in, out := &in.Query, &out.Query
 		*out = new(MonolithicQuerySpec)
@@ -1665,6 +1679,20 @@ func (in *TempoStackSpec) DeepCopyInto(out *TempoStackSpec) {
 		in, out := &in.ExtraConfig, &out.ExtraConfig
 		*out = new(ExtraConfigSpec)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.Env != nil {
+		in, out := &in.Env, &out.Env
+		*out = make([]v1.EnvVar, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.EnvFrom != nil {
+		in, out := &in.EnvFrom, &out.EnvFrom
+		*out = make([]v1.EnvFromSource, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
 	}
 }
 

--- a/bundle/community/manifests/tempo-operator.clusterserviceversion.yaml
+++ b/bundle/community/manifests/tempo-operator.clusterserviceversion.yaml
@@ -74,7 +74,7 @@ metadata:
     capabilities: Deep Insights
     categories: Logging & Tracing,Monitoring,Observability
     containerImage: ghcr.io/grafana/tempo-operator/tempo-operator:v0.20.0
-    createdAt: "2026-03-03T12:35:53Z"
+    createdAt: "2026-03-26T06:05:54Z"
     description: Create and manage deployments of Tempo, a high-scale distributed
       tracing backend.
     operatorframework.io/cluster-monitoring: "true"
@@ -249,6 +249,24 @@ spec:
       - description: Affinity defines the Affinity rules for scheduling pods.
         displayName: Affinity
         path: affinity
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+      - description: |-
+          Env defines additional environment variables for the Tempo container.
+          These environment variables can be used together with extraConfig and the -config.expand-env=true flag
+          to reference Kubernetes Secrets or ConfigMaps in the Tempo configuration,
+          for example for a password-protected Redis cache.
+        displayName: Environment Variables
+        path: env
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+      - description: |-
+          EnvFrom defines additional environment variable sources for the Tempo container.
+          These environment variables can be used together with extraConfig and the -config.expand-env=true flag
+          to reference Kubernetes Secrets or ConfigMaps in the Tempo configuration,
+          for example for a password-protected Redis cache.
+        displayName: Environment Variable Sources
+        path: envFrom
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: ExtraConfig defines any extra (overlay) configuration of components.
@@ -662,6 +680,24 @@ spec:
         path: template.queryFrontend.jaegerQuery.authentication.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: |-
+          Env defines additional environment variables for the Tempo containers of all components.
+          These environment variables can be used together with extraConfig and the -config.expand-env=true flag
+          to reference Kubernetes Secrets or ConfigMaps in the Tempo configuration,
+          for example for a password-protected Redis cache.
+        displayName: Environment Variables
+        path: env
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+      - description: |-
+          EnvFrom defines additional environment variable sources for the Tempo containers of all components.
+          These environment variables can be used together with extraConfig and the -config.expand-env=true flag
+          to reference Kubernetes Secrets or ConfigMaps in the Tempo configuration,
+          for example for a password-protected Redis cache.
+        displayName: Environment Variable Sources
+        path: envFrom
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       - displayName: Extra Configurations
         path: extraConfig
       - description: Tempo defines any extra Tempo configuration, which will be merged

--- a/bundle/community/manifests/tempo.grafana.com_tempomonolithics.yaml
+++ b/bundle/community/manifests/tempo.grafana.com_tempomonolithics.yaml
@@ -963,6 +963,218 @@ spec:
                         x-kubernetes-list-type: atomic
                     type: object
                 type: object
+              env:
+                description: |-
+                  Env defines additional environment variables for the Tempo container.
+                  These environment variables can be used together with extraConfig and the -config.expand-env=true flag
+                  to reference Kubernetes Secrets or ConfigMaps in the Tempo configuration,
+                  for example for a password-protected Redis cache.
+                items:
+                  description: EnvVar represents an environment variable present in
+                    a Container.
+                  properties:
+                    name:
+                      description: |-
+                        Name of the environment variable.
+                        May consist of any printable ASCII characters except '='.
+                      type: string
+                    value:
+                      description: |-
+                        Variable references $(VAR_NAME) are expanded
+                        using the previously defined environment variables in the container and
+                        any service environment variables. If a variable cannot be resolved,
+                        the reference in the input string will be unchanged. Double $$ are reduced
+                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                        Escaped references will never be expanded, regardless of whether the variable
+                        exists or not.
+                        Defaults to "".
+                      type: string
+                    valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fieldRef:
+                          description: |-
+                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fileKeyRef:
+                          description: |-
+                            FileKeyRef selects a key of the env file.
+                            Requires the EnvFiles feature gate to be enabled.
+                          properties:
+                            key:
+                              description: |-
+                                The key within the env file. An invalid key will prevent the pod from starting.
+                                The keys defined within a source may consist of any printable ASCII characters except '='.
+                                During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                              type: string
+                            optional:
+                              default: false
+                              description: |-
+                                Specify whether the file or its key must be defined. If the file or key
+                                does not exist, then the env var is not published.
+                                If optional is set to true and the specified key does not exist,
+                                the environment variable will not be set in the Pod's containers.
+
+                                If optional is set to false and the specified key does not exist,
+                                an error will be returned during Pod creation.
+                              type: boolean
+                            path:
+                              description: |-
+                                The path within the volume from which to select the file.
+                                Must be relative and may not contain the '..' path or start with '..'.
+                              type: string
+                            volumeName:
+                              description: The name of the volume mount containing
+                                the env file.
+                              type: string
+                          required:
+                          - key
+                          - path
+                          - volumeName
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        resourceFieldRef:
+                          description: |-
+                            Selects a resource of the container: only resources limits and requests
+                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              envFrom:
+                description: |-
+                  EnvFrom defines additional environment variable sources for the Tempo container.
+                  These environment variables can be used together with extraConfig and the -config.expand-env=true flag
+                  to reference Kubernetes Secrets or ConfigMaps in the Tempo configuration,
+                  for example for a password-protected Redis cache.
+                items:
+                  description: EnvFromSource represents the source of a set of ConfigMaps
+                    or Secrets
+                  properties:
+                    configMapRef:
+                      description: The ConfigMap to select from
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: Specify whether the ConfigMap must be defined
+                          type: boolean
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    prefix:
+                      description: |-
+                        Optional text to prepend to the name of each environment variable.
+                        May consist of any printable ASCII characters except '='.
+                      type: string
+                    secretRef:
+                      description: The Secret to select from
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: Specify whether the Secret must be defined
+                          type: boolean
+                      type: object
+                      x-kubernetes-map-type: atomic
+                  type: object
+                type: array
               extraConfig:
                 description: ExtraConfig defines any extra (overlay) configuration
                   of components.

--- a/bundle/community/manifests/tempo.grafana.com_tempostacks.yaml
+++ b/bundle/community/manifests/tempo.grafana.com_tempostacks.yaml
@@ -58,6 +58,218 @@ spec:
           spec:
             description: TempoStackSpec defines the desired state of TempoStack.
             properties:
+              env:
+                description: |-
+                  Env defines additional environment variables for the Tempo containers of all components.
+                  These environment variables can be used together with extraConfig and the -config.expand-env=true flag
+                  to reference Kubernetes Secrets or ConfigMaps in the Tempo configuration,
+                  for example for a password-protected Redis cache.
+                items:
+                  description: EnvVar represents an environment variable present in
+                    a Container.
+                  properties:
+                    name:
+                      description: |-
+                        Name of the environment variable.
+                        May consist of any printable ASCII characters except '='.
+                      type: string
+                    value:
+                      description: |-
+                        Variable references $(VAR_NAME) are expanded
+                        using the previously defined environment variables in the container and
+                        any service environment variables. If a variable cannot be resolved,
+                        the reference in the input string will be unchanged. Double $$ are reduced
+                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                        Escaped references will never be expanded, regardless of whether the variable
+                        exists or not.
+                        Defaults to "".
+                      type: string
+                    valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fieldRef:
+                          description: |-
+                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fileKeyRef:
+                          description: |-
+                            FileKeyRef selects a key of the env file.
+                            Requires the EnvFiles feature gate to be enabled.
+                          properties:
+                            key:
+                              description: |-
+                                The key within the env file. An invalid key will prevent the pod from starting.
+                                The keys defined within a source may consist of any printable ASCII characters except '='.
+                                During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                              type: string
+                            optional:
+                              default: false
+                              description: |-
+                                Specify whether the file or its key must be defined. If the file or key
+                                does not exist, then the env var is not published.
+                                If optional is set to true and the specified key does not exist,
+                                the environment variable will not be set in the Pod's containers.
+
+                                If optional is set to false and the specified key does not exist,
+                                an error will be returned during Pod creation.
+                              type: boolean
+                            path:
+                              description: |-
+                                The path within the volume from which to select the file.
+                                Must be relative and may not contain the '..' path or start with '..'.
+                              type: string
+                            volumeName:
+                              description: The name of the volume mount containing
+                                the env file.
+                              type: string
+                          required:
+                          - key
+                          - path
+                          - volumeName
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        resourceFieldRef:
+                          description: |-
+                            Selects a resource of the container: only resources limits and requests
+                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              envFrom:
+                description: |-
+                  EnvFrom defines additional environment variable sources for the Tempo containers of all components.
+                  These environment variables can be used together with extraConfig and the -config.expand-env=true flag
+                  to reference Kubernetes Secrets or ConfigMaps in the Tempo configuration,
+                  for example for a password-protected Redis cache.
+                items:
+                  description: EnvFromSource represents the source of a set of ConfigMaps
+                    or Secrets
+                  properties:
+                    configMapRef:
+                      description: The ConfigMap to select from
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: Specify whether the ConfigMap must be defined
+                          type: boolean
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    prefix:
+                      description: |-
+                        Optional text to prepend to the name of each environment variable.
+                        May consist of any printable ASCII characters except '='.
+                      type: string
+                    secretRef:
+                      description: The Secret to select from
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: Specify whether the Secret must be defined
+                          type: boolean
+                      type: object
+                      x-kubernetes-map-type: atomic
+                  type: object
+                type: array
               extraConfig:
                 description: |-
                   ExtraConfigSpec defines extra configurations for tempo that will be merged with the operator generated, configurations defined here

--- a/bundle/openshift/manifests/tempo-operator.clusterserviceversion.yaml
+++ b/bundle/openshift/manifests/tempo-operator.clusterserviceversion.yaml
@@ -74,7 +74,7 @@ metadata:
     capabilities: Deep Insights
     categories: Logging & Tracing,Monitoring,Observability
     containerImage: ghcr.io/grafana/tempo-operator/tempo-operator:v0.20.0
-    createdAt: "2026-03-03T12:35:52Z"
+    createdAt: "2026-03-26T06:05:52Z"
     description: Create and manage deployments of Tempo, a high-scale distributed
       tracing backend.
     operatorframework.io/cluster-monitoring: "true"
@@ -249,6 +249,24 @@ spec:
       - description: Affinity defines the Affinity rules for scheduling pods.
         displayName: Affinity
         path: affinity
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+      - description: |-
+          Env defines additional environment variables for the Tempo container.
+          These environment variables can be used together with extraConfig and the -config.expand-env=true flag
+          to reference Kubernetes Secrets or ConfigMaps in the Tempo configuration,
+          for example for a password-protected Redis cache.
+        displayName: Environment Variables
+        path: env
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+      - description: |-
+          EnvFrom defines additional environment variable sources for the Tempo container.
+          These environment variables can be used together with extraConfig and the -config.expand-env=true flag
+          to reference Kubernetes Secrets or ConfigMaps in the Tempo configuration,
+          for example for a password-protected Redis cache.
+        displayName: Environment Variable Sources
+        path: envFrom
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: ExtraConfig defines any extra (overlay) configuration of components.
@@ -662,6 +680,24 @@ spec:
         path: template.queryFrontend.jaegerQuery.authentication.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: |-
+          Env defines additional environment variables for the Tempo containers of all components.
+          These environment variables can be used together with extraConfig and the -config.expand-env=true flag
+          to reference Kubernetes Secrets or ConfigMaps in the Tempo configuration,
+          for example for a password-protected Redis cache.
+        displayName: Environment Variables
+        path: env
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+      - description: |-
+          EnvFrom defines additional environment variable sources for the Tempo containers of all components.
+          These environment variables can be used together with extraConfig and the -config.expand-env=true flag
+          to reference Kubernetes Secrets or ConfigMaps in the Tempo configuration,
+          for example for a password-protected Redis cache.
+        displayName: Environment Variable Sources
+        path: envFrom
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       - displayName: Extra Configurations
         path: extraConfig
       - description: Tempo defines any extra Tempo configuration, which will be merged

--- a/bundle/openshift/manifests/tempo.grafana.com_tempomonolithics.yaml
+++ b/bundle/openshift/manifests/tempo.grafana.com_tempomonolithics.yaml
@@ -963,6 +963,218 @@ spec:
                         x-kubernetes-list-type: atomic
                     type: object
                 type: object
+              env:
+                description: |-
+                  Env defines additional environment variables for the Tempo container.
+                  These environment variables can be used together with extraConfig and the -config.expand-env=true flag
+                  to reference Kubernetes Secrets or ConfigMaps in the Tempo configuration,
+                  for example for a password-protected Redis cache.
+                items:
+                  description: EnvVar represents an environment variable present in
+                    a Container.
+                  properties:
+                    name:
+                      description: |-
+                        Name of the environment variable.
+                        May consist of any printable ASCII characters except '='.
+                      type: string
+                    value:
+                      description: |-
+                        Variable references $(VAR_NAME) are expanded
+                        using the previously defined environment variables in the container and
+                        any service environment variables. If a variable cannot be resolved,
+                        the reference in the input string will be unchanged. Double $$ are reduced
+                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                        Escaped references will never be expanded, regardless of whether the variable
+                        exists or not.
+                        Defaults to "".
+                      type: string
+                    valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fieldRef:
+                          description: |-
+                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fileKeyRef:
+                          description: |-
+                            FileKeyRef selects a key of the env file.
+                            Requires the EnvFiles feature gate to be enabled.
+                          properties:
+                            key:
+                              description: |-
+                                The key within the env file. An invalid key will prevent the pod from starting.
+                                The keys defined within a source may consist of any printable ASCII characters except '='.
+                                During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                              type: string
+                            optional:
+                              default: false
+                              description: |-
+                                Specify whether the file or its key must be defined. If the file or key
+                                does not exist, then the env var is not published.
+                                If optional is set to true and the specified key does not exist,
+                                the environment variable will not be set in the Pod's containers.
+
+                                If optional is set to false and the specified key does not exist,
+                                an error will be returned during Pod creation.
+                              type: boolean
+                            path:
+                              description: |-
+                                The path within the volume from which to select the file.
+                                Must be relative and may not contain the '..' path or start with '..'.
+                              type: string
+                            volumeName:
+                              description: The name of the volume mount containing
+                                the env file.
+                              type: string
+                          required:
+                          - key
+                          - path
+                          - volumeName
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        resourceFieldRef:
+                          description: |-
+                            Selects a resource of the container: only resources limits and requests
+                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              envFrom:
+                description: |-
+                  EnvFrom defines additional environment variable sources for the Tempo container.
+                  These environment variables can be used together with extraConfig and the -config.expand-env=true flag
+                  to reference Kubernetes Secrets or ConfigMaps in the Tempo configuration,
+                  for example for a password-protected Redis cache.
+                items:
+                  description: EnvFromSource represents the source of a set of ConfigMaps
+                    or Secrets
+                  properties:
+                    configMapRef:
+                      description: The ConfigMap to select from
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: Specify whether the ConfigMap must be defined
+                          type: boolean
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    prefix:
+                      description: |-
+                        Optional text to prepend to the name of each environment variable.
+                        May consist of any printable ASCII characters except '='.
+                      type: string
+                    secretRef:
+                      description: The Secret to select from
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: Specify whether the Secret must be defined
+                          type: boolean
+                      type: object
+                      x-kubernetes-map-type: atomic
+                  type: object
+                type: array
               extraConfig:
                 description: ExtraConfig defines any extra (overlay) configuration
                   of components.

--- a/bundle/openshift/manifests/tempo.grafana.com_tempostacks.yaml
+++ b/bundle/openshift/manifests/tempo.grafana.com_tempostacks.yaml
@@ -58,6 +58,218 @@ spec:
           spec:
             description: TempoStackSpec defines the desired state of TempoStack.
             properties:
+              env:
+                description: |-
+                  Env defines additional environment variables for the Tempo containers of all components.
+                  These environment variables can be used together with extraConfig and the -config.expand-env=true flag
+                  to reference Kubernetes Secrets or ConfigMaps in the Tempo configuration,
+                  for example for a password-protected Redis cache.
+                items:
+                  description: EnvVar represents an environment variable present in
+                    a Container.
+                  properties:
+                    name:
+                      description: |-
+                        Name of the environment variable.
+                        May consist of any printable ASCII characters except '='.
+                      type: string
+                    value:
+                      description: |-
+                        Variable references $(VAR_NAME) are expanded
+                        using the previously defined environment variables in the container and
+                        any service environment variables. If a variable cannot be resolved,
+                        the reference in the input string will be unchanged. Double $$ are reduced
+                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                        Escaped references will never be expanded, regardless of whether the variable
+                        exists or not.
+                        Defaults to "".
+                      type: string
+                    valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fieldRef:
+                          description: |-
+                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fileKeyRef:
+                          description: |-
+                            FileKeyRef selects a key of the env file.
+                            Requires the EnvFiles feature gate to be enabled.
+                          properties:
+                            key:
+                              description: |-
+                                The key within the env file. An invalid key will prevent the pod from starting.
+                                The keys defined within a source may consist of any printable ASCII characters except '='.
+                                During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                              type: string
+                            optional:
+                              default: false
+                              description: |-
+                                Specify whether the file or its key must be defined. If the file or key
+                                does not exist, then the env var is not published.
+                                If optional is set to true and the specified key does not exist,
+                                the environment variable will not be set in the Pod's containers.
+
+                                If optional is set to false and the specified key does not exist,
+                                an error will be returned during Pod creation.
+                              type: boolean
+                            path:
+                              description: |-
+                                The path within the volume from which to select the file.
+                                Must be relative and may not contain the '..' path or start with '..'.
+                              type: string
+                            volumeName:
+                              description: The name of the volume mount containing
+                                the env file.
+                              type: string
+                          required:
+                          - key
+                          - path
+                          - volumeName
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        resourceFieldRef:
+                          description: |-
+                            Selects a resource of the container: only resources limits and requests
+                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              envFrom:
+                description: |-
+                  EnvFrom defines additional environment variable sources for the Tempo containers of all components.
+                  These environment variables can be used together with extraConfig and the -config.expand-env=true flag
+                  to reference Kubernetes Secrets or ConfigMaps in the Tempo configuration,
+                  for example for a password-protected Redis cache.
+                items:
+                  description: EnvFromSource represents the source of a set of ConfigMaps
+                    or Secrets
+                  properties:
+                    configMapRef:
+                      description: The ConfigMap to select from
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: Specify whether the ConfigMap must be defined
+                          type: boolean
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    prefix:
+                      description: |-
+                        Optional text to prepend to the name of each environment variable.
+                        May consist of any printable ASCII characters except '='.
+                      type: string
+                    secretRef:
+                      description: The Secret to select from
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: Specify whether the Secret must be defined
+                          type: boolean
+                      type: object
+                      x-kubernetes-map-type: atomic
+                  type: object
+                type: array
               extraConfig:
                 description: |-
                   ExtraConfigSpec defines extra configurations for tempo that will be merged with the operator generated, configurations defined here

--- a/config/crd/bases/tempo.grafana.com_tempomonolithics.yaml
+++ b/config/crd/bases/tempo.grafana.com_tempomonolithics.yaml
@@ -959,6 +959,218 @@ spec:
                         x-kubernetes-list-type: atomic
                     type: object
                 type: object
+              env:
+                description: |-
+                  Env defines additional environment variables for the Tempo container.
+                  These environment variables can be used together with extraConfig and the -config.expand-env=true flag
+                  to reference Kubernetes Secrets or ConfigMaps in the Tempo configuration,
+                  for example for a password-protected Redis cache.
+                items:
+                  description: EnvVar represents an environment variable present in
+                    a Container.
+                  properties:
+                    name:
+                      description: |-
+                        Name of the environment variable.
+                        May consist of any printable ASCII characters except '='.
+                      type: string
+                    value:
+                      description: |-
+                        Variable references $(VAR_NAME) are expanded
+                        using the previously defined environment variables in the container and
+                        any service environment variables. If a variable cannot be resolved,
+                        the reference in the input string will be unchanged. Double $$ are reduced
+                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                        Escaped references will never be expanded, regardless of whether the variable
+                        exists or not.
+                        Defaults to "".
+                      type: string
+                    valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fieldRef:
+                          description: |-
+                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fileKeyRef:
+                          description: |-
+                            FileKeyRef selects a key of the env file.
+                            Requires the EnvFiles feature gate to be enabled.
+                          properties:
+                            key:
+                              description: |-
+                                The key within the env file. An invalid key will prevent the pod from starting.
+                                The keys defined within a source may consist of any printable ASCII characters except '='.
+                                During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                              type: string
+                            optional:
+                              default: false
+                              description: |-
+                                Specify whether the file or its key must be defined. If the file or key
+                                does not exist, then the env var is not published.
+                                If optional is set to true and the specified key does not exist,
+                                the environment variable will not be set in the Pod's containers.
+
+                                If optional is set to false and the specified key does not exist,
+                                an error will be returned during Pod creation.
+                              type: boolean
+                            path:
+                              description: |-
+                                The path within the volume from which to select the file.
+                                Must be relative and may not contain the '..' path or start with '..'.
+                              type: string
+                            volumeName:
+                              description: The name of the volume mount containing
+                                the env file.
+                              type: string
+                          required:
+                          - key
+                          - path
+                          - volumeName
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        resourceFieldRef:
+                          description: |-
+                            Selects a resource of the container: only resources limits and requests
+                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              envFrom:
+                description: |-
+                  EnvFrom defines additional environment variable sources for the Tempo container.
+                  These environment variables can be used together with extraConfig and the -config.expand-env=true flag
+                  to reference Kubernetes Secrets or ConfigMaps in the Tempo configuration,
+                  for example for a password-protected Redis cache.
+                items:
+                  description: EnvFromSource represents the source of a set of ConfigMaps
+                    or Secrets
+                  properties:
+                    configMapRef:
+                      description: The ConfigMap to select from
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: Specify whether the ConfigMap must be defined
+                          type: boolean
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    prefix:
+                      description: |-
+                        Optional text to prepend to the name of each environment variable.
+                        May consist of any printable ASCII characters except '='.
+                      type: string
+                    secretRef:
+                      description: The Secret to select from
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: Specify whether the Secret must be defined
+                          type: boolean
+                      type: object
+                      x-kubernetes-map-type: atomic
+                  type: object
+                type: array
               extraConfig:
                 description: ExtraConfig defines any extra (overlay) configuration
                   of components.

--- a/config/crd/bases/tempo.grafana.com_tempostacks.yaml
+++ b/config/crd/bases/tempo.grafana.com_tempostacks.yaml
@@ -54,6 +54,218 @@ spec:
           spec:
             description: TempoStackSpec defines the desired state of TempoStack.
             properties:
+              env:
+                description: |-
+                  Env defines additional environment variables for the Tempo containers of all components.
+                  These environment variables can be used together with extraConfig and the -config.expand-env=true flag
+                  to reference Kubernetes Secrets or ConfigMaps in the Tempo configuration,
+                  for example for a password-protected Redis cache.
+                items:
+                  description: EnvVar represents an environment variable present in
+                    a Container.
+                  properties:
+                    name:
+                      description: |-
+                        Name of the environment variable.
+                        May consist of any printable ASCII characters except '='.
+                      type: string
+                    value:
+                      description: |-
+                        Variable references $(VAR_NAME) are expanded
+                        using the previously defined environment variables in the container and
+                        any service environment variables. If a variable cannot be resolved,
+                        the reference in the input string will be unchanged. Double $$ are reduced
+                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                        Escaped references will never be expanded, regardless of whether the variable
+                        exists or not.
+                        Defaults to "".
+                      type: string
+                    valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fieldRef:
+                          description: |-
+                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fileKeyRef:
+                          description: |-
+                            FileKeyRef selects a key of the env file.
+                            Requires the EnvFiles feature gate to be enabled.
+                          properties:
+                            key:
+                              description: |-
+                                The key within the env file. An invalid key will prevent the pod from starting.
+                                The keys defined within a source may consist of any printable ASCII characters except '='.
+                                During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                              type: string
+                            optional:
+                              default: false
+                              description: |-
+                                Specify whether the file or its key must be defined. If the file or key
+                                does not exist, then the env var is not published.
+                                If optional is set to true and the specified key does not exist,
+                                the environment variable will not be set in the Pod's containers.
+
+                                If optional is set to false and the specified key does not exist,
+                                an error will be returned during Pod creation.
+                              type: boolean
+                            path:
+                              description: |-
+                                The path within the volume from which to select the file.
+                                Must be relative and may not contain the '..' path or start with '..'.
+                              type: string
+                            volumeName:
+                              description: The name of the volume mount containing
+                                the env file.
+                              type: string
+                          required:
+                          - key
+                          - path
+                          - volumeName
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        resourceFieldRef:
+                          description: |-
+                            Selects a resource of the container: only resources limits and requests
+                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              envFrom:
+                description: |-
+                  EnvFrom defines additional environment variable sources for the Tempo containers of all components.
+                  These environment variables can be used together with extraConfig and the -config.expand-env=true flag
+                  to reference Kubernetes Secrets or ConfigMaps in the Tempo configuration,
+                  for example for a password-protected Redis cache.
+                items:
+                  description: EnvFromSource represents the source of a set of ConfigMaps
+                    or Secrets
+                  properties:
+                    configMapRef:
+                      description: The ConfigMap to select from
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: Specify whether the ConfigMap must be defined
+                          type: boolean
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    prefix:
+                      description: |-
+                        Optional text to prepend to the name of each environment variable.
+                        May consist of any printable ASCII characters except '='.
+                      type: string
+                    secretRef:
+                      description: The Secret to select from
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: Specify whether the Secret must be defined
+                          type: boolean
+                      type: object
+                      x-kubernetes-map-type: atomic
+                  type: object
+                type: array
               extraConfig:
                 description: |-
                   ExtraConfigSpec defines extra configurations for tempo that will be merged with the operator generated, configurations defined here

--- a/config/manifests/community/bases/tempo-operator.clusterserviceversion.yaml
+++ b/config/manifests/community/bases/tempo-operator.clusterserviceversion.yaml
@@ -180,6 +180,24 @@ spec:
         path: affinity
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
+      - description: |-
+          Env defines additional environment variables for the Tempo container.
+          These environment variables can be used together with extraConfig and the -config.expand-env=true flag
+          to reference Kubernetes Secrets or ConfigMaps in the Tempo configuration,
+          for example for a password-protected Redis cache.
+        displayName: Environment Variables
+        path: env
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+      - description: |-
+          EnvFrom defines additional environment variable sources for the Tempo container.
+          These environment variables can be used together with extraConfig and the -config.expand-env=true flag
+          to reference Kubernetes Secrets or ConfigMaps in the Tempo configuration,
+          for example for a password-protected Redis cache.
+        displayName: Environment Variable Sources
+        path: envFrom
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: ExtraConfig defines any extra (overlay) configuration of components.
         displayName: Extra Configuration
         path: extraConfig
@@ -591,6 +609,24 @@ spec:
         path: template.queryFrontend.jaegerQuery.authentication.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: |-
+          Env defines additional environment variables for the Tempo containers of all components.
+          These environment variables can be used together with extraConfig and the -config.expand-env=true flag
+          to reference Kubernetes Secrets or ConfigMaps in the Tempo configuration,
+          for example for a password-protected Redis cache.
+        displayName: Environment Variables
+        path: env
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+      - description: |-
+          EnvFrom defines additional environment variable sources for the Tempo containers of all components.
+          These environment variables can be used together with extraConfig and the -config.expand-env=true flag
+          to reference Kubernetes Secrets or ConfigMaps in the Tempo configuration,
+          for example for a password-protected Redis cache.
+        displayName: Environment Variable Sources
+        path: envFrom
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       - displayName: Extra Configurations
         path: extraConfig
       - description: Tempo defines any extra Tempo configuration, which will be merged

--- a/config/manifests/openshift/bases/tempo-operator.clusterserviceversion.yaml
+++ b/config/manifests/openshift/bases/tempo-operator.clusterserviceversion.yaml
@@ -180,6 +180,24 @@ spec:
         path: affinity
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
+      - description: |-
+          Env defines additional environment variables for the Tempo container.
+          These environment variables can be used together with extraConfig and the -config.expand-env=true flag
+          to reference Kubernetes Secrets or ConfigMaps in the Tempo configuration,
+          for example for a password-protected Redis cache.
+        displayName: Environment Variables
+        path: env
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+      - description: |-
+          EnvFrom defines additional environment variable sources for the Tempo container.
+          These environment variables can be used together with extraConfig and the -config.expand-env=true flag
+          to reference Kubernetes Secrets or ConfigMaps in the Tempo configuration,
+          for example for a password-protected Redis cache.
+        displayName: Environment Variable Sources
+        path: envFrom
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: ExtraConfig defines any extra (overlay) configuration of components.
         displayName: Extra Configuration
         path: extraConfig
@@ -591,6 +609,24 @@ spec:
         path: template.queryFrontend.jaegerQuery.authentication.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: |-
+          Env defines additional environment variables for the Tempo containers of all components.
+          These environment variables can be used together with extraConfig and the -config.expand-env=true flag
+          to reference Kubernetes Secrets or ConfigMaps in the Tempo configuration,
+          for example for a password-protected Redis cache.
+        displayName: Environment Variables
+        path: env
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+      - description: |-
+          EnvFrom defines additional environment variable sources for the Tempo containers of all components.
+          These environment variables can be used together with extraConfig and the -config.expand-env=true flag
+          to reference Kubernetes Secrets or ConfigMaps in the Tempo configuration,
+          for example for a password-protected Redis cache.
+        displayName: Environment Variable Sources
+        path: envFrom
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       - displayName: Extra Configurations
         path: extraConfig
       - description: Tempo defines any extra Tempo configuration, which will be merged

--- a/docs/spec/tempo.grafana.com_tempomonolithics.yaml
+++ b/docs/spec/tempo.grafana.com_tempomonolithics.yaml
@@ -3,6 +3,38 @@ kind: TempoMonolithic                    # Kind is a string value representing t
 metadata:
   name: example
 spec:                                    # TempoMonolithicSpec defines the desired state of TempoMonolithic.
+  env:                                   # Env defines additional environment variables for the Tempo container. These environment variables can be used together with extraConfig and the -config.expand-env=true flag to reference Kubernetes Secrets or ConfigMaps in the Tempo configuration, for example for a password-protected Redis cache.
+  - name: ""                             # Name of the environment variable. May consist of any printable ASCII characters except '='.
+    value: ""                            # Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".
+    valueFrom:                           # Source for the environment variable's value. Cannot be used if value is not empty.
+      configMapKeyRef:                   # Selects a key of a ConfigMap.
+        key: ""                          # The key to select.
+        name: ""                         # Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+        optional: false                  # Specify whether the ConfigMap or its key must be defined
+      fieldRef:                          # Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+        apiVersion: ""                   # Version of the schema the FieldPath is written in terms of, defaults to "v1".
+        fieldPath: ""                    # Path of the field to select in the specified API version.
+      fileKeyRef:                        # FileKeyRef selects a key of the env file. Requires the EnvFiles feature gate to be enabled.
+        key: ""                          # The key within the env file. An invalid key will prevent the pod from starting. The keys defined within a source may consist of any printable ASCII characters except '='. During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+        optional: false                  # Specify whether the file or its key must be defined. If the file or key does not exist, then the env var is not published. If optional is set to true and the specified key does not exist, the environment variable will not be set in the Pod's containers.  If optional is set to false and the specified key does not exist, an error will be returned during Pod creation.
+        path: ""                         # The path within the volume from which to select the file. Must be relative and may not contain the '..' path or start with '..'.
+        volumeName: ""                   # The name of the volume mount containing the env file.
+      resourceFieldRef:                  # Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+        containerName: ""                # Container name: required for volumes, optional for env vars
+        divisor: 0Gi                     # Specifies the output format of the exposed resources, defaults to "1"
+        resource: ""                     # Required: resource to select
+      secretKeyRef:                      # Selects a key of a secret in the pod's namespace
+        key: ""                          # The key of the secret to select from.  Must be a valid secret key.
+        name: ""                         # Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+        optional: false                  # Specify whether the Secret or its key must be defined
+  envFrom:                               # EnvFrom defines additional environment variable sources for the Tempo container. These environment variables can be used together with extraConfig and the -config.expand-env=true flag to reference Kubernetes Secrets or ConfigMaps in the Tempo configuration, for example for a password-protected Redis cache.
+  - configMapRef:                        # The ConfigMap to select from
+      name: ""                           # Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+      optional: false                    # Specify whether the ConfigMap must be defined
+    prefix: ""                           # Optional text to prepend to the name of each environment variable. May consist of any printable ASCII characters except '='.
+    secretRef:                           # The Secret to select from
+      name: ""                           # Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+      optional: false                    # Specify whether the Secret must be defined
   extraConfig:                           # ExtraConfig defines any extra (overlay) configuration of components.
     tempo: {}                            # Tempo defines any extra Tempo configuration, which will be merged with the operator's generated Tempo configuration
   ingestion:                             # Ingestion defines the trace ingestion configuration.

--- a/docs/spec/tempo.grafana.com_tempostacks.yaml
+++ b/docs/spec/tempo.grafana.com_tempostacks.yaml
@@ -3,6 +3,38 @@ kind: TempoStack                         # Kind is a string value representing t
 metadata:
   name: example
 spec:                                    # TempoStackSpec defines the desired state of TempoStack.
+  env:                                   # Env defines additional environment variables for the Tempo containers of all components. These environment variables can be used together with extraConfig and the -config.expand-env=true flag to reference Kubernetes Secrets or ConfigMaps in the Tempo configuration, for example for a password-protected Redis cache.
+  - name: ""                             # Name of the environment variable. May consist of any printable ASCII characters except '='.
+    value: ""                            # Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".
+    valueFrom:                           # Source for the environment variable's value. Cannot be used if value is not empty.
+      configMapKeyRef:                   # Selects a key of a ConfigMap.
+        key: ""                          # The key to select.
+        name: ""                         # Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+        optional: false                  # Specify whether the ConfigMap or its key must be defined
+      fieldRef:                          # Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+        apiVersion: ""                   # Version of the schema the FieldPath is written in terms of, defaults to "v1".
+        fieldPath: ""                    # Path of the field to select in the specified API version.
+      fileKeyRef:                        # FileKeyRef selects a key of the env file. Requires the EnvFiles feature gate to be enabled.
+        key: ""                          # The key within the env file. An invalid key will prevent the pod from starting. The keys defined within a source may consist of any printable ASCII characters except '='. During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+        optional: false                  # Specify whether the file or its key must be defined. If the file or key does not exist, then the env var is not published. If optional is set to true and the specified key does not exist, the environment variable will not be set in the Pod's containers.  If optional is set to false and the specified key does not exist, an error will be returned during Pod creation.
+        path: ""                         # The path within the volume from which to select the file. Must be relative and may not contain the '..' path or start with '..'.
+        volumeName: ""                   # The name of the volume mount containing the env file.
+      resourceFieldRef:                  # Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+        containerName: ""                # Container name: required for volumes, optional for env vars
+        divisor: 0Gi                     # Specifies the output format of the exposed resources, defaults to "1"
+        resource: ""                     # Required: resource to select
+      secretKeyRef:                      # Selects a key of a secret in the pod's namespace
+        key: ""                          # The key of the secret to select from.  Must be a valid secret key.
+        name: ""                         # Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+        optional: false                  # Specify whether the Secret or its key must be defined
+  envFrom:                               # EnvFrom defines additional environment variable sources for the Tempo containers of all components. These environment variables can be used together with extraConfig and the -config.expand-env=true flag to reference Kubernetes Secrets or ConfigMaps in the Tempo configuration, for example for a password-protected Redis cache.
+  - configMapRef:                        # The ConfigMap to select from
+      name: ""                           # Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+      optional: false                    # Specify whether the ConfigMap must be defined
+    prefix: ""                           # Optional text to prepend to the name of each environment variable. May consist of any printable ASCII characters except '='.
+    secretRef:                           # The Secret to select from
+      name: ""                           # Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+      optional: false                    # Specify whether the Secret must be defined
   extraConfig:                           # ExtraConfigSpec defines extra configurations for tempo that will be merged with the operator generated, configurations defined here has precedence and could override generated config.
     tempo: {}                            # Tempo defines any extra Tempo configuration, which will be merged with the operator's generated Tempo configuration
   hashRing:                              # HashRing defines the spec for the distributed hash ring configuration.

--- a/internal/manifests/compactor/compactor.go
+++ b/internal/manifests/compactor/compactor.go
@@ -43,6 +43,8 @@ func BuildCompactor(params manifestutils.Params) ([]client.Object, error) {
 		}
 	}
 
+	manifestutils.PatchEnvVars(&d.Spec.Template.Spec, "tempo", tempo.Spec.Env, tempo.Spec.EnvFrom)
+
 	return []client.Object{d, service(tempo)}, nil
 }
 

--- a/internal/manifests/distributor/distributor.go
+++ b/internal/manifests/distributor/distributor.go
@@ -46,6 +46,7 @@ func BuildDistributor(params manifestutils.Params) ([]client.Object, error) {
 	}
 
 	manifestutils.SetGoMemLimit("tempo", &dep.Spec.Template.Spec)
+	manifestutils.PatchEnvVars(&dep.Spec.Template.Spec, "tempo", tempo.Spec.Env, tempo.Spec.EnvFrom)
 
 	distributorService := service(tempo)
 	objects := []client.Object{dep, distributorService}

--- a/internal/manifests/ingester/ingester.go
+++ b/internal/manifests/ingester/ingester.go
@@ -46,6 +46,8 @@ func BuildIngester(params manifestutils.Params) ([]client.Object, error) {
 		}
 	}
 
+	manifestutils.PatchEnvVars(&ss.Spec.Template.Spec, "tempo", tempo.Spec.Env, tempo.Spec.EnvFrom)
+
 	return []client.Object{ss, service(tempo)}, nil
 }
 

--- a/internal/manifests/manifestutils/env.go
+++ b/internal/manifests/manifestutils/env.go
@@ -1,0 +1,27 @@
+package manifestutils
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+// PatchEnvVars appends user-provided env vars to the named container and sets envFrom.
+// This should be called after all operator-managed env vars have been set,
+// so user env vars can override operator defaults if needed.
+func PatchEnvVars(pod *corev1.PodSpec, containerName string, env []corev1.EnvVar, envFrom []corev1.EnvFromSource) {
+	if len(env) == 0 && len(envFrom) == 0 {
+		return
+	}
+
+	index, _ := findContainerIndex(pod, containerName)
+	if index == -1 {
+		return
+	}
+
+	container := &pod.Containers[index]
+	if len(env) > 0 {
+		container.Env = append(container.Env, env...)
+	}
+	if len(envFrom) > 0 {
+		container.EnvFrom = append(container.EnvFrom, envFrom...)
+	}
+}

--- a/internal/manifests/manifestutils/env_test.go
+++ b/internal/manifests/manifestutils/env_test.go
@@ -1,0 +1,118 @@
+package manifestutils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestPatchEnvVars(t *testing.T) {
+	t.Run("appends user env vars after existing env vars", func(t *testing.T) {
+		pod := corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "tempo",
+					Env: []corev1.EnvVar{
+						{Name: "EXISTING", Value: "value"},
+					},
+				},
+			},
+		}
+
+		userEnv := []corev1.EnvVar{
+			{Name: "REDIS_PASSWORD", ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: "redis-secret"},
+					Key:                  "password",
+				},
+			}},
+		}
+
+		PatchEnvVars(&pod, "tempo", userEnv, nil)
+
+		require.Len(t, pod.Containers[0].Env, 2)
+		require.Equal(t, "EXISTING", pod.Containers[0].Env[0].Name)
+		require.Equal(t, "REDIS_PASSWORD", pod.Containers[0].Env[1].Name)
+	})
+
+	t.Run("sets envFrom on the container", func(t *testing.T) {
+		pod := corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "tempo",
+				},
+			},
+		}
+
+		envFrom := []corev1.EnvFromSource{
+			{SecretRef: &corev1.SecretEnvSource{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "my-secret"},
+			}},
+		}
+
+		PatchEnvVars(&pod, "tempo", nil, envFrom)
+
+		require.Len(t, pod.Containers[0].EnvFrom, 1)
+		require.Equal(t, "my-secret", pod.Containers[0].EnvFrom[0].SecretRef.Name)
+	})
+
+	t.Run("no-op when env and envFrom are empty", func(t *testing.T) {
+		pod := corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "tempo",
+					Env: []corev1.EnvVar{
+						{Name: "EXISTING", Value: "value"},
+					},
+				},
+			},
+		}
+
+		PatchEnvVars(&pod, "tempo", nil, nil)
+
+		require.Len(t, pod.Containers[0].Env, 1)
+		require.Nil(t, pod.Containers[0].EnvFrom)
+	})
+
+	t.Run("only modifies the named container", func(t *testing.T) {
+		pod := corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "jaeger-query",
+				},
+				{
+					Name: "tempo",
+				},
+			},
+		}
+
+		userEnv := []corev1.EnvVar{
+			{Name: "REDIS_PASSWORD", Value: "secret"},
+		}
+
+		PatchEnvVars(&pod, "tempo", userEnv, nil)
+
+		require.Empty(t, pod.Containers[0].Env)
+		require.Len(t, pod.Containers[1].Env, 1)
+		require.Equal(t, "REDIS_PASSWORD", pod.Containers[1].Env[0].Name)
+	})
+
+	t.Run("does nothing when container not found", func(t *testing.T) {
+		pod := corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "other",
+				},
+			},
+		}
+
+		userEnv := []corev1.EnvVar{
+			{Name: "REDIS_PASSWORD", Value: "secret"},
+		}
+
+		PatchEnvVars(&pod, "tempo", userEnv, nil)
+
+		require.Empty(t, pod.Containers[0].Env)
+	})
+}

--- a/internal/manifests/monolithic/statefulset.go
+++ b/internal/manifests/monolithic/statefulset.go
@@ -72,6 +72,7 @@ func BuildTempoStatefulset(opts Options, extraAnnotations map[string]string) (*a
 								"-config.file=/conf/tempo.yaml",
 								"-mem-ballast-size-mbs=1024",
 								"-log.level=info",
+								"-config.expand-env=true",
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
@@ -115,6 +116,7 @@ func BuildTempoStatefulset(opts Options, extraAnnotations map[string]string) (*a
 	}
 
 	manifestutils.SetGoMemLimit("tempo", &sts.Spec.Template.Spec)
+	manifestutils.PatchEnvVars(&sts.Spec.Template.Spec, "tempo", tempo.Spec.Env, tempo.Spec.EnvFrom)
 
 	err := configureStorage(opts, sts)
 	if err != nil {

--- a/internal/manifests/monolithic/statefulset_test.go
+++ b/internal/manifests/monolithic/statefulset_test.go
@@ -101,6 +101,7 @@ func TestStatefulsetMemoryStorage(t *testing.T) {
 								"-config.file=/conf/tempo.yaml",
 								"-mem-ballast-size-mbs=1024",
 								"-log.level=info",
+								"-config.expand-env=true",
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
@@ -334,6 +335,7 @@ func TestStatefulsetS3TLSStorage(t *testing.T) {
 		"-config.file=/conf/tempo.yaml",
 		"-mem-ballast-size-mbs=1024",
 		"-log.level=info",
+		"-config.expand-env=true",
 		"--storage.trace.s3.secret_key=$(S3_SECRET_KEY)",
 		"--storage.trace.s3.access_key=$(S3_ACCESS_KEY)",
 	}, sts.Spec.Template.Spec.Containers[0].Args)

--- a/internal/manifests/querier/querier.go
+++ b/internal/manifests/querier/querier.go
@@ -45,6 +45,8 @@ func BuildQuerier(params manifestutils.Params) ([]client.Object, error) {
 		}
 	}
 
+	manifestutils.PatchEnvVars(&d.Spec.Template.Spec, "tempo", tempo.Spec.Env, tempo.Spec.EnvFrom)
+
 	return []client.Object{d, service(tempo)}, nil
 }
 

--- a/internal/manifests/queryfrontend/query_frontend.go
+++ b/internal/manifests/queryfrontend/query_frontend.go
@@ -74,6 +74,7 @@ func BuildQueryFrontend(params manifestutils.Params) ([]client.Object, error) {
 	for _, target := range targets {
 		manifestutils.SetGoMemLimit(target, &d.Spec.Template.Spec)
 	}
+	manifestutils.PatchEnvVars(&d.Spec.Template.Spec, containerNameTempo, tempo.Spec.Env, tempo.Spec.EnvFrom)
 
 	svcs := services(params)
 	for _, s := range svcs {

--- a/tests/e2e/monolithic-extraconfig/chainsaw-test.yaml
+++ b/tests/e2e/monolithic-extraconfig/chainsaw-test.yaml
@@ -6,8 +6,10 @@ spec:
   description: Test extra config in Tempo Monolithic
   namespace: chainsaw-monoextcfg
   steps:
-  - name: Install Tempo Monolithic
+  - name: Install env Secret and Tempo Monolithic
     try:
+    - apply:
+        file: install-env-secret.yaml
     - apply:
         file: install-tempo.yaml
     - assert:

--- a/tests/e2e/monolithic-extraconfig/install-env-secret.yaml
+++ b/tests/e2e/monolithic-extraconfig/install-env-secret.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-env-secret
+stringData:
+  SECRET_PASSWORD: "secret-from-env"

--- a/tests/e2e/monolithic-extraconfig/install-tempo-assert.yaml
+++ b/tests/e2e/monolithic-extraconfig/install-tempo-assert.yaml
@@ -17,6 +17,10 @@ spec:
       app.kubernetes.io/instance: simplest
       app.kubernetes.io/managed-by: tempo-operator
       app.kubernetes.io/name: tempo-monolithic
+# Verify env and envFrom are injected into the tempo container
+(spec.template.spec.containers[?name == 'tempo'] | [0].env[?name == 'TEST_DIRECT_ENV'] | [0].value): "direct-value"
+(spec.template.spec.containers[?name == 'tempo'] | [0].env[?name == 'TEST_SECRET_ENV'] | [0].valueFrom.secretKeyRef.name): "test-env-secret"
+(spec.template.spec.containers[?name == 'tempo'] | [0].envFrom[?secretRef.name == 'test-env-secret'] | length(@) > `0`): true
 status:
   readyReplicas: 1
 ---

--- a/tests/e2e/monolithic-extraconfig/install-tempo.yaml
+++ b/tests/e2e/monolithic-extraconfig/install-tempo.yaml
@@ -3,6 +3,17 @@ kind: TempoMonolithic
 metadata:
   name: simplest
 spec:
+  env:
+    - name: TEST_DIRECT_ENV
+      value: "direct-value"
+    - name: TEST_SECRET_ENV
+      valueFrom:
+        secretKeyRef:
+          name: test-env-secret
+          key: SECRET_PASSWORD
+  envFrom:
+    - secretRef:
+        name: test-env-secret
   extraConfig:
     tempo:
       querier:

--- a/tests/e2e/tempostack-extraconfig/chainsaw-test.yaml
+++ b/tests/e2e/tempostack-extraconfig/chainsaw-test.yaml
@@ -7,8 +7,10 @@ spec:
   description: Test extra config in TempoStack
   namespace: chainsaw-tempoextcfg
   steps:
-  - name: Install Minio storage
+  - name: Install env Secret and Minio storage
     try:
+    - apply:
+        file: install-env-secret.yaml
     - apply:
         file: install-storage.yaml
     - assert:

--- a/tests/e2e/tempostack-extraconfig/install-env-secret.yaml
+++ b/tests/e2e/tempostack-extraconfig/install-env-secret.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-env-secret
+stringData:
+  SECRET_PASSWORD: "secret-from-env"

--- a/tests/e2e/tempostack-extraconfig/install-tempostack-assert.yaml
+++ b/tests/e2e/tempostack-extraconfig/install-tempostack-assert.yaml
@@ -35,6 +35,9 @@ spec:
       app.kubernetes.io/instance: simplest
       app.kubernetes.io/managed-by: tempo-operator
       app.kubernetes.io/name: tempo
+(spec.template.spec.containers[?name == 'tempo'] | [0].env[?name == 'TEST_DIRECT_ENV'] | [0].value): "direct-value"
+(spec.template.spec.containers[?name == 'tempo'] | [0].env[?name == 'TEST_SECRET_ENV'] | [0].valueFrom.secretKeyRef.name): "test-env-secret"
+(spec.template.spec.containers[?name == 'tempo'] | [0].envFrom[?secretRef.name == 'test-env-secret'] | length(@) > `0`): true
 status:
   readyReplicas: 1
 ---
@@ -55,6 +58,9 @@ spec:
       app.kubernetes.io/instance: simplest
       app.kubernetes.io/managed-by: tempo-operator
       app.kubernetes.io/name: tempo
+(spec.template.spec.containers[?name == 'tempo'] | [0].env[?name == 'TEST_DIRECT_ENV'] | [0].value): "direct-value"
+(spec.template.spec.containers[?name == 'tempo'] | [0].env[?name == 'TEST_SECRET_ENV'] | [0].valueFrom.secretKeyRef.name): "test-env-secret"
+(spec.template.spec.containers[?name == 'tempo'] | [0].envFrom[?secretRef.name == 'test-env-secret'] | length(@) > `0`): true
 status:
   readyReplicas: 1
 ---
@@ -74,6 +80,9 @@ spec:
       app.kubernetes.io/instance: simplest
       app.kubernetes.io/managed-by: tempo-operator
       app.kubernetes.io/name: tempo
+(spec.template.spec.containers[?name == 'tempo'] | [0].env[?name == 'TEST_DIRECT_ENV'] | [0].value): "direct-value"
+(spec.template.spec.containers[?name == 'tempo'] | [0].env[?name == 'TEST_SECRET_ENV'] | [0].valueFrom.secretKeyRef.name): "test-env-secret"
+(spec.template.spec.containers[?name == 'tempo'] | [0].envFrom[?secretRef.name == 'test-env-secret'] | length(@) > `0`): true
 status:
   readyReplicas: 1
 ---
@@ -93,6 +102,9 @@ spec:
       app.kubernetes.io/instance: simplest
       app.kubernetes.io/managed-by: tempo-operator
       app.kubernetes.io/name: tempo
+(spec.template.spec.containers[?name == 'tempo'] | [0].env[?name == 'TEST_DIRECT_ENV'] | [0].value): "direct-value"
+(spec.template.spec.containers[?name == 'tempo'] | [0].env[?name == 'TEST_SECRET_ENV'] | [0].valueFrom.secretKeyRef.name): "test-env-secret"
+(spec.template.spec.containers[?name == 'tempo'] | [0].envFrom[?secretRef.name == 'test-env-secret'] | length(@) > `0`): true
 status:
   readyReplicas: 1
 #
@@ -115,6 +127,9 @@ spec:
       app.kubernetes.io/instance: simplest
       app.kubernetes.io/managed-by: tempo-operator
       app.kubernetes.io/name: tempo
+(spec.template.spec.containers[?name == 'tempo'] | [0].env[?name == 'TEST_DIRECT_ENV'] | [0].value): "direct-value"
+(spec.template.spec.containers[?name == 'tempo'] | [0].env[?name == 'TEST_SECRET_ENV'] | [0].valueFrom.secretKeyRef.name): "test-env-secret"
+(spec.template.spec.containers[?name == 'tempo'] | [0].envFrom[?secretRef.name == 'test-env-secret'] | length(@) > `0`): true
 status:
   readyReplicas: 1
 #

--- a/tests/e2e/tempostack-extraconfig/install-tempostack.yaml
+++ b/tests/e2e/tempostack-extraconfig/install-tempostack.yaml
@@ -4,6 +4,17 @@ metadata:
   name: simplest
 spec:
   timeout: 70s
+  env:
+    - name: TEST_DIRECT_ENV
+      value: "direct-value"
+    - name: TEST_SECRET_ENV
+      valueFrom:
+        secretKeyRef:
+          name: test-env-secret
+          key: SECRET_PASSWORD
+  envFrom:
+    - secretRef:
+        name: test-env-secret
   extraConfig:
     tempo:
       server:


### PR DESCRIPTION
Allow injecting environment variables from Kubernetes Secrets or ConfigMaps into Tempo containers. Combined with extraConfig and -config.expand-env=true, this enables use cases like password-protected Redis cache.

Also adds -config.expand-env=true to TempoMonolithic for feature parity with TempoStack.

Fixes https://github.com/grafana/tempo-operator/issues/1135