### PR TITLE
Inject cluster-wide trusted CA bundle into gateway pod for HostedClus…

### DIFF
--- a/.chloggen/fix_gateway-trusted-ca-bundle-hostedcluster.yaml
+++ b/.chloggen/fix_gateway-trusted-ca-bundle-hostedcluster.yaml
@@ -1,0 +1,21 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. tempostack, tempomonolithic, github action)
+component: tempostack, tempomonolithic
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: |
+  Fix gateway OAuth callback failing with "x509: certificate signed by unknown authority" on HostedClusters (e.g. ROSA)
+
+# One or more tracking issues related to the change
+issues: [1414]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  On HostedClusters the OAuth server's TLS certificate may be signed by a CA not present in the
+  gateway pod's default trust store. The operator now injects the cluster-wide trusted CA bundle
+  (config.openshift.io/inject-trusted-cabundle) into the gateway container and sets SSL_CERT_FILE
+  so that Go's TLS client uses it for outbound HTTPS connections such as the OAuth token exchange.

--- a/internal/manifests/gateway/gateway.go
+++ b/internal/manifests/gateway/gateway.go
@@ -93,7 +93,17 @@ func BuildGateway(params manifestutils.Params) ([]client.Object, error) {
 				gatewayObjectName,
 			),
 			serviceAccount(params.Tempo),
+			manifestutils.NewConfigMapTrustedCABundle(
+				tempo.Namespace,
+				naming.Name("gateway-trusted-cabundle", tempo.Name),
+				manifestutils.ComponentLabels(manifestutils.GatewayComponentName, tempo.Name),
+			),
 		}...)
+
+		dep, err = patchOCPTrustedCA(params.Tempo, dep)
+		if err != nil {
+			return nil, err
+		}
 
 		if params.CtrlConfig.Gates.OpenShift.ServingCertsService {
 			objs = append(objs, manifestutils.NewConfigMapCABundle(

--- a/internal/manifests/gateway/gateway_test.go
+++ b/internal/manifests/gateway/gateway_test.go
@@ -189,7 +189,7 @@ func TestBuildGateway_openshift(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	assert.Equal(t, 9, len(objects))
+	assert.Equal(t, 10, len(objects))
 	obj := getObjectByTypeAndName(objects, "tempo-simplest-gateway", reflect.TypeOf(&appsv1.Deployment{}))
 	require.NotNil(t, obj)
 	dep, ok := obj.(*appsv1.Deployment)
@@ -256,6 +256,14 @@ func TestBuildGateway_openshift(t *testing.T) {
 	require.Equal(t, map[string]string{
 		"service.beta.openshift.io/inject-cabundle": "true",
 	}, caConfigMap.Annotations)
+
+	obj = getObjectByTypeAndName(objects, "tempo-simplest-gateway-trusted-cabundle", reflect.TypeOf(&corev1.ConfigMap{}))
+	require.NotNil(t, obj)
+	trustedCAConfigMap, ok := obj.(*corev1.ConfigMap)
+	require.True(t, ok)
+	require.Equal(t, map[string]string{
+		"config.openshift.io/inject-trusted-cabundle": "true",
+	}, trustedCAConfigMap.Annotations)
 }
 
 func getObjectByTypeAndName(objects []client.Object, name string, t reflect.Type) client.Object { // nolint: unparam

--- a/internal/manifests/gateway/openshift.go
+++ b/internal/manifests/gateway/openshift.go
@@ -196,6 +196,52 @@ func patchOCPServingCerts(tempo v1alpha1.TempoStack, dep *v1.Deployment) (*v1.De
 	return dep, err
 }
 
+func patchOCPTrustedCA(tempo v1alpha1.TempoStack, dep *v1.Deployment) (*v1.Deployment, error) {
+	trustedCAVolumeName := "trusted-ca"
+	trustedCAMountPath := path.Join(tempoGatewayMountDir, "trusted-ca")
+	trustedCAFile := path.Join(trustedCAMountPath, "ca-bundle.crt")
+
+	container := corev1.Container{
+		VolumeMounts: []corev1.VolumeMount{
+			{
+				Name:      trustedCAVolumeName,
+				ReadOnly:  true,
+				MountPath: trustedCAMountPath,
+			},
+		},
+		Env: []corev1.EnvVar{
+			{
+				Name:  "SSL_CERT_FILE",
+				Value: trustedCAFile,
+			},
+		},
+	}
+	err := mergo.Merge(&dep.Spec.Template.Spec.Containers[0], container, mergo.WithAppendSlice)
+	if err != nil {
+		return nil, err
+	}
+
+	pod := corev1.PodSpec{
+		Volumes: []corev1.Volume{
+			{
+				Name: trustedCAVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: naming.Name("gateway-trusted-cabundle", tempo.Name),
+						},
+					},
+				},
+			},
+		},
+	}
+	err = mergo.Merge(&dep.Spec.Template.Spec, pod, mergo.WithAppendSlice)
+	if err != nil {
+		return nil, err
+	}
+	return dep, nil
+}
+
 func patchOCPServiceAccount(tempo v1alpha1.TempoStack, dep *v1.Deployment) *v1.Deployment {
 	dep.Spec.Template.Spec.ServiceAccountName = naming.Name(manifestutils.GatewayComponentName, tempo.Name)
 	return dep

--- a/internal/manifests/gateway/openshift_test.go
+++ b/internal/manifests/gateway/openshift_test.go
@@ -51,6 +51,64 @@ func TestPatchOPAContainer(t *testing.T) {
 	}, dep.Spec.Template.Spec.Containers[0].Args)
 }
 
+func TestPatchOCPTrustedCA(t *testing.T) {
+	tempo := v1alpha1.TempoStack{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "simplest",
+			Namespace: "observability",
+		},
+	}
+	dep := &appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Volumes: []corev1.Volume{
+						{
+							Name: "data",
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Args: []string{"--help"},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name: "data",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	expected := dep.DeepCopy()
+	expected.Spec.Template.Spec.Volumes = append(expected.Spec.Template.Spec.Volumes, corev1.Volume{
+		Name: "trusted-ca",
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: naming.Name("gateway-trusted-cabundle", tempo.Name),
+				},
+			},
+		},
+	})
+	expected.Spec.Template.Spec.Containers[0].VolumeMounts = append(expected.Spec.Template.Spec.Containers[0].VolumeMounts,
+		corev1.VolumeMount{
+			Name:      "trusted-ca",
+			ReadOnly:  true,
+			MountPath: "/etc/tempo-gateway/trusted-ca",
+		})
+	expected.Spec.Template.Spec.Containers[0].Env = append(expected.Spec.Template.Spec.Containers[0].Env,
+		corev1.EnvVar{
+			Name:  "SSL_CERT_FILE",
+			Value: "/etc/tempo-gateway/trusted-ca/ca-bundle.crt",
+		})
+
+	got, err := patchOCPTrustedCA(tempo, dep)
+	require.NoError(t, err)
+	assert.Equal(t, expected, got)
+}
+
 func TestPatchOCPServingCerts(t *testing.T) {
 	tempo := v1alpha1.TempoStack{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/manifests/manifestutils/tls.go
+++ b/internal/manifests/manifestutils/tls.go
@@ -119,6 +119,20 @@ func NewConfigMapCABundle(namespace string, name string, labels labels.Set) *cor
 	}
 }
 
+// NewConfigMapTrustedCABundle creates a new ConfigMap with an annotation that triggers the
+// cluster-network-operator to inject the cluster-wide trusted CA bundle in this ConfigMap (ca-bundle.crt key).
+// This includes the system trust store plus any custom CA certificates configured in the cluster's Proxy resource.
+func NewConfigMapTrustedCABundle(namespace string, name string, labels labels.Set) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			Labels:      labels,
+			Annotations: map[string]string{"config.openshift.io/inject-trusted-cabundle": "true"},
+		},
+	}
+}
+
 func findContainerIndex(pod *corev1.PodSpec, containerName string) (int, error) {
 	for i, container := range pod.Containers {
 		if container.Name == containerName {

--- a/internal/manifests/monolithic/gateway.go
+++ b/internal/manifests/monolithic/gateway.go
@@ -72,6 +72,12 @@ func BuildGatewayObjects(opts Options) ([]client.Object, map[string]string, erro
 			tempo.Namespace,
 			naming.DefaultServiceAccountName(tempo.Name),
 		))
+
+		manifests = append(manifests, manifestutils.NewConfigMapTrustedCABundle(
+			tempo.Namespace,
+			naming.Name("gateway-trusted-cabundle", tempo.Name),
+			ComponentLabels(manifestutils.GatewayComponentName, tempo.Name),
+		))
 	}
 
 	return manifests, extraAnnotations, nil

--- a/internal/manifests/monolithic/gateway_test.go
+++ b/internal/manifests/monolithic/gateway_test.go
@@ -46,7 +46,7 @@ func TestGateway(t *testing.T) {
 	}
 	objs, annotations, err := BuildGatewayObjects(opts)
 	require.NoError(t, err)
-	require.Len(t, objs, 4)
+	require.Len(t, objs, 5)
 
 	require.Contains(t, annotations, "tempo.grafana.com/rbacConfig.hash")
 	require.Contains(t, annotations, "tempo.grafana.com/tenantsConfig.hash")

--- a/internal/manifests/monolithic/statefulset.go
+++ b/internal/manifests/monolithic/statefulset.go
@@ -582,6 +582,21 @@ func configureGateway(opts Options, sts *appsv1.StatefulSet) error {
 			ptr.Deref(opts.Tempo.Spec.Multitenancy.Resources, corev1.ResourceRequirements{}),
 		)
 		sts.Spec.Template.Spec.Containers = append(sts.Spec.Template.Spec.Containers, opaContainer)
+
+		trustedCAMountPath := path.Join(gatewayMountDir, "trusted-ca")
+		err := manifestutils.MountCAConfigMap(&sts.Spec.Template.Spec, containerName, naming.Name("gateway-trusted-cabundle", tempo.Name), trustedCAMountPath)
+		if err != nil {
+			return err
+		}
+		for i := range sts.Spec.Template.Spec.Containers {
+			if sts.Spec.Template.Spec.Containers[i].Name == containerName {
+				sts.Spec.Template.Spec.Containers[i].Env = append(sts.Spec.Template.Spec.Containers[i].Env, corev1.EnvVar{
+					Name:  "SSL_CERT_FILE",
+					Value: path.Join(trustedCAMountPath, "ca-bundle.crt"),
+				})
+				break
+			}
+		}
 	}
 
 	if opts.CtrlConfig.Gates.OpenShift.ServingCertsService {

--- a/internal/manifests/monolithic/statefulset_test.go
+++ b/internal/manifests/monolithic/statefulset_test.go
@@ -793,7 +793,10 @@ func TestStatefulsetGateway(t *testing.T) {
 	require.Equal(t, corev1.Container{
 		Name:  "tempo-gateway",
 		Image: "quay.io/observatorium/api:x.y.z",
-		Env:   proxy.ReadProxyVarsFromEnv(),
+		Env: append(proxy.ReadProxyVarsFromEnv(), corev1.EnvVar{
+			Name:  "SSL_CERT_FILE",
+			Value: "/etc/tempo-gateway/trusted-ca/ca-bundle.crt",
+		}),
 		Args: []string{
 			"--web.listen=0.0.0.0:8080",
 			"--web.internal.listen=0.0.0.0:8081",
@@ -867,6 +870,11 @@ func TestStatefulsetGateway(t *testing.T) {
 				MountPath: "/etc/tempo-gateway/tenants",
 			},
 			{
+				Name:      "tempo-sample-gateway-trusted-cabundle",
+				ReadOnly:  true,
+				MountPath: "/etc/tempo-gateway/trusted-ca",
+			},
+			{
 				Name:      "tempo-sample-serving-cabundle",
 				ReadOnly:  true,
 				MountPath: "/etc/tempo-gateway/serving-ca",
@@ -917,6 +925,16 @@ func TestStatefulsetGateway(t *testing.T) {
 							Key:  "tenants.yaml",
 							Path: "tenants.yaml",
 						},
+					},
+				},
+			},
+		},
+		{
+			Name: "tempo-sample-gateway-trusted-cabundle",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "tempo-sample-gateway-trusted-cabundle",
 					},
 				},
 			},
@@ -1078,7 +1096,10 @@ func TestStatefulsetGatewayRBAC(t *testing.T) {
 	require.Equal(t, corev1.Container{
 		Name:  "tempo-gateway",
 		Image: "quay.io/observatorium/api:x.y.z",
-		Env:   proxy.ReadProxyVarsFromEnv(),
+		Env: append(proxy.ReadProxyVarsFromEnv(), corev1.EnvVar{
+			Name:  "SSL_CERT_FILE",
+			Value: "/etc/tempo-gateway/trusted-ca/ca-bundle.crt",
+		}),
 		Args: []string{
 			"--web.listen=0.0.0.0:8080",
 			"--web.internal.listen=0.0.0.0:8081",
@@ -1152,6 +1173,11 @@ func TestStatefulsetGatewayRBAC(t *testing.T) {
 				MountPath: "/etc/tempo-gateway/tenants",
 			},
 			{
+				Name:      "tempo-sample-gateway-trusted-cabundle",
+				ReadOnly:  true,
+				MountPath: "/etc/tempo-gateway/trusted-ca",
+			},
+			{
 				Name:      "tempo-sample-serving-cabundle",
 				ReadOnly:  true,
 				MountPath: "/etc/tempo-gateway/serving-ca",
@@ -1202,6 +1228,16 @@ func TestStatefulsetGatewayRBAC(t *testing.T) {
 							Key:  "tenants.yaml",
 							Path: "tenants.yaml",
 						},
+					},
+				},
+			},
+		},
+		{
+			Name: "tempo-sample-gateway-trusted-cabundle",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "tempo-sample-gateway-trusted-cabundle",
 					},
 				},
 			},

--- a/internal/manifests/mutate.go
+++ b/internal/manifests/mutate.go
@@ -184,6 +184,13 @@ func mutateConfigMap(existing, desired *corev1.ConfigMap) {
 		return
 	}
 
+	if _, ok := desired.Annotations["config.openshift.io/inject-trusted-cabundle"]; ok {
+		// The OpenShift cluster-network-operator will inject ca-bundle.crt into the ConfigMap.
+		// Skip mutating this ConfigMap, otherwise the ca-bundle.crt will be deleted by this operator
+		// and re-added by the cluster-network-operator in a loop.
+		return
+	}
+
 	existing.BinaryData = desired.BinaryData
 	existing.Data = desired.Data
 }

--- a/internal/manifests/mutate_test.go
+++ b/internal/manifests/mutate_test.go
@@ -112,6 +112,35 @@ func TestGetMutateFunc_MutateConfigMapServingCABundle(t *testing.T) {
 	require.Contains(t, existing.Data, "service-ca.crt")
 }
 
+func TestGetMutateFunc_MutateTrustedCABundle(t *testing.T) {
+	existing := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"config.openshift.io/inject-trusted-cabundle": "true",
+			},
+		},
+		Data: map[string]string{"ca-bundle.crt": "abc"},
+	}
+
+	desired := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"config.openshift.io/inject-trusted-cabundle": "true",
+			},
+		},
+		Data: map[string]string{},
+	}
+
+	f := manifests.MutateFuncFor(existing, desired)
+	err := f()
+	require.NoError(t, err)
+
+	// Ensure ca-bundle.crt did not get removed
+	require.Equal(t, existing.Labels, desired.Labels)
+	require.Equal(t, existing.Annotations, desired.Annotations)
+	require.Contains(t, existing.Data, "ca-bundle.crt")
+}
+
 func TestGetMutateFunc_MutateSecert(t *testing.T) {
 	got := &corev1.Secret{
 		Data: map[string][]byte{},


### PR DESCRIPTION
…ter OAuth support

On HostedClusters (e.g. ROSA), the OAuth server's TLS certificate may be signed by a CA not present in the gateway pod's default trust store, causing "x509: certificate signed by unknown authority" during the OAuth callback.

This injects the cluster-wide trusted CA bundle (config.openshift.io/ inject-trusted-cabundle) into the gateway container and sets SSL_CERT_FILE so Go's TLS client uses it. Applied to both TempoStack and TempoMonolithic.


Fixes https://github.com/grafana/tempo-operator/issues/1414