### PR TITLE
Fix OTLP HTTP receiver to use internal mTLS when gateway and HTTPEncryption are enabled 

### DIFF
--- a/.chloggen/fix_monolithic_otlp_http_receiver_tls.yaml
+++ b/.chloggen/fix_monolithic_otlp_http_receiver_tls.yaml
@@ -1,0 +1,23 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. tempostack, tempomonolithic, github action)
+component: tempomonolithic
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix OTLP HTTP receiver to use internal mTLS when gateway and HTTPEncryption are enabled
+
+# One or more tracking issues related to the change
+issues: [1415]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  When gateway and HTTPEncryption were both enabled, the OTLP HTTP receiver was not
+  configured with the internal mTLS certificate (unlike the gRPC receiver), and the
+  gateway always forwarded OTLP HTTP traffic over plain HTTP. This caused TLS
+  verification failures and all OTLP HTTP trace ingestion to be silently dropped.
+  The HTTP receiver and gateway OTLP HTTP upstream now match the gRPC behavior:
+  internal mTLS is used for the receiver and the gateway connects over HTTPS
+  whenever HTTPEncryption is enabled.

--- a/internal/manifests/monolithic/configmap.go
+++ b/internal/manifests/monolithic/configmap.go
@@ -326,7 +326,30 @@ func buildTempoConfig(opts Options) ([]byte, error) {
 				}
 			}
 
-			if tempo.Spec.Ingestion.OTLP.HTTP != nil && tempo.Spec.Ingestion.OTLP.HTTP.Enabled {
+			// When gateway and HTTPEncryption are enabled, use the internal mTLS cert for the HTTP receiver,
+			// matching the gRPC receiver behavior above.
+			if tempo.Spec.Multitenancy.IsGatewayEnabled() && opts.CtrlConfig.Gates.HTTPEncryption {
+				minVersion := opts.TLSProfile.MinVersionOTELFormat()
+				ciphers := opts.TLSProfile.Ciphers
+				if tempo.Spec.Ingestion.OTLP.HTTP != nil && tempo.Spec.Ingestion.OTLP.HTTP.TLS != nil {
+					if tempo.Spec.Ingestion.OTLP.HTTP.TLS.MinVersion != "" {
+						minVersion = tempo.Spec.Ingestion.OTLP.HTTP.TLS.MinVersion
+					}
+					if tempo.Spec.Ingestion.OTLP.HTTP.TLS.CipherSuites != nil {
+						ciphers = tempo.Spec.Ingestion.OTLP.HTTP.TLS.CipherSuites
+					}
+				}
+				config.Distributor.Receivers.OTLP.Protocols.HTTP = &tempoReceiverConfig{
+					TLS: tempoReceiverTLSConfig{
+						CertFile:     path.Join(manifestutils.TempoInternalTLSCertDir, manifestutils.TLSCertFilename),
+						CAFile:       path.Join(manifestutils.TempoInternalTLSCADir, manifestutils.TLSCAFilename),
+						KeyFile:      path.Join(manifestutils.TempoInternalTLSCertDir, manifestutils.TLSKeyFilename),
+						MinVersion:   minVersion,
+						CipherSuites: ciphers,
+					},
+					Endpoint: fmt.Sprintf("localhost:%d", manifestutils.PortOtlpHttp),
+				}
+			} else if tempo.Spec.Ingestion.OTLP.HTTP != nil && tempo.Spec.Ingestion.OTLP.HTTP.Enabled {
 				receiverTLS := configureReceiverTLS(tempo.Spec.Ingestion.OTLP.HTTP.TLS,
 					opts.TLSProfile, manifestutils.ReceiverHTTPTLSCADir, manifestutils.ReceiverHTTPTLSCertDir)
 

--- a/internal/manifests/monolithic/configmap_test.go
+++ b/internal/manifests/monolithic/configmap_test.go
@@ -541,6 +541,86 @@ usage_report:
   reporting_enabled: false
 `,
 		},
+		{
+			name: "gateway with HTTPEncryption and OTLP/HTTP receiver TLS",
+			spec: v1alpha1.TempoMonolithicSpec{
+				Ingestion: &v1alpha1.MonolithicIngestionSpec{
+					OTLP: &v1alpha1.MonolithicIngestionOTLPSpec{
+						GRPC: &v1alpha1.MonolithicIngestionOTLPProtocolsGRPCSpec{
+							Enabled: true,
+						},
+						HTTP: &v1alpha1.MonolithicIngestionOTLPProtocolsHTTPSpec{
+							Enabled: true,
+							TLS: &v1alpha1.TLSSpec{
+								Enabled:    true,
+								MinVersion: "1.3",
+							},
+						},
+					},
+				},
+				Multitenancy: &v1alpha1.MonolithicMultitenancySpec{
+					Enabled: true,
+					TenantsSpec: v1alpha1.TenantsSpec{
+						Mode: v1alpha1.ModeOpenShift,
+						Authentication: []v1alpha1.AuthenticationSpec{
+							{
+								TenantName: "dev",
+								TenantID:   "abc",
+							},
+						},
+					},
+				},
+			},
+			opts: Options{
+				CtrlConfig: configv1alpha1.ProjectConfig{
+					Gates: configv1alpha1.FeatureGates{
+						HTTPEncryption: true,
+					},
+				},
+			},
+			expected: `
+server:
+  http_listen_port: 3200
+  http_listen_address: 0.0.0.0
+  grpc_listen_address: localhost
+  http_server_read_timeout: 30s
+  http_server_write_timeout: 30s
+  http_tls_config:
+    cert_file: /var/run/tls/server/tls.crt
+    key_file: /var/run/tls/server/tls.key
+    client_auth_type: RequireAndVerifyClientCert
+    client_ca_file: /var/run/ca/service-ca.crt
+internal_server:
+  enable: true
+  http_listen_address: 0.0.0.0
+multitenancy_enabled: true
+storage:
+  trace:
+    backend: local
+    wal:
+      path: /var/tempo/wal
+    local:
+      path: /var/tempo/blocks
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        http:
+          endpoint: localhost:4318
+          tls:
+            cert_file: /var/run/tls/server/tls.crt
+            client_ca_file: /var/run/ca/service-ca.crt
+            key_file: /var/run/tls/server/tls.key
+            min_version: "1.3"
+        grpc:
+          tls:
+            cert_file: /var/run/tls/server/tls.crt
+            client_ca_file: /var/run/ca/service-ca.crt
+            key_file: /var/run/tls/server/tls.key
+usage_report:
+  reporting_enabled: false
+`,
+		},
 	}
 
 	for _, test := range tests {

--- a/internal/manifests/monolithic/statefulset.go
+++ b/internal/manifests/monolithic/statefulset.go
@@ -476,7 +476,8 @@ func configureGateway(opts Options, sts *appsv1.StatefulSet) error {
 		args = append(args, fmt.Sprintf("--grpc.listen=0.0.0.0:%d", manifestutils.GatewayPortGRPCServer))                   // proxies Tempo Distributor gRPC
 		args = append(args, fmt.Sprintf("--traces.write.otlpgrpc.endpoint=localhost:%d", manifestutils.PortOtlpGrpcServer)) // Tempo Distributor gRPC upstream
 		otlpHTTPScheme := "http"
-		if tempo.Spec.Ingestion.OTLP.HTTP != nil && tempo.Spec.Ingestion.OTLP.HTTP.TLS != nil && tempo.Spec.Ingestion.OTLP.HTTP.TLS.Enabled {
+		if opts.CtrlConfig.Gates.HTTPEncryption ||
+			(tempo.Spec.Ingestion.OTLP.HTTP != nil && tempo.Spec.Ingestion.OTLP.HTTP.TLS != nil && tempo.Spec.Ingestion.OTLP.HTTP.TLS.Enabled) {
 			otlpHTTPScheme = "https"
 		}
 		args = append(args, fmt.Sprintf("--traces.write.otlphttp.endpoint=%s://localhost:%d", otlpHTTPScheme, manifestutils.PortOtlpHttp)) // Tempo Distributor HTTP upstream

--- a/tests/e2e-openshift-tls-profile/tls-profile-override-mono/02-assert.yaml
+++ b/tests/e2e-openshift-tls-profile/tls-profile-override-mono/02-assert.yaml
@@ -18,4 +18,26 @@ metadata:
   name: tempo-mono-0
   namespace: chainsaw-tls-profile-mono
 status:
+  containerStatuses:
+  - name: jaeger-query
+    ready: true
+    started: true
+  - name: tempo
+    ready: true
+    started: true
+  - name: tempo-gateway
+    ready: true
+    started: true
+  - name: tempo-gateway-opa
+    ready: true
+    started: true
+  - name: tempo-query
+    ready: true
+    started: true
   phase: Running
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tempo-mono-gateway
+  namespace: chainsaw-tls-profile-mono

--- a/tests/e2e-openshift-tls-profile/tls-profile-override-mono/02-install-tempo.yaml
+++ b/tests/e2e-openshift-tls-profile/tls-profile-override-mono/02-install-tempo.yaml
@@ -52,8 +52,12 @@ spec:
           caName: custom-ca
   jaegerui:
     enabled: true
-    route:
-      enabled: true
+  multitenancy:
+    enabled: true
+    mode: openshift
+    authentication:
+    - tenantName: dev
+      tenantId: "1610b0c3-c509-4592-a256-a1871353dbfa"
   ingestion:
     otlp:
       grpc:
@@ -62,3 +66,65 @@ spec:
       http:
         tls:
           enabled: true
+---
+# Grant the dev-collector Service Account permission to write traces to the 'dev' tenant
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: allow-write-traces-dev-tenant-tls-profile-mono
+rules:
+- apiGroups: [tempo.grafana.com]
+  resources: [dev]
+  resourceNames: [traces]
+  verbs: [create]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: allow-write-traces-dev-tenant-tls-profile-mono
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: allow-write-traces-dev-tenant-tls-profile-mono
+subjects:
+- kind: ServiceAccount
+  name: dev-collector
+  namespace: chainsaw-tls-profile-mono
+---
+# Grant the default Service Account permission to read traces of the 'dev' tenant
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: allow-read-traces-dev-tenant-tls-profile-mono
+rules:
+- apiGroups: [tempo.grafana.com]
+  resources: [dev]
+  resourceNames: [traces]
+  verbs: [get]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: allow-read-traces-dev-tenant-tls-profile-mono
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: allow-read-traces-dev-tenant-tls-profile-mono
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: chainsaw-tls-profile-mono
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: view
+  namespace: chainsaw-tls-profile-mono
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: chainsaw-tls-profile-mono

--- a/tests/e2e-openshift-tls-profile/tls-profile-override-mono/04-verify-monolithic.sh
+++ b/tests/e2e-openshift-tls-profile/tls-profile-override-mono/04-verify-monolithic.sh
@@ -56,7 +56,7 @@ CONFIG=$(kubectl get configmap tempo-mono-config -n $NAMESPACE -o jsonpath='{.da
 echo "$CONFIG"
 
 # Verify both gRPC and HTTP receivers use Modern profile (min_version "1.3") from subscription TLS_PROFILE
-COUNT_13=$(echo "$CONFIG" | grep -c 'min_version: "1.3"')
+COUNT_13=$(echo "$CONFIG" | grep -c 'min_version: "1.3"' || true)
 if [[ "$COUNT_13" -ne 2 ]]; then
   fail "expected 2 occurrences of min_version 1.3 (gRPC + HTTP receivers from subscription TLS_PROFILE=Modern), found $COUNT_13"
 fi
@@ -75,30 +75,44 @@ if echo "$CONFIG" | grep -q 'tls_min_version: VersionTLS12'; then
 fi
 echo "ConfigMap: storage TLS minVersion=VersionTLS13 (from subscription TLS_PROFILE=Modern) - OK"
 
-# --- 2. Functional TLS checks (tls-scanner -host <service> -port <port>) ---
+# --- 2. Gateway args verification ---
+# Gateway uses Modern profile from subscription TLS_PROFILE=Modern.
+MONO_GW_ARGS=$(kubectl get statefulset tempo-mono -n $NAMESPACE -o jsonpath='{.spec.template.spec.containers[?(@.name=="tempo-gateway")].args}')
+echo "$MONO_GW_ARGS" | grep -- '--tls.min-version=VersionTLS13' || fail "gateway --tls.min-version should be VersionTLS13 (from subscription TLS_PROFILE=Modern)"
+echo "PASS: gateway --tls.min-version=VersionTLS13"
+echo "$MONO_GW_ARGS" | grep -- '--tls.cipher-suites=' || fail "gateway --tls.cipher-suites missing"
+echo "PASS: gateway --tls.cipher-suites present"
+echo "Gateway args: Modern profile from subscription TLS_PROFILE=Modern - OK"
+
+# --- 3. Functional TLS checks (tls-scanner -host <service> -port <port>) ---
 echo "=== Functional TLS checks ==="
-kubectl exec tls-scanner -n $NAMESPACE -- tls-scanner -host tempo-mono -port 4317 \
-  || fail "TLS check failed on monolithic gRPC:4317"
-echo "PASS: monolithic gRPC:4317 TLS functional"
+kubectl exec tls-scanner -n $NAMESPACE -- tls-scanner -host tempo-mono-gateway -port 8080 \
+  || fail "TLS check failed on gateway HTTP:8080"
+echo "PASS: gateway HTTP:8080 TLS functional"
 
-kubectl exec tls-scanner -n $NAMESPACE -- tls-scanner -host tempo-mono -port 4318 \
-  || fail "TLS check failed on monolithic HTTP:4318"
-echo "PASS: monolithic HTTP:4318 TLS functional"
+kubectl exec tls-scanner -n $NAMESPACE -- tls-scanner -host tempo-mono-gateway -port 8090 \
+  || fail "TLS check failed on gateway gRPC:8090"
+echo "PASS: gateway gRPC:8090 TLS functional"
 
-# --- 3. Comprehensive scan + profile verification ---
-echo "=== Scanning all Tempo pods in $NAMESPACE ==="
-SCAN_OUTPUT=$(kubectl exec tls-scanner -n $NAMESPACE -- tls-scanner \
-  -all-pods \
-  -namespace-filter $NAMESPACE \
-  -json-file /tmp/monolithic-scan.json 2>&1) || true
-echo "$SCAN_OUTPUT"
+# --- 4. Gateway TLS profile verification via direct nmap ---
+# Note: tls-scanner -all-pods uses nmap -sV which can misdetect gateway HTTP port 8080
+# as "tcpwrapped". Using nmap without -sV for gateway ports gives reliable TLS detection.
+MONO_GW_IP=$(kubectl get pod -n $NAMESPACE tempo-mono-0 -o jsonpath='{.status.podIP}')
 
-kubectl cp $NAMESPACE/tls-scanner:/tmp/monolithic-scan.json /tmp/monolithic-scan.json 2>/dev/null || true
+echo "=== nmap ssl-enum-ciphers: Monolithic Gateway ($MONO_GW_IP ports 8080,8090) ==="
+NMAP_RESULT=$(kubectl exec tls-scanner -n $NAMESPACE -- nmap -Pn --script ssl-enum-ciphers -p 8080,8090 "$MONO_GW_IP")
+echo "$NMAP_RESULT"
 
-# Verify port 4317 (gRPC): Modern profile (TLSv1.3 only) from subscription TLS_PROFILE=Modern
-verify_tls_profile "$SCAN_OUTPUT" 4317 modern "Monolithic gRPC (subscription TLS_PROFILE=Modern)"
+for port in 8080 8090; do
+  PORT_SECTION=$(echo "$NMAP_RESULT" | grep -A 50 "${port}/tcp" || true)
+  if [ -z "$PORT_SECTION" ]; then
+    fail "Monolithic gateway: port $port not found in nmap output"
+  fi
+  echo "$PORT_SECTION" | grep "TLSv1.3" || fail "Monolithic gateway: port $port missing TLSv1.3 under Modern profile"
+  if echo "$PORT_SECTION" | head -30 | grep -q "TLSv1.2"; then
+    fail "Monolithic gateway: port $port still accepting TLSv1.2 under Modern profile"
+  fi
+  echo "PASS: Monolithic gateway port $port = Modern (TLSv1.3 only)"
+done
 
-# Verify port 4318 (HTTP): Modern profile (TLSv1.3 only) from subscription TLS_PROFILE=Modern
-verify_tls_profile "$SCAN_OUTPUT" 4318 modern "Monolithic HTTP (subscription TLS_PROFILE=Modern)"
-
-echo "PASS: All TLS profile settings verified from subscription TLS_PROFILE=Modern - gRPC=Modern, HTTP=Modern, storage=VersionTLS13"
+echo "PASS: All TLS profile settings verified from subscription TLS_PROFILE=Modern - gateway HTTP=Modern, gateway gRPC=Modern, storage=VersionTLS13"

--- a/tests/e2e-openshift-tls-profile/tls-profile-override-mono/05-install-otelcol.yaml
+++ b/tests/e2e-openshift-tls-profile/tls-profile-override-mono/05-install-otelcol.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: chainsaw-tls-profile-mono
 spec:
   config: |
+    extensions:
+      bearertokenauth:
+        filename: /var/run/secrets/kubernetes.io/serviceaccount/token
+
     receivers:
       otlp/grpc:
         protocols:
@@ -12,23 +16,32 @@ spec:
       otlp/http:
         protocols:
           http:
+
     exporters:
       otlp:
-        endpoint: tempo-mono.chainsaw-tls-profile-mono.svc.cluster.local:4317
+        endpoint: tempo-mono-gateway.chainsaw-tls-profile-mono.svc.cluster.local:4317
         tls:
-          insecure: false
-          ca_file: "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+        auth:
+          authenticator: bearertokenauth
+        headers:
+          X-Scope-OrgID: dev
       otlphttp:
-        endpoint: https://tempo-mono.chainsaw-tls-profile-mono.svc.cluster.local:4318
+        endpoint: https://tempo-mono-gateway.chainsaw-tls-profile-mono.svc.cluster.local:8080/api/traces/v1/dev
         tls:
-          insecure: false
-          ca_file: "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+        auth:
+          authenticator: bearertokenauth
+        headers:
+          X-Scope-OrgID: dev
+
     service:
       telemetry:
         logs:
           level: "DEBUG"
           development: true
           encoding: "json"
+      extensions: [bearertokenauth]
       pipelines:
         traces/grpc:
           receivers: [otlp/grpc]

--- a/tests/e2e-openshift-tls-profile/tls-profile-override-mono/07-assert.yaml
+++ b/tests/e2e-openshift-tls-profile/tls-profile-override-mono/07-assert.yaml
@@ -9,7 +9,23 @@ status:
 apiVersion: batch/v1
 kind: Job
 metadata:
+  name: verify-traces-traceql-grpc
+  namespace: chainsaw-tls-profile-mono
+status:
+  succeeded: 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
   name: verify-traces-http
+  namespace: chainsaw-tls-profile-mono
+status:
+  succeeded: 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify-traces-traceql-http
   namespace: chainsaw-tls-profile-mono
 status:
   succeeded: 1

--- a/tests/e2e-openshift-tls-profile/tls-profile-override-mono/07-verify-traces.yaml
+++ b/tests/e2e-openshift-tls-profile/tls-profile-override-mono/07-verify-traces.yaml
@@ -9,18 +9,49 @@ spec:
       containers:
       - name: verify-traces
         image: ghcr.io/grafana/tempo-operator/test-utils:main
-        command:
-        - /bin/bash
-        - -eux
-        - -c
+        command: ["/bin/bash", "-eux", "-c"]
         args:
         - |
-          curl -v -G http://tempo-mono-jaegerui:16686/api/traces --data-urlencode "service=grpc" | tee /tmp/jaeger.out
+          curl -v -G \
+            --header "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
+            --cacert /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt \
+            https://tempo-mono-gateway.chainsaw-tls-profile-mono.svc:8080/api/traces/v1/dev/api/traces \
+            --data-urlencode "service=grpc" \
+            | tee /tmp/jaeger.out
+
           num_traces=$(jq ".data | length" /tmp/jaeger.out)
-          if [[ "$num_traces" -ne 10 ]]; then
+          if [[ "$num_traces" != "10" ]]; then
             echo && echo "The Jaeger API returned $num_traces instead of 10 traces."
             exit 1
           fi
+      restartPolicy: Never
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify-traces-traceql-grpc
+  namespace: chainsaw-tls-profile-mono
+spec:
+  template:
+    spec:
+      containers:
+        - name: verify-traces
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
+          command: ["/bin/bash", "-eux", "-c"]
+          args:
+            - |
+              curl -sS -G \
+                --header "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
+                --cacert /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt \
+                --data-urlencode 'q={ resource.service.name="grpc" }' \
+                https://tempo-mono-gateway.chainsaw-tls-profile-mono.svc:8080/api/traces/v1/dev/tempo/api/search \
+                | tee /tmp/tempo.out
+
+              num_traces=$(jq ".traces | length" /tmp/tempo.out)
+              if [[ "$num_traces" != "10" ]]; then
+                echo && echo "The Tempo API returned $num_traces instead of 10 traces."
+                exit 1
+              fi
       restartPolicy: Never
 ---
 apiVersion: batch/v1
@@ -34,16 +65,47 @@ spec:
       containers:
         - name: verify-traces
           image: ghcr.io/grafana/tempo-operator/test-utils:main
-          command:
-            - /bin/bash
-            - -eux
-            - -c
+          command: ["/bin/bash", "-eux", "-c"]
           args:
           - |
-            curl -v -G http://tempo-mono-jaegerui:16686/api/traces --data-urlencode "service=http" | tee /tmp/jaeger.out
+            curl -v -G \
+              --header "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
+              --cacert /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt \
+              https://tempo-mono-gateway.chainsaw-tls-profile-mono.svc:8080/api/traces/v1/dev/api/traces \
+              --data-urlencode "service=http" \
+              | tee /tmp/jaeger.out
+
             num_traces=$(jq ".data | length" /tmp/jaeger.out)
-            if [[ "$num_traces" -ne 10 ]]; then
+            if [[ "$num_traces" != "10" ]]; then
               echo && echo "The Jaeger API returned $num_traces instead of 10 traces."
               exit 1
             fi
+      restartPolicy: Never
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify-traces-traceql-http
+  namespace: chainsaw-tls-profile-mono
+spec:
+  template:
+    spec:
+      containers:
+        - name: verify-traces
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
+          command: ["/bin/bash", "-eux", "-c"]
+          args:
+            - |
+              curl -sS -G \
+                --header "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
+                --cacert /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt \
+                --data-urlencode 'q={ resource.service.name="http" }' \
+                https://tempo-mono-gateway.chainsaw-tls-profile-mono.svc:8080/api/traces/v1/dev/tempo/api/search \
+                | tee /tmp/tempo.out
+
+              num_traces=$(jq ".traces | length" /tmp/tempo.out)
+              if [[ "$num_traces" != "10" ]]; then
+                echo && echo "The Tempo API returned $num_traces instead of 10 traces."
+                exit 1
+              fi
       restartPolicy: Never

--- a/tests/e2e-openshift-tls-profile/tls-profile-override-mono/09-assert.yaml
+++ b/tests/e2e-openshift-tls-profile/tls-profile-override-mono/09-assert.yaml
@@ -18,4 +18,20 @@ metadata:
   name: tempo-mono-0
   namespace: chainsaw-tls-profile-mono
 status:
+  containerStatuses:
+  - name: jaeger-query
+    ready: true
+    started: true
+  - name: tempo
+    ready: true
+    started: true
+  - name: tempo-gateway
+    ready: true
+    started: true
+  - name: tempo-gateway-opa
+    ready: true
+    started: true
+  - name: tempo-query
+    ready: true
+    started: true
   phase: Running

--- a/tests/e2e-openshift-tls-profile/tls-profile-override-mono/09-update-tempo-cr-override.yaml
+++ b/tests/e2e-openshift-tls-profile/tls-profile-override-mono/09-update-tempo-cr-override.yaml
@@ -16,8 +16,12 @@ spec:
           minVersion: "1.3"
   jaegerui:
     enabled: true
-    route:
-      enabled: true
+  multitenancy:
+    enabled: true
+    mode: openshift
+    authentication:
+    - tenantName: dev
+      tenantId: "1610b0c3-c509-4592-a256-a1871353dbfa"
   ingestion:
     otlp:
       grpc:

--- a/tests/e2e-openshift-tls-profile/tls-profile-override-mono/10-verify-cr-override.sh
+++ b/tests/e2e-openshift-tls-profile/tls-profile-override-mono/10-verify-cr-override.sh
@@ -16,7 +16,7 @@ CONFIG=$(kubectl get configmap tempo-mono-config -n $NAMESPACE -o jsonpath='{.da
 echo "$CONFIG"
 
 # Verify both gRPC and HTTP receivers use per-CR override (min_version "1.3")
-COUNT_13=$(echo "$CONFIG" | grep -c 'min_version: "1.3"')
+COUNT_13=$(echo "$CONFIG" | grep -c 'min_version: "1.3"' || true)
 if [[ "$COUNT_13" -ne 2 ]]; then
   fail "expected 2 occurrences of min_version 1.3 (gRPC + HTTP receivers from per-CR minVersion override), found $COUNT_13"
 fi
@@ -37,12 +37,12 @@ echo "ConfigMap: storage TLS minVersion=VersionTLS13 (from per-CR minVersion ove
 
 # --- 2. Functional TLS checks ---
 echo "=== Functional TLS checks ==="
-kubectl exec tls-scanner -n $NAMESPACE -- tls-scanner -host tempo-mono -port 4317 \
-  || fail "TLS check failed on monolithic gRPC:4317"
-echo "PASS: monolithic gRPC:4317 TLS functional"
+kubectl exec tls-scanner -n $NAMESPACE -- tls-scanner -host tempo-mono-gateway -port 8080 \
+  || fail "TLS check failed on gateway HTTP:8080"
+echo "PASS: gateway HTTP:8080 TLS functional"
 
-kubectl exec tls-scanner -n $NAMESPACE -- tls-scanner -host tempo-mono -port 4318 \
-  || fail "TLS check failed on monolithic HTTP:4318"
-echo "PASS: monolithic HTTP:4318 TLS functional"
+kubectl exec tls-scanner -n $NAMESPACE -- tls-scanner -host tempo-mono-gateway -port 8090 \
+  || fail "TLS check failed on gateway gRPC:8090"
+echo "PASS: gateway gRPC:8090 TLS functional"
 
-echo "PASS: All per-CR TLS overrides verified - gRPC=Modern, HTTP=Modern, storage=VersionTLS13"
+echo "PASS: All per-CR TLS overrides verified - gateway HTTP=Modern, gateway gRPC=Modern, storage=VersionTLS13"

--- a/tests/e2e-openshift-tls-profile/tls-profile-override-mono/11-assert.yaml
+++ b/tests/e2e-openshift-tls-profile/tls-profile-override-mono/11-assert.yaml
@@ -5,3 +5,11 @@ metadata:
   namespace: chainsaw-tls-profile-mono
 status:
   succeeded: 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: generate-traces-http-override
+  namespace: chainsaw-tls-profile-mono
+status:
+  succeeded: 1

--- a/tests/e2e-openshift-tls-profile/tls-profile-override-mono/11-generate-traces-cr-override.yaml
+++ b/tests/e2e-openshift-tls-profile/tls-profile-override-mono/11-generate-traces-cr-override.yaml
@@ -16,3 +16,23 @@ spec:
         - --otlp-insecure
         - --traces=10
       restartPolicy: Never
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: generate-traces-http-override
+  namespace: chainsaw-tls-profile-mono
+spec:
+  template:
+    spec:
+      containers:
+        - name: telemetrygen
+          image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
+          args:
+            - traces
+            - --otlp-endpoint=dev-collector:4318
+            - --otlp-http
+            - --otlp-insecure
+            - --service=http-override
+            - --traces=10
+      restartPolicy: Never

--- a/tests/e2e-openshift-tls-profile/tls-profile-override-mono/12-assert.yaml
+++ b/tests/e2e-openshift-tls-profile/tls-profile-override-mono/12-assert.yaml
@@ -5,3 +5,27 @@ metadata:
   namespace: chainsaw-tls-profile-mono
 status:
   succeeded: 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify-traces-http-override
+  namespace: chainsaw-tls-profile-mono
+status:
+  succeeded: 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify-traces-traceql-grpc-override
+  namespace: chainsaw-tls-profile-mono
+status:
+  succeeded: 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify-traces-traceql-http-override
+  namespace: chainsaw-tls-profile-mono
+status:
+  succeeded: 1

--- a/tests/e2e-openshift-tls-profile/tls-profile-override-mono/12-verify-traces-cr-override.yaml
+++ b/tests/e2e-openshift-tls-profile/tls-profile-override-mono/12-verify-traces-cr-override.yaml
@@ -9,16 +9,111 @@ spec:
       containers:
       - name: verify-traces
         image: ghcr.io/grafana/tempo-operator/test-utils:main
-        command:
-        - /bin/bash
-        - -eux
-        - -c
+        command: ["/bin/bash", "-eux", "-c"]
         args:
         - |
-          curl -v -G http://tempo-mono-jaegerui:16686/api/traces --data-urlencode "service=grpc-override" | tee /tmp/jaeger.out
+          curl -v -G \
+            --header "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
+            --cacert /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt \
+            https://tempo-mono-gateway.chainsaw-tls-profile-mono.svc:8080/api/traces/v1/dev/api/traces \
+            --data-urlencode "service=grpc-override" \
+            | tee /tmp/jaeger.out
+
           num_traces=$(jq ".data | length" /tmp/jaeger.out)
-          if [[ "$num_traces" -ne 10 ]]; then
+          if [[ "$num_traces" != "10" ]]; then
             echo && echo "The Jaeger API returned $num_traces instead of 10 traces."
             exit 1
           fi
+      restartPolicy: Never
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify-traces-http-override
+  namespace: chainsaw-tls-profile-mono
+spec:
+  template:
+    spec:
+      containers:
+        - name: verify-traces
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
+          command: ["/bin/bash", "-eux", "-c"]
+          args:
+            - |
+              curl -v -G \
+                --header "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
+                --cacert /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt \
+                https://tempo-mono-gateway.chainsaw-tls-profile-mono.svc:8080/api/traces/v1/dev/api/traces \
+                --data-urlencode "service=http-override" \
+                | tee /tmp/jaeger.out
+
+              num_traces=$(jq ".data | length" /tmp/jaeger.out)
+              if [[ "$num_traces" != "10" ]]; then
+                echo && echo "The Jaeger API returned $num_traces instead of 10 traces."
+                exit 1
+              fi
+      restartPolicy: Never
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify-traces-traceql-grpc-override
+  namespace: chainsaw-tls-profile-mono
+spec:
+  template:
+    spec:
+      containers:
+        - name: verify-traces
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
+          command:
+            - /bin/bash
+            - -eux
+            - -c
+          args:
+            - |
+              token=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+              curl \
+                -v -G \
+                --header "Authorization: Bearer $token" \
+                --cacert /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt \
+                https://tempo-mono-gateway.chainsaw-tls-profile-mono.svc:8080/api/traces/v1/dev/tempo/api/search \
+                --data-urlencode 'q={ resource.service.name="grpc-override" }' \
+                | tee /tmp/jaeger.out
+              num_traces=$(jq ".traces | length" /tmp/jaeger.out)
+              if [[ "$num_traces" != "10" ]]; then
+                echo && echo "The Jaeger API returned $num_traces instead of 10 traces."
+                exit 1
+              fi
+      restartPolicy: Never
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify-traces-traceql-http-override
+  namespace: chainsaw-tls-profile-mono
+spec:
+  template:
+    spec:
+      containers:
+        - name: verify-traces
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
+          command:
+            - /bin/bash
+            - -eux
+            - -c
+          args:
+            - |
+              token=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+              curl \
+                -v -G \
+                --header "Authorization: Bearer $token" \
+                --cacert /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt \
+                https://tempo-mono-gateway.chainsaw-tls-profile-mono.svc:8080/api/traces/v1/dev/tempo/api/search \
+                --data-urlencode 'q={ resource.service.name="http-override" }' \
+                | tee /tmp/jaeger.out
+              num_traces=$(jq ".traces | length" /tmp/jaeger.out)
+              if [[ "$num_traces" != "10" ]]; then
+                echo && echo "The Jaeger API returned $num_traces instead of 10 traces."
+                exit 1
+              fi
       restartPolicy: Never

--- a/tests/e2e-openshift-tls-profile/tls-profile-override-stack/04-verify-override.sh
+++ b/tests/e2e-openshift-tls-profile/tls-profile-override-stack/04-verify-override.sh
@@ -103,9 +103,12 @@ fi
 echo "ConfigMap: storage TLS minVersion=VersionTLS13 (from subscription TLS_PROFILE=Modern) - OK"
 
 # Verify distributor receivers use Modern profile (min_version "1.3") from subscription TLS_PROFILE=Modern.
-# With gateway enabled, traces flow through the gateway, not the distributor receiver ports.
-echo "$CONFIG" | grep 'min_version: "1.3"' || fail "distributor receiver min_version should be 1.3 (from subscription TLS_PROFILE=Modern)"
-echo "ConfigMap: distributor receiver TLS minVersion=1.3 (from subscription TLS_PROFILE=Modern) - OK"
+# With HTTPEncryption, both gRPC and HTTP receivers get min_version from the TLS profile.
+COUNT_13=$(echo "$CONFIG" | grep -c 'min_version: "1.3"' || true)
+if [[ "$COUNT_13" -ne 2 ]]; then
+  fail "expected 2 occurrences of min_version 1.3 (gRPC + HTTP receivers from subscription TLS_PROFILE=Modern), found $COUNT_13"
+fi
+echo "ConfigMap: gRPC receiver=1.3, HTTP receiver=1.3 (from subscription TLS_PROFILE=Modern) - OK"
 
 # --- 2. Gateway args verification ---
 # Gateway uses Modern profile from subscription TLS_PROFILE=Modern.

--- a/tests/e2e-openshift-tls-profile/tls-profile-override-stack/09-update-tempo-cr-override.yaml
+++ b/tests/e2e-openshift-tls-profile/tls-profile-override-stack/09-update-tempo-cr-override.yaml
@@ -11,7 +11,7 @@ spec:
     tls:
       enabled: true
       caName: custom-ca
-      minVersion: "1.3"
+      minVersion: "VersionTLS13"
   storageSize: 1Gi
   resources:
     total:

--- a/tests/e2e-openshift-tls-profile/tls-profile/01-assert.yaml
+++ b/tests/e2e-openshift-tls-profile/tls-profile/01-assert.yaml
@@ -51,3 +51,41 @@ metadata:
   namespace: chainsaw-tls-profile-gw
 status:
   readyReplicas: 1
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: tempo-mono
+  namespace: chainsaw-tls-profile-gw
+status:
+  readyReplicas: 1
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: tempo-mono-0
+  namespace: chainsaw-tls-profile-gw
+status:
+  containerStatuses:
+  - name: jaeger-query
+    ready: true
+    started: true
+  - name: tempo
+    ready: true
+    started: true
+  - name: tempo-gateway
+    ready: true
+    started: true
+  - name: tempo-gateway-opa
+    ready: true
+    started: true
+  - name: tempo-query
+    ready: true
+    started: true
+  phase: Running
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tempo-mono-gateway
+  namespace: chainsaw-tls-profile-gw

--- a/tests/e2e-openshift-tls-profile/tls-profile/01-install-tempo.yaml
+++ b/tests/e2e-openshift-tls-profile/tls-profile/01-install-tempo.yaml
@@ -111,3 +111,83 @@ subjects:
 - kind: ServiceAccount
   name: default
   namespace: chainsaw-tls-profile-gw
+---
+apiVersion: tempo.grafana.com/v1alpha1
+kind: TempoMonolithic
+metadata:
+  name: mono
+  namespace: chainsaw-tls-profile-gw
+spec:
+  storage:
+    traces:
+      backend: s3
+      size: 1Gi
+      s3:
+        secret: minio
+        tls:
+          enabled: true
+          caName: custom-ca
+  jaegerui:
+    enabled: true
+  multitenancy:
+    enabled: true
+    mode: openshift
+    authentication:
+    - tenantName: dev
+      tenantId: "1610b0c3-c509-4592-a256-a1871353dbfa"
+  ingestion:
+    otlp:
+      grpc:
+        tls:
+          enabled: true
+      http:
+        tls:
+          enabled: true
+---
+# Grant the dev-mono-collector Service Account permission to write traces to the 'dev' tenant (monolithic)
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: allow-write-traces-dev-tenant-tls-profile-gw-mono
+rules:
+- apiGroups: [tempo.grafana.com]
+  resources: [dev]
+  resourceNames: [traces]
+  verbs: [create]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: allow-write-traces-dev-tenant-tls-profile-gw-mono
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: allow-write-traces-dev-tenant-tls-profile-gw-mono
+subjects:
+- kind: ServiceAccount
+  name: dev-mono-collector
+  namespace: chainsaw-tls-profile-gw
+---
+# Grant the default Service Account permission to read traces of the 'dev' tenant (monolithic)
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: allow-read-traces-dev-tenant-tls-profile-gw-mono
+rules:
+- apiGroups: [tempo.grafana.com]
+  resources: [dev]
+  resourceNames: [traces]
+  verbs: [get]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: allow-read-traces-dev-tenant-tls-profile-gw-mono
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: allow-read-traces-dev-tenant-tls-profile-gw-mono
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: chainsaw-tls-profile-gw

--- a/tests/e2e-openshift-tls-profile/tls-profile/03-verify-intermediate.sh
+++ b/tests/e2e-openshift-tls-profile/tls-profile/03-verify-intermediate.sh
@@ -116,7 +116,31 @@ echo "PASS: gateway:8090 TLS functional"
 GATEWAY_IP=$(kubectl get pod -n $NAMESPACE -l app.kubernetes.io/component=gateway -o jsonpath='{.items[0].status.podIP}')
 verify_nmap_tls_profile "$GATEWAY_IP" "8080,8090" intermediate "Gateway"
 
-# --- 5. Internal gRPC TLS profile verification via -all-pods ---
+# --- 5. Monolithic ConfigMap verification ---
+MONO_CONFIG=$(kubectl get configmap tempo-mono-config -n $NAMESPACE -o jsonpath='{.data.tempo\.yaml}')
+echo "$MONO_CONFIG" | grep 'tls_min_version: VersionTLS12' || fail "monolithic tls_min_version VersionTLS12 not found"
+echo "$MONO_CONFIG" | grep 'tls_ca_path' || fail "monolithic storage tls_ca_path not found - storage TLS not configured"
+
+# --- 6. Monolithic Gateway args verification ---
+MONO_GW_ARGS=$(kubectl get statefulset tempo-mono -n $NAMESPACE -o jsonpath='{.spec.template.spec.containers[?(@.name=="tempo-gateway")].args}')
+echo "$MONO_GW_ARGS" | grep -- '--tls.min-version=VersionTLS12' || fail "monolithic gateway --tls.min-version missing"
+echo "$MONO_GW_ARGS" | grep -- '--tls.cipher-suites=' || fail "monolithic gateway --tls.cipher-suites missing"
+
+# --- 7. Monolithic Functional TLS checks ---
+echo "=== Monolithic Functional TLS checks ==="
+kubectl exec tls-scanner -n $NAMESPACE -- tls-scanner -host tempo-mono-gateway -port 8080 \
+  || fail "TLS check failed on monolithic gateway:8080"
+echo "PASS: monolithic gateway:8080 TLS functional"
+
+kubectl exec tls-scanner -n $NAMESPACE -- tls-scanner -host tempo-mono-gateway -port 8090 \
+  || fail "TLS check failed on monolithic gateway:8090"
+echo "PASS: monolithic gateway:8090 TLS functional"
+
+# --- 8. Monolithic Gateway TLS profile verification via direct nmap ---
+MONO_GATEWAY_IP=$(kubectl get pod -n $NAMESPACE tempo-mono-0 -o jsonpath='{.status.podIP}')
+verify_nmap_tls_profile "$MONO_GATEWAY_IP" "8080,8090" intermediate "Monolithic Gateway"
+
+# --- 9. Internal gRPC TLS profile verification via -all-pods ---
 echo "=== Scanning all Tempo pods in $NAMESPACE ==="
 SCAN_OUTPUT=$(kubectl exec tls-scanner -n $NAMESPACE -- tls-scanner \
   -all-pods \
@@ -152,4 +176,4 @@ echo "PASS: operator metrics:8443 TLS functional"
 # Operator TLS profile verification via direct nmap
 verify_nmap_tls_profile "$OPERATOR_IP" "9443,8443" intermediate "Operator"
 
-echo "PASS: Intermediate profile verified on all components, gateway, storage, and operator"
+echo "PASS: Intermediate profile verified on all components, gateway, monolithic gateway, storage, and operator"

--- a/tests/e2e-openshift-tls-profile/tls-profile/04-assert.yaml
+++ b/tests/e2e-openshift-tls-profile/tls-profile/04-assert.yaml
@@ -6,3 +6,11 @@ metadata:
   namespace: chainsaw-tls-profile-gw
 status:
   readyReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dev-mono-collector
+  namespace: chainsaw-tls-profile-gw
+status:
+  readyReplicas: 1

--- a/tests/e2e-openshift-tls-profile/tls-profile/04-install-otelcol.yaml
+++ b/tests/e2e-openshift-tls-profile/tls-profile/04-install-otelcol.yaml
@@ -54,6 +54,62 @@ spec:
           receivers: [otlp/http]
           exporters: [otlphttp]
 ---
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: dev-mono
+  namespace: chainsaw-tls-profile-gw
+spec:
+  config: |
+    extensions:
+      bearertokenauth:
+        filename: "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    receivers:
+      otlp/grpc:
+        protocols:
+          grpc:
+      otlp/http:
+        protocols:
+          http:
+
+    processors:
+
+    exporters:
+      otlp:
+        endpoint: tempo-mono-gateway.chainsaw-tls-profile-gw.svc.cluster.local:4317
+        tls:
+          insecure: false
+          ca_file: "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
+        auth:
+          authenticator: bearertokenauth
+        headers:
+          X-Scope-OrgID: "dev"
+      otlphttp:
+        endpoint: https://tempo-mono-gateway.chainsaw-tls-profile-gw.svc.cluster.local:8080/api/traces/v1/dev
+        tls:
+          insecure: false
+          ca_file: "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
+        auth:
+          authenticator: bearertokenauth
+        headers:
+          X-Scope-OrgID: "dev"
+
+    service:
+      telemetry:
+        logs:
+          level: "DEBUG"
+          development: true
+          encoding: "json"
+      extensions: [bearertokenauth]
+      pipelines:
+        traces/grpc:
+          receivers: [otlp/grpc]
+          exporters: [otlp]
+        traces/http:
+          receivers: [otlp/http]
+          exporters: [otlphttp]
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/tests/e2e-openshift-tls-profile/tls-profile/05-assert.yaml
+++ b/tests/e2e-openshift-tls-profile/tls-profile/05-assert.yaml
@@ -13,3 +13,19 @@ metadata:
   namespace: chainsaw-tls-profile-gw
 status:
   succeeded: 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: generate-traces-grpc-mono
+  namespace: chainsaw-tls-profile-gw
+status:
+  succeeded: 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: generate-traces-http-mono
+  namespace: chainsaw-tls-profile-gw
+status:
+  succeeded: 1

--- a/tests/e2e-openshift-tls-profile/tls-profile/05-generate-traces.yaml
+++ b/tests/e2e-openshift-tls-profile/tls-profile/05-generate-traces.yaml
@@ -36,3 +36,42 @@ spec:
             - --service=http
             - --traces=10
       restartPolicy: Never
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: generate-traces-grpc-mono
+  namespace: chainsaw-tls-profile-gw
+spec:
+  template:
+    spec:
+      containers:
+      - name: telemetrygen
+        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
+        args:
+        - traces
+        - --otlp-endpoint=dev-mono-collector:4317
+        - --service=grpc-mono
+        - --otlp-insecure
+        - --traces=10
+      restartPolicy: Never
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: generate-traces-http-mono
+  namespace: chainsaw-tls-profile-gw
+spec:
+  template:
+    spec:
+      containers:
+        - name: telemetrygen
+          image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
+          args:
+            - traces
+            - --otlp-endpoint=dev-mono-collector:4318
+            - --otlp-http
+            - --otlp-insecure
+            - --service=http-mono
+            - --traces=10
+      restartPolicy: Never

--- a/tests/e2e-openshift-tls-profile/tls-profile/06-assert.yaml
+++ b/tests/e2e-openshift-tls-profile/tls-profile/06-assert.yaml
@@ -29,3 +29,35 @@ metadata:
   namespace: chainsaw-tls-profile-gw
 status:
   succeeded: 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify-traces-grpc-mono
+  namespace: chainsaw-tls-profile-gw
+status:
+  succeeded: 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify-traces-traceql-grpc-mono
+  namespace: chainsaw-tls-profile-gw
+status:
+  succeeded: 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify-traces-http-mono
+  namespace: chainsaw-tls-profile-gw
+status:
+  succeeded: 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify-traces-traceql-http-mono
+  namespace: chainsaw-tls-profile-gw
+status:
+  succeeded: 1

--- a/tests/e2e-openshift-tls-profile/tls-profile/06-verify-traces.yaml
+++ b/tests/e2e-openshift-tls-profile/tls-profile/06-verify-traces.yaml
@@ -127,3 +127,133 @@ spec:
                 exit 1
               fi
       restartPolicy: Never
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify-traces-grpc-mono
+  namespace: chainsaw-tls-profile-gw
+spec:
+  template:
+    spec:
+      containers:
+      - name: verify-traces
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - /bin/bash
+        - -eux
+        - -c
+        args:
+        - |
+          token=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+          curl \
+            -v -G \
+            --header "Authorization: Bearer $token" \
+            --cacert /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt \
+            https://tempo-mono-gateway.chainsaw-tls-profile-gw.svc:8080/api/traces/v1/dev/api/traces \
+            --data-urlencode "service=grpc-mono" \
+            | tee /tmp/jaeger.out
+
+          num_traces=$(jq ".data | length" /tmp/jaeger.out)
+          if [[ "$num_traces" != "10" ]]; then
+            echo && echo "The Jaeger API returned $num_traces instead of 10 traces."
+            exit 1
+          fi
+      restartPolicy: Never
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify-traces-traceql-grpc-mono
+  namespace: chainsaw-tls-profile-gw
+spec:
+  template:
+    spec:
+      containers:
+        - name: verify-traces
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
+          command:
+            - /bin/bash
+            - -eux
+            - -c
+          args:
+            - |
+              token=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+              curl \
+                -v -G \
+                --header "Authorization: Bearer $token" \
+                --cacert /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt \
+                https://tempo-mono-gateway.chainsaw-tls-profile-gw.svc:8080/api/traces/v1/dev/tempo/api/search \
+                --data-urlencode 'q={ resource.service.name="grpc-mono" }' \
+                | tee /tmp/jaeger.out
+              num_traces=$(jq ".traces | length" /tmp/jaeger.out)
+              if [[ "$num_traces" != "10" ]]; then
+                echo && echo "The Jaeger API returned $num_traces instead of 10 traces."
+                exit 1
+              fi
+      restartPolicy: Never
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify-traces-http-mono
+  namespace: chainsaw-tls-profile-gw
+spec:
+  template:
+    spec:
+      containers:
+        - name: verify-traces
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
+          command:
+            - /bin/bash
+            - -eux
+            - -c
+          args:
+            - |
+              token=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+              curl \
+                -v -G \
+                --header "Authorization: Bearer $token" \
+                --cacert /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt \
+                https://tempo-mono-gateway.chainsaw-tls-profile-gw.svc:8080/api/traces/v1/dev/api/traces \
+                --data-urlencode "service=http-mono" \
+                | tee /tmp/jaeger.out
+
+              num_traces=$(jq ".data | length" /tmp/jaeger.out)
+              if [[ "$num_traces" != "10" ]]; then
+                echo && echo "The Jaeger API returned $num_traces instead of 10 traces."
+                exit 1
+              fi
+      restartPolicy: Never
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify-traces-traceql-http-mono
+  namespace: chainsaw-tls-profile-gw
+spec:
+  template:
+    spec:
+      containers:
+        - name: verify-traces
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
+          command:
+            - /bin/bash
+            - -eux
+            - -c
+          args:
+            - |
+              token=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+              curl \
+                -v -G \
+                --header "Authorization: Bearer $token" \
+                --cacert /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt \
+                https://tempo-mono-gateway.chainsaw-tls-profile-gw.svc:8080/api/traces/v1/dev/tempo/api/search \
+                --data-urlencode 'q={ resource.service.name="http-mono" }' \
+                | tee /tmp/jaeger.out
+              num_traces=$(jq ".traces | length" /tmp/jaeger.out)
+              if [[ "$num_traces" != "10" ]]; then
+                echo && echo "The Jaeger API returned $num_traces instead of 10 traces."
+                exit 1
+              fi
+      restartPolicy: Never

--- a/tests/e2e-openshift-tls-profile/tls-profile/08-verify-modern.sh
+++ b/tests/e2e-openshift-tls-profile/tls-profile/08-verify-modern.sh
@@ -122,7 +122,33 @@ echo "PASS: gateway:8090 TLS functional"
 GATEWAY_IP=$(kubectl get pod -n $NAMESPACE -l app.kubernetes.io/component=gateway -o jsonpath='{.items[0].status.podIP}')
 verify_nmap_tls_profile "$GATEWAY_IP" "8080,8090" modern "Gateway"
 
-# --- 5. Internal gRPC TLS profile verification via targeted nmap ---
+# --- 5. Monolithic ConfigMap verification ---
+MONO_CONFIG=$(kubectl get configmap tempo-mono-config -n $NAMESPACE -o jsonpath='{.data.tempo\.yaml}')
+echo "$MONO_CONFIG" | grep 'tls_min_version: VersionTLS13' || fail "monolithic tls_min_version VersionTLS13 not found"
+echo "$MONO_CONFIG" | grep 'tls_ca_path' || fail "monolithic storage tls_ca_path not found - storage TLS not configured"
+if echo "$MONO_CONFIG" | grep -q 'tls_min_version: VersionTLS12'; then
+  fail "monolithic storage still using VersionTLS12 under Modern profile"
+fi
+
+# --- 6. Monolithic Gateway args verification ---
+MONO_GW_ARGS=$(kubectl get statefulset tempo-mono -n $NAMESPACE -o jsonpath='{.spec.template.spec.containers[?(@.name=="tempo-gateway")].args}')
+echo "$MONO_GW_ARGS" | grep -- '--tls.min-version=VersionTLS13' || fail "monolithic gateway not updated to VersionTLS13"
+
+# --- 7. Monolithic Functional TLS checks ---
+echo "=== Monolithic Functional TLS checks ==="
+kubectl exec tls-scanner -n $NAMESPACE -- tls-scanner -host tempo-mono-gateway -port 8080 \
+  || fail "TLS check failed on monolithic gateway:8080"
+echo "PASS: monolithic gateway:8080 TLS functional"
+
+kubectl exec tls-scanner -n $NAMESPACE -- tls-scanner -host tempo-mono-gateway -port 8090 \
+  || fail "TLS check failed on monolithic gateway:8090"
+echo "PASS: monolithic gateway:8090 TLS functional"
+
+# --- 8. Monolithic Gateway TLS profile verification via direct nmap ---
+MONO_GATEWAY_IP=$(kubectl get pod -n $NAMESPACE tempo-mono-0 -o jsonpath='{.status.podIP}')
+verify_nmap_tls_profile "$MONO_GATEWAY_IP" "8080,8090" modern "Monolithic Gateway"
+
+# --- 9. Internal gRPC TLS profile verification via targeted nmap ---
 # Use targeted nmap on specific pod IPs instead of -all-pods scan for reliability
 # after rollout (avoids scanning terminating pods and cross-node network issues).
 echo "=== Targeted internal gRPC scan (Modern profile) ==="
@@ -164,4 +190,4 @@ echo "PASS: operator metrics:8443 TLS functional"
 # Operator TLS profile verification via direct nmap
 verify_nmap_tls_profile "$OPERATOR_IP" "9443,8443" modern "Operator"
 
-echo "PASS: Modern profile verified on all components, gateway, and operator"
+echo "PASS: Modern profile verified on all components, gateway, monolithic gateway, and operator"

--- a/tests/e2e-openshift-tls-profile/tls-profile/09-assert.yaml
+++ b/tests/e2e-openshift-tls-profile/tls-profile/09-assert.yaml
@@ -13,3 +13,19 @@ metadata:
   namespace: chainsaw-tls-profile-gw
 status:
   succeeded: 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: generate-traces-grpc-mono-modern
+  namespace: chainsaw-tls-profile-gw
+status:
+  succeeded: 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: generate-traces-http-mono-modern
+  namespace: chainsaw-tls-profile-gw
+status:
+  succeeded: 1

--- a/tests/e2e-openshift-tls-profile/tls-profile/09-generate-traces-modern.yaml
+++ b/tests/e2e-openshift-tls-profile/tls-profile/09-generate-traces-modern.yaml
@@ -36,3 +36,42 @@ spec:
             - --service=http-modern
             - --traces=10
       restartPolicy: Never
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: generate-traces-grpc-mono-modern
+  namespace: chainsaw-tls-profile-gw
+spec:
+  template:
+    spec:
+      containers:
+      - name: telemetrygen
+        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
+        args:
+        - traces
+        - --otlp-endpoint=dev-mono-collector:4317
+        - --service=grpc-mono-modern
+        - --otlp-insecure
+        - --traces=10
+      restartPolicy: Never
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: generate-traces-http-mono-modern
+  namespace: chainsaw-tls-profile-gw
+spec:
+  template:
+    spec:
+      containers:
+        - name: telemetrygen
+          image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
+          args:
+            - traces
+            - --otlp-endpoint=dev-mono-collector:4318
+            - --otlp-http
+            - --otlp-insecure
+            - --service=http-mono-modern
+            - --traces=10
+      restartPolicy: Never

--- a/tests/e2e-openshift-tls-profile/tls-profile/10-assert.yaml
+++ b/tests/e2e-openshift-tls-profile/tls-profile/10-assert.yaml
@@ -29,3 +29,35 @@ metadata:
   namespace: chainsaw-tls-profile-gw
 status:
   succeeded: 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify-traces-grpc-mono-modern
+  namespace: chainsaw-tls-profile-gw
+status:
+  succeeded: 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify-traces-traceql-grpc-mono-modern
+  namespace: chainsaw-tls-profile-gw
+status:
+  succeeded: 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify-traces-http-mono-modern
+  namespace: chainsaw-tls-profile-gw
+status:
+  succeeded: 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify-traces-traceql-http-mono-modern
+  namespace: chainsaw-tls-profile-gw
+status:
+  succeeded: 1

--- a/tests/e2e-openshift-tls-profile/tls-profile/10-verify-traces-modern.yaml
+++ b/tests/e2e-openshift-tls-profile/tls-profile/10-verify-traces-modern.yaml
@@ -127,3 +127,133 @@ spec:
                 exit 1
               fi
       restartPolicy: Never
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify-traces-grpc-mono-modern
+  namespace: chainsaw-tls-profile-gw
+spec:
+  template:
+    spec:
+      containers:
+      - name: verify-traces
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - /bin/bash
+        - -eux
+        - -c
+        args:
+        - |
+          token=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+          curl \
+            -v -G \
+            --header "Authorization: Bearer $token" \
+            --cacert /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt \
+            https://tempo-mono-gateway.chainsaw-tls-profile-gw.svc:8080/api/traces/v1/dev/api/traces \
+            --data-urlencode "service=grpc-mono-modern" \
+            | tee /tmp/jaeger.out
+
+          num_traces=$(jq ".data | length" /tmp/jaeger.out)
+          if [[ "$num_traces" != "10" ]]; then
+            echo && echo "The Jaeger API returned $num_traces instead of 10 traces."
+            exit 1
+          fi
+      restartPolicy: Never
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify-traces-traceql-grpc-mono-modern
+  namespace: chainsaw-tls-profile-gw
+spec:
+  template:
+    spec:
+      containers:
+        - name: verify-traces
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
+          command:
+            - /bin/bash
+            - -eux
+            - -c
+          args:
+            - |
+              token=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+              curl \
+                -v -G \
+                --header "Authorization: Bearer $token" \
+                --cacert /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt \
+                https://tempo-mono-gateway.chainsaw-tls-profile-gw.svc:8080/api/traces/v1/dev/tempo/api/search \
+                --data-urlencode 'q={ resource.service.name="grpc-mono-modern" }' \
+                | tee /tmp/jaeger.out
+              num_traces=$(jq ".traces | length" /tmp/jaeger.out)
+              if [[ "$num_traces" != "10" ]]; then
+                echo && echo "The Jaeger API returned $num_traces instead of 10 traces."
+                exit 1
+              fi
+      restartPolicy: Never
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify-traces-http-mono-modern
+  namespace: chainsaw-tls-profile-gw
+spec:
+  template:
+    spec:
+      containers:
+        - name: verify-traces
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
+          command:
+            - /bin/bash
+            - -eux
+            - -c
+          args:
+            - |
+              token=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+              curl \
+                -v -G \
+                --header "Authorization: Bearer $token" \
+                --cacert /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt \
+                https://tempo-mono-gateway.chainsaw-tls-profile-gw.svc:8080/api/traces/v1/dev/api/traces \
+                --data-urlencode "service=http-mono-modern" \
+                | tee /tmp/jaeger.out
+
+              num_traces=$(jq ".data | length" /tmp/jaeger.out)
+              if [[ "$num_traces" != "10" ]]; then
+                echo && echo "The Jaeger API returned $num_traces instead of 10 traces."
+                exit 1
+              fi
+      restartPolicy: Never
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify-traces-traceql-http-mono-modern
+  namespace: chainsaw-tls-profile-gw
+spec:
+  template:
+    spec:
+      containers:
+        - name: verify-traces
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
+          command:
+            - /bin/bash
+            - -eux
+            - -c
+          args:
+            - |
+              token=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+              curl \
+                -v -G \
+                --header "Authorization: Bearer $token" \
+                --cacert /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt \
+                https://tempo-mono-gateway.chainsaw-tls-profile-gw.svc:8080/api/traces/v1/dev/tempo/api/search \
+                --data-urlencode 'q={ resource.service.name="http-mono-modern" }' \
+                | tee /tmp/jaeger.out
+              num_traces=$(jq ".traces | length" /tmp/jaeger.out)
+              if [[ "$num_traces" != "10" ]]; then
+                echo && echo "The Jaeger API returned $num_traces instead of 10 traces."
+                exit 1
+              fi
+      restartPolicy: Never

--- a/tests/e2e-openshift-tls-profile/tls-profile/chainsaw-test.yaml
+++ b/tests/e2e-openshift-tls-profile/tls-profile/chainsaw-test.yaml
@@ -26,6 +26,7 @@ spec:
     try:
     - apply:
         file: 01-install-tempo.yaml
+        timeout: 30s
     - assert:
         file: 01-assert.yaml
   - name: step-02

--- a/tests/e2e-openshift/monolithic-multitenancy-openshift/01-assert.yaml
+++ b/tests/e2e-openshift/monolithic-multitenancy-openshift/01-assert.yaml
@@ -26,7 +26,7 @@ spec:
         - --traces.tls.watch-certs=true
         - --grpc.listen=0.0.0.0:8090
         - --traces.write.otlpgrpc.endpoint=localhost:4317
-        - --traces.write.otlphttp.endpoint=http://localhost:4318
+        - --traces.write.otlphttp.endpoint=https://localhost:4318
         - --traces.read.endpoint=http://localhost:16686
         - --tls.server.cert-file=/etc/tempo-gateway/serving-cert/tls.crt
         - --tls.server.key-file=/etc/tempo-gateway/serving-cert/tls.key

--- a/tests/e2e-openshift/monolithic-multitenancy-rbac/01-assert.yaml
+++ b/tests/e2e-openshift/monolithic-multitenancy-rbac/01-assert.yaml
@@ -28,7 +28,7 @@ spec:
         - --traces.tls.watch-certs=true
         - --grpc.listen=0.0.0.0:8090
         - --traces.write.otlpgrpc.endpoint=localhost:4317
-        - --traces.write.otlphttp.endpoint=http://localhost:4318
+        - --traces.write.otlphttp.endpoint=https://localhost:4318
         - --traces.query-rbac=true
         - --tls.server.cert-file=/etc/tempo-gateway/serving-cert/tls.crt
         - --tls.server.key-file=/etc/tempo-gateway/serving-cert/tls.key
@@ -120,6 +120,21 @@ data:
                 - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
                 - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
             http:
+              tls:
+                client_ca_file: /var/run/ca/service-ca.crt
+                cert_file: /var/run/tls/server/tls.crt
+                key_file: /var/run/tls/server/tls.key
+                min_version: "1.2"
+                cipher_suites:
+                - TLS_AES_128_GCM_SHA256
+                - TLS_AES_256_GCM_SHA384
+                - TLS_CHACHA20_POLY1305_SHA256
+                - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+                - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+                - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+                - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+                - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+                - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
               endpoint: localhost:4318
     usage_report:
       reporting_enabled: false


### PR DESCRIPTION
The PR fixes issue: https://redhat.atlassian.net/browse/TRACING-6133

When gateway and HTTPEncryption were both enabled, the OTLP HTTP receiver was configured with the gateway serving certificate (which only has SANs for the gateway service DNS names). Since the gateway connects to the receiver at localhost:4318, TLS verification failed with "certificate is valid for tempo-*-gateway.*.svc, not localhost", causing all OTLP HTTP trace ingestion to be silently dropped.
  
The gRPC receiver already had a special case for this scenario, using the internal mTLS certificate (which includes localhost in its SANs). This commit adds the same handling for the HTTP receiver.