### PR TITLE
[Chore] Fix e2e tests

### DIFF
--- a/tests/e2e-openshift-ossm/ossm-monolithic-otel/install-ossm.yaml
+++ b/tests/e2e-openshift-ossm/ossm-monolithic-otel/install-ossm.yaml
@@ -29,6 +29,9 @@ metadata:
   namespace: istio-system
 spec:
   version: v2.5
+  security:
+    identity:
+      type: ThirdParty
   tracing:
     type: None
     sampling: 10000

--- a/tests/e2e-openshift-ossm/ossm-tempostack-otel/install-ossm.yaml
+++ b/tests/e2e-openshift-ossm/ossm-tempostack-otel/install-ossm.yaml
@@ -29,6 +29,9 @@ metadata:
   namespace: istio-system
 spec:
   version: v2.5
+  security:
+    identity:
+      type: ThirdParty
   tracing:
     type: None
     sampling: 10000

--- a/tests/e2e-openshift-ossm/ossm-tempostack/install-ossm.yaml
+++ b/tests/e2e-openshift-ossm/ossm-tempostack/install-ossm.yaml
@@ -23,6 +23,9 @@ metadata:
   namespace: istio-system
 spec:
   version: v2.5
+  security:
+    identity:
+      type: ThirdParty
   tracing:
     type: None
     sampling: 10000

--- a/tests/e2e-openshift/monolithic-multitenancy-rbac/01-assert.yaml
+++ b/tests/e2e-openshift/monolithic-multitenancy-rbac/01-assert.yaml
@@ -10,6 +10,7 @@ spec:
         - -config.file=/conf/tempo.yaml
         - -mem-ballast-size-mbs=1024
         - -log.level=info
+        - -config.expand-env=true
         name: tempo
       - args:
         - --web.listen=0.0.0.0:8080

--- a/tests/e2e-openshift/monolithic-route/install-tempo-assert.yaml
+++ b/tests/e2e-openshift/monolithic-route/install-tempo-assert.yaml
@@ -35,6 +35,7 @@ spec:
         - -config.file=/conf/tempo.yaml
         - -mem-ballast-size-mbs=1024
         - -log.level=info
+        - -config.expand-env=true
         name: tempo
         ports:
         - containerPort: 3200

--- a/tests/e2e-openshift/monolithic-single-tenant-auth/install-tempo-assert.yaml
+++ b/tests/e2e-openshift/monolithic-single-tenant-auth/install-tempo-assert.yaml
@@ -35,6 +35,7 @@ spec:
         - -config.file=/conf/tempo.yaml
         - -mem-ballast-size-mbs=1024
         - -log.level=info
+        - -config.expand-env=true
         name: tempo
         ports:
         - containerPort: 3200

--- a/tests/e2e-openshift/multitenancy/01-assert.yaml
+++ b/tests/e2e-openshift/multitenancy/01-assert.yaml
@@ -200,11 +200,11 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 120m
-            memory: "161061280"
+            cpu: 80m
+            memory: "96636760"
           requests:
-            cpu: 36m
-            memory: "48318384"
+            cpu: 24m
+            memory: "28991030"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/tests/e2e-openshift/tempostack-resources/install-tempostack-assert.yaml
+++ b/tests/e2e-openshift/tempostack-resources/install-tempostack-assert.yaml
@@ -125,7 +125,7 @@ spec:
             memory: "64424508"
           requests:
             cpu: 24m
-            memory: "19327352"
+            memory: "19327354"
       - name: tempo-gateway-opa
         resources:
           limits:

--- a/tests/e2e-openshift/tls-monolithic-singletenant/01-assert.yaml
+++ b/tests/e2e-openshift/tls-monolithic-singletenant/01-assert.yaml
@@ -35,6 +35,7 @@ spec:
         - -config.file=/conf/tempo.yaml
         - -mem-ballast-size-mbs=1024
         - -log.level=info
+        - -config.expand-env=true
         name: tempo
         ports:
         - containerPort: 3200


### PR DESCRIPTION
Fix test asserts for changes caused due to following PRs. 
  - PR #1412 (env/envFrom fields) added -config.expand-env=true to all tempo container args, which 4 monolithic test assertions
   were missing
  - PR #1409 (OPA container resource fix) split gateway resources between tempo-gateway (cpu: 0.04, memory: 0.03) and tempo-gateway-opa (cpu: 0.02, memory: 0.02), reducing the gateway container's share. This affected the multitenancy and tempostack-resources test assertions.
