### PR TITLE
Add podAntiAffinity to gateway and compactor deployments

### DIFF
--- a/.chloggen/fix_gateway_compactor_anti_affinity.yaml
+++ b/.chloggen/fix_gateway_compactor_anti_affinity.yaml
@@ -1,0 +1,20 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. tempostack, tempomonolithic, github action)
+component: tempostack
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add podAntiAffinity to gateway and compactor deployments to improve HA
+
+# One or more tracking issues related to the change
+issues: [1422]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Previously, the gateway and compactor deployments did not set podAntiAffinity,
+  allowing all replicas to be scheduled on the same node. This reduces high availability.
+  All other components (distributor, ingester, querier, query-frontend) already had
+  podAntiAffinity configured.

--- a/internal/manifests/compactor/compactor.go
+++ b/internal/manifests/compactor/compactor.go
@@ -90,6 +90,7 @@ func deployment(params manifestutils.Params) (*v1.Deployment, error) {
 					ServiceAccountName: tempo.Spec.ServiceAccount,
 					NodeSelector:       cfg.NodeSelector,
 					Tolerations:        cfg.Tolerations,
+					Affinity:           manifestutils.DefaultAffinity(labels),
 					Containers: []corev1.Container{
 						{
 							Name:  "tempo",

--- a/internal/manifests/compactor/compactor_test.go
+++ b/internal/manifests/compactor/compactor_test.go
@@ -157,6 +157,7 @@ func TestBuildCompactor(t *testing.T) {
 									Key: "c",
 								},
 							},
+							Affinity: manifestutils.DefaultAffinity(labels),
 							Containers: []corev1.Container{
 								{
 									Name:  "tempo",

--- a/internal/manifests/gateway/gateway.go
+++ b/internal/manifests/gateway/gateway.go
@@ -252,6 +252,7 @@ func deployment(params manifestutils.Params, rbacCfgHash string, tenantsCfgHash 
 					ServiceAccountName: tempo.Spec.ServiceAccount,
 					NodeSelector:       cfg.NodeSelector,
 					Tolerations:        cfg.Tolerations,
+					Affinity:           manifestutils.DefaultAffinity(labels),
 					Containers: []corev1.Container{
 						{
 							Name:  containerNameTempoGateway,

--- a/internal/manifests/gateway/gateway_test.go
+++ b/internal/manifests/gateway/gateway_test.go
@@ -199,6 +199,7 @@ func TestBuildGateway_openshift(t *testing.T) {
 	assert.Equal(t, 2, len(dep.Spec.Template.Spec.Containers))
 	assert.Equal(t, "tempo-gateway-opa", dep.Spec.Template.Spec.Containers[1].Name)
 	assert.Equal(t, "tempo-simplest-gateway", dep.Spec.Template.Spec.ServiceAccountName)
+	assert.Equal(t, manifestutils.DefaultAffinity(dep.Spec.Template.Labels), dep.Spec.Template.Spec.Affinity)
 	assert.Equal(t, &corev1.Probe{
 		ProbeHandler: corev1.ProbeHandler{
 			HTTPGet: &corev1.HTTPGetAction{

--- a/tests/e2e-openshift/component-replicas/install-tempo-assert.yaml
+++ b/tests/e2e-openshift/component-replicas/install-tempo-assert.yaml
@@ -143,6 +143,27 @@ spec:
         app.kubernetes.io/managed-by: tempo-operator
         app.kubernetes.io/name: tempo
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: gateway
+                  app.kubernetes.io/instance: cmpreps
+                  app.kubernetes.io/managed-by: tempo-operator
+                  app.kubernetes.io/name: tempo
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: gateway
+                  app.kubernetes.io/instance: cmpreps
+                  app.kubernetes.io/managed-by: tempo-operator
+                  app.kubernetes.io/name: tempo
+              topologyKey: failure-domain.beta.kubernetes.io/zone
+            weight: 75
       containers:
       - args:
         - --traces.tenant-header=x-scope-orgid
@@ -374,6 +395,30 @@ kind: Deployment
 metadata:
   name: tempo-cmpreps-compactor
   namespace: chainsaw-replicas
+spec:
+  template:
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: compactor
+                  app.kubernetes.io/instance: cmpreps
+                  app.kubernetes.io/managed-by: tempo-operator
+                  app.kubernetes.io/name: tempo
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: compactor
+                  app.kubernetes.io/instance: cmpreps
+                  app.kubernetes.io/managed-by: tempo-operator
+                  app.kubernetes.io/name: tempo
+              topologyKey: failure-domain.beta.kubernetes.io/zone
+            weight: 75
 status:
   readyReplicas: 1
 ---
@@ -382,6 +427,30 @@ kind: Deployment
 metadata:
   name: tempo-cmpreps-distributor
   namespace: chainsaw-replicas
+spec:
+  template:
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: distributor
+                  app.kubernetes.io/instance: cmpreps
+                  app.kubernetes.io/managed-by: tempo-operator
+                  app.kubernetes.io/name: tempo
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: distributor
+                  app.kubernetes.io/instance: cmpreps
+                  app.kubernetes.io/managed-by: tempo-operator
+                  app.kubernetes.io/name: tempo
+              topologyKey: failure-domain.beta.kubernetes.io/zone
+            weight: 75
 status:
   readyReplicas: 1
 ---
@@ -390,6 +459,30 @@ kind: Deployment
 metadata:
   name: tempo-cmpreps-querier
   namespace: chainsaw-replicas
+spec:
+  template:
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: querier
+                  app.kubernetes.io/instance: cmpreps
+                  app.kubernetes.io/managed-by: tempo-operator
+                  app.kubernetes.io/name: tempo
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: querier
+                  app.kubernetes.io/instance: cmpreps
+                  app.kubernetes.io/managed-by: tempo-operator
+                  app.kubernetes.io/name: tempo
+              topologyKey: failure-domain.beta.kubernetes.io/zone
+            weight: 75
 status:
   readyReplicas: 1
 ---
@@ -398,6 +491,30 @@ kind: Deployment
 metadata:
   name: tempo-cmpreps-query-frontend
   namespace: chainsaw-replicas
+spec:
+  template:
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: query-frontend
+                  app.kubernetes.io/instance: cmpreps
+                  app.kubernetes.io/managed-by: tempo-operator
+                  app.kubernetes.io/name: tempo
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: query-frontend
+                  app.kubernetes.io/instance: cmpreps
+                  app.kubernetes.io/managed-by: tempo-operator
+                  app.kubernetes.io/name: tempo
+              topologyKey: failure-domain.beta.kubernetes.io/zone
+            weight: 75
 status:
   readyReplicas: 1
 ---
@@ -406,5 +523,29 @@ kind: StatefulSet
 metadata:
   name: tempo-cmpreps-ingester
   namespace: chainsaw-replicas
+spec:
+  template:
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: ingester
+                  app.kubernetes.io/instance: cmpreps
+                  app.kubernetes.io/managed-by: tempo-operator
+                  app.kubernetes.io/name: tempo
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: ingester
+                  app.kubernetes.io/instance: cmpreps
+                  app.kubernetes.io/managed-by: tempo-operator
+                  app.kubernetes.io/name: tempo
+              topologyKey: failure-domain.beta.kubernetes.io/zone
+            weight: 75
 status:
   readyReplicas: 1

--- a/tests/e2e-openshift/component-replicas/scale-tempo-assert.yaml
+++ b/tests/e2e-openshift/component-replicas/scale-tempo-assert.yaml
@@ -143,6 +143,27 @@ spec:
         app.kubernetes.io/managed-by: tempo-operator
         app.kubernetes.io/name: tempo
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: gateway
+                  app.kubernetes.io/instance: cmpreps
+                  app.kubernetes.io/managed-by: tempo-operator
+                  app.kubernetes.io/name: tempo
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: gateway
+                  app.kubernetes.io/instance: cmpreps
+                  app.kubernetes.io/managed-by: tempo-operator
+                  app.kubernetes.io/name: tempo
+              topologyKey: failure-domain.beta.kubernetes.io/zone
+            weight: 75
       containers:
       - args:
         - --traces.tenant-header=x-scope-orgid
@@ -374,6 +395,30 @@ kind: Deployment
 metadata:
   name: tempo-cmpreps-compactor
   namespace: chainsaw-replicas
+spec:
+  template:
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: compactor
+                  app.kubernetes.io/instance: cmpreps
+                  app.kubernetes.io/managed-by: tempo-operator
+                  app.kubernetes.io/name: tempo
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: compactor
+                  app.kubernetes.io/instance: cmpreps
+                  app.kubernetes.io/managed-by: tempo-operator
+                  app.kubernetes.io/name: tempo
+              topologyKey: failure-domain.beta.kubernetes.io/zone
+            weight: 75
 status:
   readyReplicas: ($tempo_replicas)
 ---
@@ -382,6 +427,30 @@ kind: Deployment
 metadata:
   name: tempo-cmpreps-distributor
   namespace: chainsaw-replicas
+spec:
+  template:
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: distributor
+                  app.kubernetes.io/instance: cmpreps
+                  app.kubernetes.io/managed-by: tempo-operator
+                  app.kubernetes.io/name: tempo
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: distributor
+                  app.kubernetes.io/instance: cmpreps
+                  app.kubernetes.io/managed-by: tempo-operator
+                  app.kubernetes.io/name: tempo
+              topologyKey: failure-domain.beta.kubernetes.io/zone
+            weight: 75
 status:
   readyReplicas: ($tempo_replicas)
 ---
@@ -390,6 +459,30 @@ kind: Deployment
 metadata:
   name: tempo-cmpreps-querier
   namespace: chainsaw-replicas
+spec:
+  template:
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: querier
+                  app.kubernetes.io/instance: cmpreps
+                  app.kubernetes.io/managed-by: tempo-operator
+                  app.kubernetes.io/name: tempo
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: querier
+                  app.kubernetes.io/instance: cmpreps
+                  app.kubernetes.io/managed-by: tempo-operator
+                  app.kubernetes.io/name: tempo
+              topologyKey: failure-domain.beta.kubernetes.io/zone
+            weight: 75
 status:
   readyReplicas: ($tempo_replicas)
 ---
@@ -398,6 +491,30 @@ kind: Deployment
 metadata:
   name: tempo-cmpreps-query-frontend
   namespace: chainsaw-replicas
+spec:
+  template:
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: query-frontend
+                  app.kubernetes.io/instance: cmpreps
+                  app.kubernetes.io/managed-by: tempo-operator
+                  app.kubernetes.io/name: tempo
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: query-frontend
+                  app.kubernetes.io/instance: cmpreps
+                  app.kubernetes.io/managed-by: tempo-operator
+                  app.kubernetes.io/name: tempo
+              topologyKey: failure-domain.beta.kubernetes.io/zone
+            weight: 75
 status:
   readyReplicas: ($tempo_replicas)
 ---
@@ -406,5 +523,29 @@ kind: StatefulSet
 metadata:
   name: tempo-cmpreps-ingester
   namespace: chainsaw-replicas
+spec:
+  template:
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: ingester
+                  app.kubernetes.io/instance: cmpreps
+                  app.kubernetes.io/managed-by: tempo-operator
+                  app.kubernetes.io/name: tempo
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: ingester
+                  app.kubernetes.io/instance: cmpreps
+                  app.kubernetes.io/managed-by: tempo-operator
+                  app.kubernetes.io/name: tempo
+              topologyKey: failure-domain.beta.kubernetes.io/zone
+            weight: 75
 status:
   readyReplicas: ($tempo_replicas)


### PR DESCRIPTION
## Summary
- Add `podAntiAffinity` to gateway and compactor deployments to improve high availability
- The gateway and compactor were the only TempoStack components missing anti-affinity, allowing all replicas to be co-located on the same node
- Add e2e assertions for `podAntiAffinity` on all six TempoStack components (gateway, compactor, distributor, querier, query-frontend, ingester) to prevent future regressions

## Root Cause
- PR #177 (Feb 1, 2023) added `DefaultAffinity` to distributor, ingester, querier, and query-frontend
- The gateway was added 6 days later in PR #199 and was simply missed
- The compactor was skipped at the time since it typically runs a single replica, but users can configure multiple replicas

## Changes
- `internal/manifests/gateway/gateway.go` — Added `Affinity: manifestutils.DefaultAffinity(labels)` to gateway deployment PodSpec
- `internal/manifests/compactor/compactor.go` — Added `Affinity: manifestutils.DefaultAffinity(labels)` to compactor deployment PodSpec
- `internal/manifests/gateway/gateway_test.go` — Added affinity assertion to gateway unit test
- `internal/manifests/compactor/compactor_test.go` — Added expected affinity to compactor unit test
- `tests/e2e-openshift/component-replicas/install-tempo-assert.yaml` — Added `podAntiAffinity` assertions for all 6 components
- `tests/e2e-openshift/component-replicas/scale-tempo-assert.yaml` — Same assertions for scaled (2 replicas) state

## Test plan
- [x] Unit tests pass (`go test ./internal/manifests/...`)
- [x] e2e test `component-replicas` passes with anti-affinity assertions for all 6 components
- [x] Anti-affinity uses `preferredDuringSchedulingIgnoredDuringExecution` (soft preference), so pods still schedule when only one node is available