### PR TITLE
Add e2e tests for TempoStack T-shirt sizes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -414,6 +414,11 @@ test-operator-metrics:
 e2e-openshift:
 	$(CHAINSAW) test --test-dir ./tests/e2e-openshift --config .chainsaw-openshift.yaml
 
+# OpenShift T-shirt sizes end-to-end tests
+.PHONY: e2e-openshift-tshirt-sizes
+e2e-openshift-tshirt-sizes:
+	$(CHAINSAW) test --test-dir ./tests/e2e-openshift-tshirt-sizes --config .chainsaw-openshift.yaml
+
 # upgrade tests
 e2e-upgrade:
 	$(CHAINSAW) test --test-dir ./tests/e2e-upgrade --config .chainsaw-upgrade.yaml

--- a/tests/e2e-openshift-tshirt-sizes/tshirt-size-demo/00-assert.yaml
+++ b/tests/e2e-openshift-tshirt-sizes/tshirt-size-demo/00-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+status:
+  readyReplicas: 1

--- a/tests/e2e-openshift-tshirt-sizes/tshirt-size-demo/00-install-storage.yaml
+++ b/tests/e2e-openshift-tshirt-sizes/tshirt-size-demo/00-install-storage.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: minio
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: minio
+    spec:
+      containers:
+        - command:
+            - /bin/sh
+            - -c
+            - |
+              mkdir -p /storage/tempo && \
+              minio server /storage
+          env:
+            - name: MINIO_ACCESS_KEY
+              value: tempo
+            - name: MINIO_SECRET_KEY
+              value: supersecret
+          image: quay.io/minio/minio:latest
+          name: minio
+          ports:
+            - containerPort: 9000
+          volumeMounts:
+            - mountPath: /storage
+              name: storage
+      volumes:
+        - name: storage
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+spec:
+  ports:
+    - port: 9000
+      protocol: TCP
+      targetPort: 9000
+  selector:
+    app.kubernetes.io/name: minio
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio-test
+stringData:
+  endpoint: http://minio:9000
+  bucket: tempo
+  access_key_id: tempo
+  access_key_secret: supersecret
+type: Opaque

--- a/tests/e2e-openshift-tshirt-sizes/tshirt-size-demo/01-assert.yaml
+++ b/tests/e2e-openshift-tshirt-sizes/tshirt-size-demo/01-assert.yaml
@@ -1,0 +1,40 @@
+# 1x.demo: no resource requests, replication factor 1, single replicas.
+# Demo size is intended for development/demo environments.
+apiVersion: tempo.grafana.com/v1alpha1
+kind: TempoStack
+metadata:
+  name: demo
+spec:
+  replicationFactor: 1
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: tempo-demo-ingester
+spec:
+  replicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tempo-demo-distributor
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tempo-demo-querier
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tempo-demo-query-frontend
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tempo-demo-compactor
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tempo-demo-gateway

--- a/tests/e2e-openshift-tshirt-sizes/tshirt-size-demo/01-install-tempo.yaml
+++ b/tests/e2e-openshift-tshirt-sizes/tshirt-size-demo/01-install-tempo.yaml
@@ -1,0 +1,24 @@
+apiVersion: tempo.grafana.com/v1alpha1
+kind: TempoStack
+metadata:
+  name: demo
+spec:
+  size: 1x.demo
+  storage:
+    secret:
+      name: minio-test
+      type: s3
+  storageSize: 200M
+  tenants:
+    mode: openshift
+    authentication:
+      - tenantName: dev
+        tenantId: "1610b0c3-c509-4592-a256-a1871353dbfa"
+      - tenantName: prod
+        tenantId: "1610b0c3-c509-4592-a256-a1871353dbfb"
+  template:
+    gateway:
+      enabled: true
+    queryFrontend:
+      jaegerQuery:
+        enabled: true

--- a/tests/e2e-openshift-tshirt-sizes/tshirt-size-demo/chainsaw-test.yaml
+++ b/tests/e2e-openshift-tshirt-sizes/tshirt-size-demo/chainsaw-test.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: tshirt-size-demo
+spec:
+  steps:
+  - name: step-00
+    try:
+    - apply:
+        file: 00-install-storage.yaml
+    - assert:
+        file: 00-assert.yaml
+  - name: step-01
+    try:
+    - apply:
+        file: 01-install-tempo.yaml
+    - assert:
+        file: 01-assert.yaml

--- a/tests/e2e-openshift-tshirt-sizes/tshirt-size-extra-small/00-assert.yaml
+++ b/tests/e2e-openshift-tshirt-sizes/tshirt-size-extra-small/00-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+status:
+  readyReplicas: 1

--- a/tests/e2e-openshift-tshirt-sizes/tshirt-size-extra-small/00-install-storage.yaml
+++ b/tests/e2e-openshift-tshirt-sizes/tshirt-size-extra-small/00-install-storage.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: minio
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: minio
+    spec:
+      containers:
+        - command:
+            - /bin/sh
+            - -c
+            - |
+              mkdir -p /storage/tempo && \
+              minio server /storage
+          env:
+            - name: MINIO_ACCESS_KEY
+              value: tempo
+            - name: MINIO_SECRET_KEY
+              value: supersecret
+          image: quay.io/minio/minio:latest
+          name: minio
+          ports:
+            - containerPort: 9000
+          volumeMounts:
+            - mountPath: /storage
+              name: storage
+      volumes:
+        - name: storage
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+spec:
+  ports:
+    - port: 9000
+      protocol: TCP
+      targetPort: 9000
+  selector:
+    app.kubernetes.io/name: minio
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio-test
+stringData:
+  endpoint: http://minio:9000
+  bucket: tempo
+  access_key_id: tempo
+  access_key_secret: supersecret
+type: Opaque

--- a/tests/e2e-openshift-tshirt-sizes/tshirt-size-extra-small/01-assert.yaml
+++ b/tests/e2e-openshift-tshirt-sizes/tshirt-size-extra-small/01-assert.yaml
@@ -1,0 +1,109 @@
+# 1x.extra-small: medium production workloads (~100GB/day) with HA support.
+# We only check spec configuration, not pod readiness, to allow running
+# on resource-constrained clusters.
+apiVersion: tempo.grafana.com/v1alpha1
+kind: TempoStack
+metadata:
+  name: extra-small
+spec:
+  replicationFactor: 2
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: tempo-extra-small-ingester
+spec:
+  replicas: 2
+  template:
+    spec:
+      containers:
+        - name: tempo
+          resources:
+            requests:
+              cpu: 1500m
+              memory: 8Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tempo-extra-small-distributor
+spec:
+  template:
+    spec:
+      containers:
+        - name: tempo
+          resources:
+            requests:
+              cpu: 200m
+              memory: 128Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tempo-extra-small-querier
+spec:
+  template:
+    spec:
+      containers:
+        - name: tempo
+          resources:
+            requests:
+              cpu: "1"
+              memory: 1Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tempo-extra-small-query-frontend
+spec:
+  template:
+    spec:
+      containers:
+        - name: tempo
+          resources:
+            requests:
+              cpu: 200m
+              memory: 1Gi
+        - name: jaeger-query
+          resources:
+            requests:
+              cpu: 400m
+              memory: 128Mi
+        - name: tempo-query
+          resources:
+            requests:
+              cpu: 200m
+              memory: 1Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tempo-extra-small-compactor
+spec:
+  template:
+    spec:
+      containers:
+        - name: tempo
+          resources:
+            requests:
+              cpu: 200m
+              memory: 4Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tempo-extra-small-gateway
+spec:
+  template:
+    spec:
+      containers:
+        - name: tempo-gateway
+          resources:
+            requests:
+              cpu: 400m
+              memory: 128Mi
+        - name: tempo-gateway-opa
+          resources:
+            requests:
+              cpu: 100m
+              memory: 64Mi

--- a/tests/e2e-openshift-tshirt-sizes/tshirt-size-extra-small/01-install-tempo.yaml
+++ b/tests/e2e-openshift-tshirt-sizes/tshirt-size-extra-small/01-install-tempo.yaml
@@ -1,0 +1,24 @@
+apiVersion: tempo.grafana.com/v1alpha1
+kind: TempoStack
+metadata:
+  name: extra-small
+spec:
+  size: 1x.extra-small
+  storage:
+    secret:
+      name: minio-test
+      type: s3
+  storageSize: 200M
+  tenants:
+    mode: openshift
+    authentication:
+      - tenantName: dev
+        tenantId: "1610b0c3-c509-4592-a256-a1871353dbfa"
+      - tenantName: prod
+        tenantId: "1610b0c3-c509-4592-a256-a1871353dbfb"
+  template:
+    gateway:
+      enabled: true
+    queryFrontend:
+      jaegerQuery:
+        enabled: true

--- a/tests/e2e-openshift-tshirt-sizes/tshirt-size-extra-small/chainsaw-test.yaml
+++ b/tests/e2e-openshift-tshirt-sizes/tshirt-size-extra-small/chainsaw-test.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: tshirt-size-extra-small
+spec:
+  steps:
+  - name: step-00
+    try:
+    - apply:
+        file: 00-install-storage.yaml
+    - assert:
+        file: 00-assert.yaml
+  - name: step-01
+    try:
+    - apply:
+        file: 01-install-tempo.yaml
+    - assert:
+        file: 01-assert.yaml

--- a/tests/e2e-openshift-tshirt-sizes/tshirt-size-invalid/00-install-tempo.yaml
+++ b/tests/e2e-openshift-tshirt-sizes/tshirt-size-invalid/00-install-tempo.yaml
@@ -1,0 +1,22 @@
+apiVersion: tempo.grafana.com/v1alpha1
+kind: TempoStack
+metadata:
+  name: invalid-size
+spec:
+  size: 1x.invalid
+  storage:
+    secret:
+      name: minio-test
+      type: s3
+  storageSize: 200M
+  tenants:
+    mode: openshift
+    authentication:
+      - tenantName: dev
+        tenantId: "1610b0c3-c509-4592-a256-a1871353dbfa"
+  template:
+    gateway:
+      enabled: true
+    queryFrontend:
+      jaegerQuery:
+        enabled: true

--- a/tests/e2e-openshift-tshirt-sizes/tshirt-size-invalid/chainsaw-test.yaml
+++ b/tests/e2e-openshift-tshirt-sizes/tshirt-size-invalid/chainsaw-test.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: tshirt-size-invalid
+spec:
+  steps:
+  - name: step-00
+    try:
+    - apply:
+        file: 00-install-tempo.yaml
+        expect:
+        - check:
+            ($error != null): true

--- a/tests/e2e-openshift-tshirt-sizes/tshirt-size-medium/00-assert.yaml
+++ b/tests/e2e-openshift-tshirt-sizes/tshirt-size-medium/00-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+status:
+  readyReplicas: 1

--- a/tests/e2e-openshift-tshirt-sizes/tshirt-size-medium/00-install-storage.yaml
+++ b/tests/e2e-openshift-tshirt-sizes/tshirt-size-medium/00-install-storage.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: minio
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: minio
+    spec:
+      containers:
+        - command:
+            - /bin/sh
+            - -c
+            - |
+              mkdir -p /storage/tempo && \
+              minio server /storage
+          env:
+            - name: MINIO_ACCESS_KEY
+              value: tempo
+            - name: MINIO_SECRET_KEY
+              value: supersecret
+          image: quay.io/minio/minio:latest
+          name: minio
+          ports:
+            - containerPort: 9000
+          volumeMounts:
+            - mountPath: /storage
+              name: storage
+      volumes:
+        - name: storage
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+spec:
+  ports:
+    - port: 9000
+      protocol: TCP
+      targetPort: 9000
+  selector:
+    app.kubernetes.io/name: minio
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio-test
+stringData:
+  endpoint: http://minio:9000
+  bucket: tempo
+  access_key_id: tempo
+  access_key_secret: supersecret
+type: Opaque

--- a/tests/e2e-openshift-tshirt-sizes/tshirt-size-medium/01-assert.yaml
+++ b/tests/e2e-openshift-tshirt-sizes/tshirt-size-medium/01-assert.yaml
@@ -1,0 +1,109 @@
+# 1x.medium: high-scale production workloads (~2TB/day) with HA support.
+# We only check spec configuration, not pod readiness, to allow running
+# on resource-constrained clusters.
+apiVersion: tempo.grafana.com/v1alpha1
+kind: TempoStack
+metadata:
+  name: medium
+spec:
+  replicationFactor: 2
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: tempo-medium-ingester
+spec:
+  replicas: 2
+  template:
+    spec:
+      containers:
+        - name: tempo
+          resources:
+            requests:
+              cpu: "8"
+              memory: 16Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tempo-medium-distributor
+spec:
+  template:
+    spec:
+      containers:
+        - name: tempo
+          resources:
+            requests:
+              cpu: 1500m
+              memory: 128Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tempo-medium-querier
+spec:
+  template:
+    spec:
+      containers:
+        - name: tempo
+          resources:
+            requests:
+              cpu: "5"
+              memory: 4Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tempo-medium-query-frontend
+spec:
+  template:
+    spec:
+      containers:
+        - name: tempo
+          resources:
+            requests:
+              cpu: 800m
+              memory: 1Gi
+        - name: jaeger-query
+          resources:
+            requests:
+              cpu: "4"
+              memory: 192Mi
+        - name: tempo-query
+          resources:
+            requests:
+              cpu: 800m
+              memory: 1Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tempo-medium-compactor
+spec:
+  template:
+    spec:
+      containers:
+        - name: tempo
+          resources:
+            requests:
+              cpu: 600m
+              memory: 10Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tempo-medium-gateway
+spec:
+  template:
+    spec:
+      containers:
+        - name: tempo-gateway
+          resources:
+            requests:
+              cpu: "4"
+              memory: 192Mi
+        - name: tempo-gateway-opa
+          resources:
+            requests:
+              cpu: 200m
+              memory: 128Mi

--- a/tests/e2e-openshift-tshirt-sizes/tshirt-size-medium/01-install-tempo.yaml
+++ b/tests/e2e-openshift-tshirt-sizes/tshirt-size-medium/01-install-tempo.yaml
@@ -1,0 +1,24 @@
+apiVersion: tempo.grafana.com/v1alpha1
+kind: TempoStack
+metadata:
+  name: medium
+spec:
+  size: 1x.medium
+  storage:
+    secret:
+      name: minio-test
+      type: s3
+  storageSize: 200M
+  tenants:
+    mode: openshift
+    authentication:
+      - tenantName: dev
+        tenantId: "1610b0c3-c509-4592-a256-a1871353dbfa"
+      - tenantName: prod
+        tenantId: "1610b0c3-c509-4592-a256-a1871353dbfb"
+  template:
+    gateway:
+      enabled: true
+    queryFrontend:
+      jaegerQuery:
+        enabled: true

--- a/tests/e2e-openshift-tshirt-sizes/tshirt-size-medium/chainsaw-test.yaml
+++ b/tests/e2e-openshift-tshirt-sizes/tshirt-size-medium/chainsaw-test.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: tshirt-size-medium
+spec:
+  steps:
+  - name: step-00
+    try:
+    - apply:
+        file: 00-install-storage.yaml
+    - assert:
+        file: 00-assert.yaml
+  - name: step-01
+    try:
+    - apply:
+        file: 01-install-tempo.yaml
+    - assert:
+        file: 01-assert.yaml

--- a/tests/e2e-openshift-tshirt-sizes/tshirt-size-oauth-proxy/00-assert.yaml
+++ b/tests/e2e-openshift-tshirt-sizes/tshirt-size-oauth-proxy/00-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+status:
+  readyReplicas: 1

--- a/tests/e2e-openshift-tshirt-sizes/tshirt-size-oauth-proxy/00-install-storage.yaml
+++ b/tests/e2e-openshift-tshirt-sizes/tshirt-size-oauth-proxy/00-install-storage.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: minio
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: minio
+    spec:
+      containers:
+        - command:
+            - /bin/sh
+            - -c
+            - |
+              mkdir -p /storage/tempo && \
+              minio server /storage
+          env:
+            - name: MINIO_ACCESS_KEY
+              value: tempo
+            - name: MINIO_SECRET_KEY
+              value: supersecret
+          image: quay.io/minio/minio:latest
+          name: minio
+          ports:
+            - containerPort: 9000
+          volumeMounts:
+            - mountPath: /storage
+              name: storage
+      volumes:
+        - name: storage
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+spec:
+  ports:
+    - port: 9000
+      protocol: TCP
+      targetPort: 9000
+  selector:
+    app.kubernetes.io/name: minio
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio-test
+stringData:
+  endpoint: http://minio:9000
+  bucket: tempo
+  access_key_id: tempo
+  access_key_secret: supersecret
+type: Opaque

--- a/tests/e2e-openshift-tshirt-sizes/tshirt-size-oauth-proxy/01-assert.yaml
+++ b/tests/e2e-openshift-tshirt-sizes/tshirt-size-oauth-proxy/01-assert.yaml
@@ -1,0 +1,96 @@
+# Verifies OAuth proxy resources from the 1x.pico size profile.
+# In single-tenant mode with Jaeger UI authentication enabled,
+# the query-frontend deployment includes an oauth-proxy container.
+# No gateway is deployed in this mode.
+apiVersion: tempo.grafana.com/v1alpha1
+kind: TempoStack
+metadata:
+  name: oauth
+spec:
+  replicationFactor: 2
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: tempo-oauth-ingester
+spec:
+  replicas: 2
+  template:
+    spec:
+      containers:
+        - name: tempo
+          resources:
+            requests:
+              cpu: 500m
+              memory: 3Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tempo-oauth-distributor
+spec:
+  template:
+    spec:
+      containers:
+        - name: tempo
+          resources:
+            requests:
+              cpu: 500m
+              memory: 500Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tempo-oauth-querier
+spec:
+  template:
+    spec:
+      containers:
+        - name: tempo
+          resources:
+            requests:
+              cpu: 750m
+              memory: 1536Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tempo-oauth-query-frontend
+spec:
+  template:
+    spec:
+      containers:
+        - name: tempo
+          resources:
+            requests:
+              cpu: 500m
+              memory: 500Mi
+        - name: jaeger-query
+          resources:
+            requests:
+              cpu: 100m
+              memory: 64Mi
+        - name: tempo-query
+          resources:
+            requests:
+              cpu: 500m
+              memory: 500Mi
+        - name: oauth-proxy
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tempo-oauth-compactor
+spec:
+  template:
+    spec:
+      containers:
+        - name: tempo
+          resources:
+            requests:
+              cpu: 500m
+              memory: 500Mi

--- a/tests/e2e-openshift-tshirt-sizes/tshirt-size-oauth-proxy/01-install-tempo.yaml
+++ b/tests/e2e-openshift-tshirt-sizes/tshirt-size-oauth-proxy/01-install-tempo.yaml
@@ -1,0 +1,22 @@
+# Tests the OAuth proxy component resources from the size profile.
+# OAuth proxy is deployed in single-tenant mode when Jaeger UI
+# authentication is enabled (not in multitenancy/gateway mode).
+apiVersion: tempo.grafana.com/v1alpha1
+kind: TempoStack
+metadata:
+  name: oauth
+spec:
+  size: 1x.pico
+  storage:
+    secret:
+      name: minio-test
+      type: s3
+  storageSize: 200M
+  template:
+    queryFrontend:
+      jaegerQuery:
+        enabled: true
+        authentication:
+          enabled: true
+        ingress:
+          type: route

--- a/tests/e2e-openshift-tshirt-sizes/tshirt-size-oauth-proxy/chainsaw-test.yaml
+++ b/tests/e2e-openshift-tshirt-sizes/tshirt-size-oauth-proxy/chainsaw-test.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: tshirt-size-oauth-proxy
+spec:
+  steps:
+  - name: step-00
+    try:
+    - apply:
+        file: 00-install-storage.yaml
+    - assert:
+        file: 00-assert.yaml
+  - name: step-01
+    try:
+    - apply:
+        file: 01-install-tempo.yaml
+    - assert:
+        file: 01-assert.yaml

--- a/tests/e2e-openshift-tshirt-sizes/tshirt-size-override/00-assert.yaml
+++ b/tests/e2e-openshift-tshirt-sizes/tshirt-size-override/00-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+status:
+  readyReplicas: 1

--- a/tests/e2e-openshift-tshirt-sizes/tshirt-size-override/00-install-storage.yaml
+++ b/tests/e2e-openshift-tshirt-sizes/tshirt-size-override/00-install-storage.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: minio
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: minio
+    spec:
+      containers:
+        - command:
+            - /bin/sh
+            - -c
+            - |
+              mkdir -p /storage/tempo && \
+              minio server /storage
+          env:
+            - name: MINIO_ACCESS_KEY
+              value: tempo
+            - name: MINIO_SECRET_KEY
+              value: supersecret
+          image: quay.io/minio/minio:latest
+          name: minio
+          ports:
+            - containerPort: 9000
+          volumeMounts:
+            - mountPath: /storage
+              name: storage
+      volumes:
+        - name: storage
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+spec:
+  ports:
+    - port: 9000
+      protocol: TCP
+      targetPort: 9000
+  selector:
+    app.kubernetes.io/name: minio
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio-test
+stringData:
+  endpoint: http://minio:9000
+  bucket: tempo
+  access_key_id: tempo
+  access_key_secret: supersecret
+type: Opaque

--- a/tests/e2e-openshift-tshirt-sizes/tshirt-size-override/01-assert.yaml
+++ b/tests/e2e-openshift-tshirt-sizes/tshirt-size-override/01-assert.yaml
@@ -1,0 +1,109 @@
+# Verify that explicit replicationFactor=3 and ingester replicas=3
+# override the 1x.pico defaults (RF=2, ingester replicas=2),
+# while resource requests still come from the size profile.
+apiVersion: tempo.grafana.com/v1alpha1
+kind: TempoStack
+metadata:
+  name: override
+spec:
+  replicationFactor: 3
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: tempo-override-ingester
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+        - name: tempo
+          resources:
+            requests:
+              cpu: 500m
+              memory: 3Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tempo-override-distributor
+spec:
+  template:
+    spec:
+      containers:
+        - name: tempo
+          resources:
+            requests:
+              cpu: 500m
+              memory: 500Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tempo-override-querier
+spec:
+  template:
+    spec:
+      containers:
+        - name: tempo
+          resources:
+            requests:
+              cpu: 750m
+              memory: 1536Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tempo-override-query-frontend
+spec:
+  template:
+    spec:
+      containers:
+        - name: tempo
+          resources:
+            requests:
+              cpu: 500m
+              memory: 500Mi
+        - name: jaeger-query
+          resources:
+            requests:
+              cpu: 100m
+              memory: 64Mi
+        - name: tempo-query
+          resources:
+            requests:
+              cpu: 500m
+              memory: 500Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tempo-override-compactor
+spec:
+  template:
+    spec:
+      containers:
+        - name: tempo
+          resources:
+            requests:
+              cpu: 500m
+              memory: 500Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tempo-override-gateway
+spec:
+  template:
+    spec:
+      containers:
+        - name: tempo-gateway
+          resources:
+            requests:
+              cpu: 100m
+              memory: 64Mi
+        - name: tempo-gateway-opa
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi

--- a/tests/e2e-openshift-tshirt-sizes/tshirt-size-override/01-install-tempo.yaml
+++ b/tests/e2e-openshift-tshirt-sizes/tshirt-size-override/01-install-tempo.yaml
@@ -1,0 +1,29 @@
+# Tests that explicit replicationFactor and ingester replicas
+# override the size defaults.
+apiVersion: tempo.grafana.com/v1alpha1
+kind: TempoStack
+metadata:
+  name: override
+spec:
+  size: 1x.pico
+  replicationFactor: 3
+  storage:
+    secret:
+      name: minio-test
+      type: s3
+  storageSize: 200M
+  tenants:
+    mode: openshift
+    authentication:
+      - tenantName: dev
+        tenantId: "1610b0c3-c509-4592-a256-a1871353dbfa"
+      - tenantName: prod
+        tenantId: "1610b0c3-c509-4592-a256-a1871353dbfb"
+  template:
+    ingester:
+      replicas: 3
+    gateway:
+      enabled: true
+    queryFrontend:
+      jaegerQuery:
+        enabled: true

--- a/tests/e2e-openshift-tshirt-sizes/tshirt-size-override/chainsaw-test.yaml
+++ b/tests/e2e-openshift-tshirt-sizes/tshirt-size-override/chainsaw-test.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: tshirt-size-override
+spec:
+  steps:
+  - name: step-00
+    try:
+    - apply:
+        file: 00-install-storage.yaml
+    - assert:
+        file: 00-assert.yaml
+  - name: step-01
+    try:
+    - apply:
+        file: 01-install-tempo.yaml
+    - assert:
+        file: 01-assert.yaml

--- a/tests/e2e-openshift-tshirt-sizes/tshirt-size-pico/00-assert.yaml
+++ b/tests/e2e-openshift-tshirt-sizes/tshirt-size-pico/00-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+status:
+  readyReplicas: 1

--- a/tests/e2e-openshift-tshirt-sizes/tshirt-size-pico/00-install-storage.yaml
+++ b/tests/e2e-openshift-tshirt-sizes/tshirt-size-pico/00-install-storage.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: minio
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: minio
+    spec:
+      containers:
+        - command:
+            - /bin/sh
+            - -c
+            - |
+              mkdir -p /storage/tempo && \
+              minio server /storage
+          env:
+            - name: MINIO_ACCESS_KEY
+              value: tempo
+            - name: MINIO_SECRET_KEY
+              value: supersecret
+          image: quay.io/minio/minio:latest
+          name: minio
+          ports:
+            - containerPort: 9000
+          volumeMounts:
+            - mountPath: /storage
+              name: storage
+      volumes:
+        - name: storage
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+spec:
+  ports:
+    - port: 9000
+      protocol: TCP
+      targetPort: 9000
+  selector:
+    app.kubernetes.io/name: minio
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio-test
+stringData:
+  endpoint: http://minio:9000
+  bucket: tempo
+  access_key_id: tempo
+  access_key_secret: supersecret
+type: Opaque

--- a/tests/e2e-openshift-tshirt-sizes/tshirt-size-pico/01-assert.yaml
+++ b/tests/e2e-openshift-tshirt-sizes/tshirt-size-pico/01-assert.yaml
@@ -1,0 +1,109 @@
+# 1x.pico: small production workloads with HA support.
+# We only check spec configuration, not pod readiness, to allow running
+# on resource-constrained clusters.
+apiVersion: tempo.grafana.com/v1alpha1
+kind: TempoStack
+metadata:
+  name: pico
+spec:
+  replicationFactor: 2
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: tempo-pico-ingester
+spec:
+  replicas: 2
+  template:
+    spec:
+      containers:
+        - name: tempo
+          resources:
+            requests:
+              cpu: 500m
+              memory: 3Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tempo-pico-distributor
+spec:
+  template:
+    spec:
+      containers:
+        - name: tempo
+          resources:
+            requests:
+              cpu: 500m
+              memory: 500Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tempo-pico-querier
+spec:
+  template:
+    spec:
+      containers:
+        - name: tempo
+          resources:
+            requests:
+              cpu: 750m
+              memory: 1536Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tempo-pico-query-frontend
+spec:
+  template:
+    spec:
+      containers:
+        - name: tempo
+          resources:
+            requests:
+              cpu: 500m
+              memory: 500Mi
+        - name: jaeger-query
+          resources:
+            requests:
+              cpu: 100m
+              memory: 64Mi
+        - name: tempo-query
+          resources:
+            requests:
+              cpu: 500m
+              memory: 500Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tempo-pico-compactor
+spec:
+  template:
+    spec:
+      containers:
+        - name: tempo
+          resources:
+            requests:
+              cpu: 500m
+              memory: 500Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tempo-pico-gateway
+spec:
+  template:
+    spec:
+      containers:
+        - name: tempo-gateway
+          resources:
+            requests:
+              cpu: 100m
+              memory: 64Mi
+        - name: tempo-gateway-opa
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi

--- a/tests/e2e-openshift-tshirt-sizes/tshirt-size-pico/01-install-tempo.yaml
+++ b/tests/e2e-openshift-tshirt-sizes/tshirt-size-pico/01-install-tempo.yaml
@@ -1,0 +1,24 @@
+apiVersion: tempo.grafana.com/v1alpha1
+kind: TempoStack
+metadata:
+  name: pico
+spec:
+  size: 1x.pico
+  storage:
+    secret:
+      name: minio-test
+      type: s3
+  storageSize: 200M
+  tenants:
+    mode: openshift
+    authentication:
+      - tenantName: dev
+        tenantId: "1610b0c3-c509-4592-a256-a1871353dbfa"
+      - tenantName: prod
+        tenantId: "1610b0c3-c509-4592-a256-a1871353dbfb"
+  template:
+    gateway:
+      enabled: true
+    queryFrontend:
+      jaegerQuery:
+        enabled: true

--- a/tests/e2e-openshift-tshirt-sizes/tshirt-size-pico/chainsaw-test.yaml
+++ b/tests/e2e-openshift-tshirt-sizes/tshirt-size-pico/chainsaw-test.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: tshirt-size-pico
+spec:
+  steps:
+  - name: step-00
+    try:
+    - apply:
+        file: 00-install-storage.yaml
+    - assert:
+        file: 00-assert.yaml
+  - name: step-01
+    try:
+    - apply:
+        file: 01-install-tempo.yaml
+    - assert:
+        file: 01-assert.yaml

--- a/tests/e2e-openshift-tshirt-sizes/tshirt-size-small/00-assert.yaml
+++ b/tests/e2e-openshift-tshirt-sizes/tshirt-size-small/00-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+status:
+  readyReplicas: 1

--- a/tests/e2e-openshift-tshirt-sizes/tshirt-size-small/00-install-storage.yaml
+++ b/tests/e2e-openshift-tshirt-sizes/tshirt-size-small/00-install-storage.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: minio
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: minio
+    spec:
+      containers:
+        - command:
+            - /bin/sh
+            - -c
+            - |
+              mkdir -p /storage/tempo && \
+              minio server /storage
+          env:
+            - name: MINIO_ACCESS_KEY
+              value: tempo
+            - name: MINIO_SECRET_KEY
+              value: supersecret
+          image: quay.io/minio/minio:latest
+          name: minio
+          ports:
+            - containerPort: 9000
+          volumeMounts:
+            - mountPath: /storage
+              name: storage
+      volumes:
+        - name: storage
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+spec:
+  ports:
+    - port: 9000
+      protocol: TCP
+      targetPort: 9000
+  selector:
+    app.kubernetes.io/name: minio
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio-test
+stringData:
+  endpoint: http://minio:9000
+  bucket: tempo
+  access_key_id: tempo
+  access_key_secret: supersecret
+type: Opaque

--- a/tests/e2e-openshift-tshirt-sizes/tshirt-size-small/01-assert.yaml
+++ b/tests/e2e-openshift-tshirt-sizes/tshirt-size-small/01-assert.yaml
@@ -1,0 +1,109 @@
+# 1x.small: larger production workloads (~500GB/day) with HA support.
+# We only check spec configuration, not pod readiness, to allow running
+# on resource-constrained clusters.
+apiVersion: tempo.grafana.com/v1alpha1
+kind: TempoStack
+metadata:
+  name: small
+spec:
+  replicationFactor: 2
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: tempo-small-ingester
+spec:
+  replicas: 2
+  template:
+    spec:
+      containers:
+        - name: tempo
+          resources:
+            requests:
+              cpu: "2"
+              memory: 10Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tempo-small-distributor
+spec:
+  template:
+    spec:
+      containers:
+        - name: tempo
+          resources:
+            requests:
+              cpu: 600m
+              memory: 128Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tempo-small-querier
+spec:
+  template:
+    spec:
+      containers:
+        - name: tempo
+          resources:
+            requests:
+              cpu: 2500m
+              memory: 3Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tempo-small-query-frontend
+spec:
+  template:
+    spec:
+      containers:
+        - name: tempo
+          resources:
+            requests:
+              cpu: 400m
+              memory: 1Gi
+        - name: jaeger-query
+          resources:
+            requests:
+              cpu: 800m
+              memory: 192Mi
+        - name: tempo-query
+          resources:
+            requests:
+              cpu: 400m
+              memory: 1Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tempo-small-compactor
+spec:
+  template:
+    spec:
+      containers:
+        - name: tempo
+          resources:
+            requests:
+              cpu: 400m
+              memory: 6Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tempo-small-gateway
+spec:
+  template:
+    spec:
+      containers:
+        - name: tempo-gateway
+          resources:
+            requests:
+              cpu: 800m
+              memory: 192Mi
+        - name: tempo-gateway-opa
+          resources:
+            requests:
+              cpu: 100m
+              memory: 64Mi

--- a/tests/e2e-openshift-tshirt-sizes/tshirt-size-small/01-install-tempo.yaml
+++ b/tests/e2e-openshift-tshirt-sizes/tshirt-size-small/01-install-tempo.yaml
@@ -1,0 +1,24 @@
+apiVersion: tempo.grafana.com/v1alpha1
+kind: TempoStack
+metadata:
+  name: small
+spec:
+  size: 1x.small
+  storage:
+    secret:
+      name: minio-test
+      type: s3
+  storageSize: 200M
+  tenants:
+    mode: openshift
+    authentication:
+      - tenantName: dev
+        tenantId: "1610b0c3-c509-4592-a256-a1871353dbfa"
+      - tenantName: prod
+        tenantId: "1610b0c3-c509-4592-a256-a1871353dbfb"
+  template:
+    gateway:
+      enabled: true
+    queryFrontend:
+      jaegerQuery:
+        enabled: true

--- a/tests/e2e-openshift-tshirt-sizes/tshirt-size-small/chainsaw-test.yaml
+++ b/tests/e2e-openshift-tshirt-sizes/tshirt-size-small/chainsaw-test.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: tshirt-size-small
+spec:
+  steps:
+  - name: step-00
+    try:
+    - apply:
+        file: 00-install-storage.yaml
+    - assert:
+        file: 00-assert.yaml
+  - name: step-01
+    try:
+    - apply:
+        file: 01-install-tempo.yaml
+    - assert:
+        file: 01-assert.yaml


### PR DESCRIPTION
## Summary
- Adds a new `e2e-openshift-tshirt-sizes` test suite with 8 Chainsaw tests covering all TempoStack deployment size profiles (`1x.demo`, `1x.pico`, `1x.extra-small`, `1x.small`, `1x.medium`)
- Asserts resource requests for all 9 documented components: distributor, ingester, compactor, querier, query-frontend, gateway, gateway OPA, Jaeger UI, and OAuth proxy
- Adds `make e2e-openshift-tshirt-sizes` Makefile target

## Test scenarios

| Test | Size | What it verifies |
|------|------|------------------|
| `tshirt-size-demo` | `1x.demo` | RF=1, replicas=1, no resource requests (dev/demo) |
| `tshirt-size-pico` | `1x.pico` | RF=2, multitenancy with gateway, resources for all components |
| `tshirt-size-extra-small` | `1x.extra-small` | RF=2, multitenancy with gateway, extra-small resource profile |
| `tshirt-size-small` | `1x.small` | RF=2, multitenancy with gateway, small resource profile |
| `tshirt-size-medium` | `1x.medium` | RF=2, multitenancy with gateway, medium resource profile |
| `tshirt-size-invalid` | `1x.invalid` | Webhook rejects invalid size values |
| `tshirt-size-override` | `1x.pico` + RF=3 | Explicit RF/replicas override size defaults, resources from profile |
| `tshirt-size-oauth-proxy` | `1x.pico` | Single-tenant auth mode, OAuth proxy resources on query-frontend |

## Design decisions
- **Spec-level assertions**: Tests check Deployment/StatefulSet template specs (resource requests, replicas) rather than pod readiness (`status.readyReplicas`). This allows tests to pass on resource-constrained OCP clusters where larger sizes leave pods Pending.
- **Two deployment modes**: Multitenancy tests (gateway + OPA) cover 7 of 9 components. A separate single-tenant auth test covers the OAuth proxy, which is mutually exclusive with the gateway.
- **CPU quantity format**: Uses Kubernetes API-normalized values (`"1"` instead of `1000m`, `"2"` instead of `2000m`) since Chainsaw does string comparison.

## Test plan
- [x] All 8 tests pass on an OCP cluster
- [x] `make e2e-openshift-tshirt-sizes` runs the full suite
