### PR TITLE
OBSDA-1394: Support OCP ca-bundle.crt key in storage TLS CA ConfigMap

### DIFF
--- a/.chloggen/ocp-ca.yaml
+++ b/.chloggen/ocp-ca.yaml
@@ -1,0 +1,18 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. tempostack, tempomonolithic, github action)
+component: tempostack
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Support ca-bundle.crt key in storage TLS CA ConfigMap for OpenShift trusted CA bundle injection
+
+# One or more tracking issues related to the change
+issues: [1437]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  ConfigMaps labeled with config.openshift.io/inject-trusted-cabundle use the key ca-bundle.crt,
+  which is now recognized in addition to service-ca.crt and ca.crt.

--- a/.chloggen/ocp-ca.yaml
+++ b/.chloggen/ocp-ca.yaml
@@ -2,7 +2,7 @@
 change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. tempostack, tempomonolithic, github action)
-component: tempostack
+component: tempostack, tempomonolithic
 
 # A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Support ca-bundle.crt key in storage TLS CA ConfigMap for OpenShift trusted CA bundle injection

--- a/internal/controller/tempo/tempostack_controller_test.go
+++ b/internal/controller/tempo/tempostack_controller_test.go
@@ -497,7 +497,7 @@ func TestStorageCustomCA(t *testing.T) {
 		Status:             "True",
 		LastTransitionTime: updatedTempo2.Status.Conditions[0].LastTransitionTime,
 		Reason:             string(v1alpha1.ReasonInvalidStorageConfig),
-		Message:            "CA ConfigMap must contain a 'service-ca.crt' key",
+		Message:            "CA ConfigMap must contain a 'service-ca.crt', 'ca.crt', or 'ca-bundle.crt' key",
 	}}, updatedTempo2.Status.Conditions)
 
 	caConfigMap.Data = map[string]string{
@@ -517,7 +517,7 @@ func TestStorageCustomCA(t *testing.T) {
 			Status:             "False",
 			LastTransitionTime: updatedTempo3.Status.Conditions[0].LastTransitionTime,
 			Reason:             string(v1alpha1.ReasonInvalidStorageConfig),
-			Message:            "CA ConfigMap must contain a 'service-ca.crt' key",
+			Message:            "CA ConfigMap must contain a 'service-ca.crt', 'ca.crt', or 'ca-bundle.crt' key",
 		},
 		{
 			Type:               string(v1alpha1.ConditionReady),

--- a/internal/handlers/storage/tls.go
+++ b/internal/handlers/storage/tls.go
@@ -57,5 +57,10 @@ func getCAConfigMapKey(caConfigMap corev1.ConfigMap, path *field.Path) (string, 
 		return manifestutils.StorageTLSCAFilename, nil
 	}
 
-	return "", field.ErrorList{field.Invalid(path, caConfigMap.Name, fmt.Sprintf("CA ConfigMap must contain a '%s' key", manifestutils.TLSCAFilename))}
+	// OpenShift injects CA bundles under this key when the ConfigMap is labeled with config.openshift.io/inject-trusted-cabundle: "true"
+	if caConfigMap.Data[manifestutils.OpenshiftTrustedCABundleFilename] != "" {
+		return manifestutils.OpenshiftTrustedCABundleFilename, nil
+	}
+
+	return "", field.ErrorList{field.Invalid(path, caConfigMap.Name, fmt.Sprintf("CA ConfigMap must contain a '%s', '%s', or '%s' key", manifestutils.TLSCAFilename, manifestutils.StorageTLSCAFilename, manifestutils.OpenshiftTrustedCABundleFilename))}
 }

--- a/internal/handlers/storage/tls_test.go
+++ b/internal/handlers/storage/tls_test.go
@@ -1,0 +1,70 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"github.com/grafana/tempo-operator/internal/manifests/manifestutils"
+)
+
+func TestGetCAConfigMapKey(t *testing.T) {
+	path := field.NewPath("spec", "storage", "tls", "caName")
+
+	tests := []struct {
+		name        string
+		data        map[string]string
+		expectedKey string
+		expectErr   bool
+	}{
+		{
+			name:        "service-ca.crt key",
+			data:        map[string]string{manifestutils.TLSCAFilename: "cert-data"},
+			expectedKey: manifestutils.TLSCAFilename,
+		},
+		{
+			name:        "ca.crt key (backwards compatibility)",
+			data:        map[string]string{manifestutils.StorageTLSCAFilename: "cert-data"},
+			expectedKey: manifestutils.StorageTLSCAFilename,
+		},
+		{
+			name:        "ca-bundle.crt key (OpenShift injected CA bundle)",
+			data:        map[string]string{manifestutils.OpenshiftTrustedCABundleFilename: "cert-data"},
+			expectedKey: manifestutils.OpenshiftTrustedCABundleFilename,
+		},
+		{
+			name:        "service-ca.crt takes precedence over ca-bundle.crt",
+			data:        map[string]string{manifestutils.TLSCAFilename: "cert-data", manifestutils.OpenshiftTrustedCABundleFilename: "cert-data"},
+			expectedKey: manifestutils.TLSCAFilename,
+		},
+		{
+			name:      "no recognized key",
+			data:      map[string]string{"other-key": "cert-data"},
+			expectErr: true,
+		},
+		{
+			name:      "empty configmap",
+			data:      map[string]string{},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cm := corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-ca"},
+				Data:       tt.data,
+			}
+			key, errs := getCAConfigMapKey(cm, path)
+			if tt.expectErr {
+				assert.NotEmpty(t, errs)
+			} else {
+				assert.Empty(t, errs)
+				assert.Equal(t, tt.expectedKey, key)
+			}
+		})
+	}
+}

--- a/internal/manifests/manifestutils/constants.go
+++ b/internal/manifests/manifestutils/constants.go
@@ -163,6 +163,8 @@ const (
 
 	// StorageTLSCAFilename is the key name of the CA file in the ConfigMap for accessing object storage.
 	StorageTLSCAFilename = "ca.crt"
+	// OpenshiftTrustedCABundleFilename is the key name used by OpenShift's automatic CA bundle injection.
+	OpenshiftTrustedCABundleFilename = "ca-bundle.crt"
 
 	tokenAuthConfigVolumeName       = "token-auth-config"       //#nosec G101 -- False positive
 	tokenAuthConfigDirectory        = "/etc/storage/token-auth" //#nosec G101 -- False positive

--- a/internal/webhooks/tempostack_webhook_test.go
+++ b/internal/webhooks/tempostack_webhook_test.go
@@ -1298,7 +1298,7 @@ func TestValidateStorageCAConfigMap(t *testing.T) {
 				},
 			},
 			expected: field.ErrorList{
-				field.Invalid(path, "test", "CA ConfigMap must contain a 'service-ca.crt' key"),
+				field.Invalid(path, "test", "CA ConfigMap must contain a 'service-ca.crt', 'ca.crt', or 'ca-bundle.crt' key"),
 			},
 		},
 		{


### PR DESCRIPTION
https://redhat.atlassian.net/browse/OBSDA-1394  

 The change is minimal: it adds ca-bundle.crt as a third recognized key name in the getCAConfigMapKey() function, alongside the existing service-ca.crt and ca.crt.                                                                                                                                     
                                                                                                                                                                                                                                                                                                         
  How it works for the user:                                                                                                                                                                                                                                                                             
   ```
  1. Create a ConfigMap with the OpenShift CA injection label:                                                                                                                                                                                                                                           
  apiVersion: v1                                            
  kind: ConfigMap                                                                                                                                                                                                                                                                                        
  metadata:                                                 
    name: trusted-ca
    labels:                                                                                                                                                                                                                                                                                              
      config.openshift.io/inject-trusted-cabundle: "true"                                                                                                                                                                                                                                                
  2. Reference it in the TempoStack CR:                                                                                                                                                                                                                                                                  
  spec:                                                                                                                                                                                                                                                                                                  
    storage:                                                
      tls:                                                                                                                                                                                                                                                                                               
        enabled: true                                                                                                                                                                                                                                                                                    
        caName: trusted-ca
```
                                                                                                                                                                                                                                          
  That's it. OpenShift automatically populates the ConfigMap with a ca-bundle.crt key containing the cluster's trusted CA certificates. Previously the operator would reject this ConfigMap because it didn't contain service-ca.crt or ca.crt. Now it recognizes ca-bundle.crt as well.                 
   
  No additional configuration is needed beyond what users were already trying to do. The key benefit is eliminating the manual workaround of copying/renaming the certificate key every time the CA rotates.                                                                                             
                                                            



> how the operator recognizes that the config map comes from the OCP and has the ca bundle?                                                                                                                                                                                                              
                                                                                             
 It doesn't. The operator doesn't detect OpenShift or inspect ConfigMap labels at all. It simply looks at which data keys are present in whatever ConfigMap the user points to via spec.storage.tls.caName.                                                                                             
                                                            
  The lookup order in getCAConfigMapKey() is:                                                                                                                                                                                                                                                            
  1. Has service-ca.crt key? Use it.
  2. Has ca.crt key? Use it.                                                                                                                                                                                                                                                                             
  3. Has ca-bundle.crt key? Use it.                         
  4. None found? Return error.                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                         
 So this change isn't OpenShift-specific in implementation ? it just happens to solve the OpenShift use case because ca-bundle.crt is the key name OpenShift injects. A user could also manually create a ConfigMap with a ca-bundle.crt key on vanilla Kubernetes and it would work the same way.      
     