### PR TITLE
Fix race condition in certificate hash annotation update

### DIFF
--- a/internal/certrotation/handlers/rotate_certs.go
+++ b/internal/certrotation/handlers/rotate_certs.go
@@ -11,6 +11,8 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -116,6 +118,14 @@ func addCertificateHashAnnotations(ctx context.Context, k client.Client, stack *
 		certSecrets[name] = cert.Secret
 	}
 
-	stack.Annotations = labels.Merge(stack.Annotations, manifestutils.CertificateHashAnnotations(certSecrets))
-	return k.Update(ctx, stack)
+	hashAnnotations := manifestutils.CertificateHashAnnotations(certSecrets)
+
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		current := &v1alpha1.TempoStack{}
+		if err := k.Get(ctx, types.NamespacedName{Name: stack.Name, Namespace: stack.Namespace}, current); err != nil {
+			return err
+		}
+		current.Annotations = labels.Merge(current.Annotations, hashAnnotations)
+		return k.Update(ctx, current)
+	})
 }

--- a/internal/manifests/monolithic/certificates.go
+++ b/internal/manifests/monolithic/certificates.go
@@ -10,6 +10,8 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -118,6 +120,14 @@ func addCertificateHashAnnotationsMonolithic(ctx context.Context, k client.Clien
 		certSecrets[name] = cert.Secret
 	}
 
-	stack.Annotations = labels.Merge(stack.Annotations, manifestutils.CertificateHashAnnotations(certSecrets))
-	return k.Update(ctx, stack)
+	hashAnnotations := manifestutils.CertificateHashAnnotations(certSecrets)
+
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		current := &v1alpha1.TempoMonolithic{}
+		if err := k.Get(ctx, types.NamespacedName{Name: stack.Name, Namespace: stack.Namespace}, current); err != nil {
+			return err
+		}
+		current.Annotations = labels.Merge(current.Annotations, hashAnnotations)
+		return k.Update(ctx, current)
+	})
 }

--- a/tests/e2e/compatibility/chainsaw-test.yaml
+++ b/tests/e2e/compatibility/chainsaw-test.yaml
@@ -20,9 +20,17 @@ spec:
         file: 01-assert.yaml
   - name: step-02
     try:
-    - script:
+    - assert:
         timeout: 5m
-        content: kubectl get --namespace $NAMESPACE tempo simplest -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' | grep True
+        resource:
+          apiVersion: tempo.grafana.com/v1alpha1
+          kind: TempoStack
+          metadata:
+            name: simplest
+          status:
+            conditions:
+            - type: Ready
+              status: "True"
   - name: step-03
     try:
     - apply:

--- a/tests/e2e/compatibility/chainsaw-test.yaml
+++ b/tests/e2e/compatibility/chainsaw-test.yaml
@@ -20,17 +20,9 @@ spec:
         file: 01-assert.yaml
   - name: step-02
     try:
-    - assert:
+    - script:
         timeout: 5m
-        resource:
-          apiVersion: tempo.grafana.com/v1alpha1
-          kind: TempoStack
-          metadata:
-            name: simplest
-          status:
-            conditions:
-            - type: Ready
-              status: "True"
+        content: kubectl get --namespace $NAMESPACE tempo simplest -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' | grep True
   - name: step-03
     try:
     - apply:

--- a/tests/e2e/tshirt-size-pico/chainsaw-test.yaml
+++ b/tests/e2e/tshirt-size-pico/chainsaw-test.yaml
@@ -16,4 +16,5 @@ spec:
     - apply:
         file: 01-install-tempo.yaml
     - assert:
+        timeout: 5m
         file: 01-assert.yaml


### PR DESCRIPTION
## Problem

The `e2e/compatibility` test was flaky due to a race condition in `addCertificateHashAnnotations()`. The function updated the TempoStack object using a stale copy fetched at the beginning of the reconciliation loop. If the TempoStack was modified between the initial `Get` and the annotation `Update` (e.g. by a concurrent status update), the update failed with a resource version conflict:

```
built in cert manager error: failed to add certificate hash annotations:
Operation cannot be fulfilled on tempostacks.tempo.grafana.com "simplest":
the object has been modified; please apply your changes to the latest version and try again
```

This conflict error was not retried — it propagated up to `handleReconcileStatus`, which treated it as a generic error and set a `FailedReconciliation` condition on the TempoStack. Although the controller would eventually requeue and succeed, the transient `Failed` condition caused assertion timing issues in e2e tests.

## Fix

- Wrap the TempoStack annotation update in `retry.RetryOnConflict` with a fresh `Get` before each retry attempt, so resource version conflicts are handled gracefully instead of surfacing as reconciliation failures.
- Increase the assert timeout for the `tshirt-size-pico` e2e test to 5 minutes to account for slow CI environments.