### PR TITLE
[Chore] Add e2e tests for MCP server feature

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -8,7 +8,7 @@ COPY . /tmp/tempo-operator
 WORKDIR /tmp
 
 # Install dependencies required by test cases and debugging
-RUN apt-get update && apt-get install -y jq vim libreadline-dev unzip
+RUN apt-get update && apt-get install -y jq vim libreadline-dev unzip python3
 
 # Install kuttl
 RUN curl -LO https://github.com/kudobuilder/kuttl/releases/download/v0.15.0/kubectl-kuttl_0.15.0_linux_x86_64 \
@@ -39,6 +39,9 @@ RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
 RUN curl -LO https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-linux-x86_64.tar.gz \
     && tar -xf google-cloud-cli-linux-x86_64.tar.gz \
     && ./google-cloud-sdk/install.sh -q
+
+# Install IBM Cloud CLI
+RUN curl -fsSL https://clis.cloud.ibm.com/install/linux | bash
 
 # Add gcloud to PATH
 ENV PATH="/tmp/google-cloud-sdk/bin:${PATH}"

--- a/tests/e2e/mcp-monolithic/01-assert.yaml
+++ b/tests/e2e/mcp-monolithic/01-assert.yaml
@@ -1,0 +1,65 @@
+apiVersion: tempo.grafana.com/v1alpha1
+kind: TempoMonolithic
+metadata:
+  name: simplest
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: tempo-simplest
+  labels:
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo-monolithic
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: simplest
+      app.kubernetes.io/managed-by: tempo-operator
+      app.kubernetes.io/name: tempo-monolithic
+status:
+  readyReplicas: 1
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: tempo-simplest-0
+status:
+  containerStatuses:
+  - name: jaeger-query
+    ready: true
+    started: true
+  - name: tempo
+    ready: true
+    started: true
+  - name: tempo-query
+    ready: true
+    started: true
+  phase: Running
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo-monolithic
+  name: tempo-simplest
+spec:
+  ports:
+  - name: http
+    port: 3200
+    protocol: TCP
+    targetPort: http
+  - name: otlp-grpc
+    port: 4317
+    protocol: TCP
+    targetPort: otlp-grpc
+  - name: otlp-http
+    port: 4318
+    protocol: TCP
+    targetPort: otlp-http
+  selector:
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo-monolithic

--- a/tests/e2e/mcp-monolithic/01-install-tempo.yaml
+++ b/tests/e2e/mcp-monolithic/01-install-tempo.yaml
@@ -1,0 +1,10 @@
+apiVersion: tempo.grafana.com/v1alpha1
+kind: TempoMonolithic
+metadata:
+  name: simplest
+spec:
+  jaegerui:
+    enabled: true
+  query:
+    mcpServer:
+      enabled: true

--- a/tests/e2e/mcp-monolithic/04-assert.yaml
+++ b/tests/e2e/mcp-monolithic/04-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: generate-traces
+status:
+  succeeded: 1

--- a/tests/e2e/mcp-monolithic/04-generate-traces.yaml
+++ b/tests/e2e/mcp-monolithic/04-generate-traces.yaml
@@ -1,0 +1,17 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: generate-traces
+spec:
+  template:
+    spec:
+      containers:
+      - name: telemetrygen
+        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
+        args:
+        - traces
+        - --otlp-endpoint=tempo-simplest:4317
+        - --otlp-insecure
+        - --traces=10
+      restartPolicy: Never
+  backoffLimit: 4

--- a/tests/e2e/mcp-monolithic/05-assert.yaml
+++ b/tests/e2e/mcp-monolithic/05-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify-mcp
+status:
+  succeeded: 1

--- a/tests/e2e/mcp-monolithic/05-verify-mcp.yaml
+++ b/tests/e2e/mcp-monolithic/05-verify-mcp.yaml
@@ -1,0 +1,112 @@
+# Verify the MCP server responds correctly to the initialize handshake.
+# Validates:
+#   - HTTP 200 from /api/mcp
+#   - result.serverInfo present in the response (handles both JSON and SSE body format)
+#   - notifications/initialized acknowledged (HTTP 200 or 202)
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify-mcp
+spec:
+  template:
+    spec:
+      containers:
+      - name: verify-mcp
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - /bin/bash
+        - -eux
+        - -c
+        args:
+        - |
+          TEMPO_MCP_URL="http://tempo-simplest:3200/api/mcp"
+
+          # Extract the first JSON object from a response that may be plain JSON
+          # or SSE format ("data: {...}\n\n").
+          extract_json() {
+            local file="$1"
+            if grep -q "^data:" "$file" 2>/dev/null; then
+              grep "^data:" "$file" | grep -v "^data: \[DONE\]" | head -1 | sed 's/^data: //'
+            else
+              cat "$file"
+            fi
+          }
+
+          echo "=== MCP initialize ==="
+          init_body=$(mktemp)
+          init_headers=$(mktemp)
+          http_status=$(curl -s \
+            -X POST \
+            -H "Content-Type: application/json" \
+            -H "Accept: application/json, text/event-stream" \
+            -D "${init_headers}" \
+            -o "${init_body}" \
+            -w "%{http_code}" \
+            --max-time 30 \
+            "${TEMPO_MCP_URL}" \
+            -d '{
+              "jsonrpc": "2.0",
+              "method": "initialize",
+              "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "e2e-test", "version": "1.0.0"}
+              },
+              "id": 1
+            }')
+
+          echo "initialize HTTP status: ${http_status}"
+          echo "initialize response headers:"
+          cat "${init_headers}"
+          echo "initialize response body:"
+          cat "${init_body}"
+
+          if [[ "${http_status}" -ne 200 ]]; then
+            echo "ERROR: initialize returned HTTP ${http_status}, expected 200"
+            exit 1
+          fi
+
+          init_json=$(extract_json "${init_body}")
+          if ! echo "${init_json}" | jq -e '.result.serverInfo' > /dev/null 2>&1; then
+            echo "ERROR: initialize response missing result.serverInfo"
+            echo "Parsed JSON: ${init_json}"
+            exit 1
+          fi
+
+          echo "serverInfo: $(echo "${init_json}" | jq '.result.serverInfo')"
+
+          # Capture session ID if the server issued one (optional per spec).
+          SESSION_ID=$(grep -i "^mcp-session-id:" "${init_headers}" \
+                       | tr -d '\r' | awk '{print $2}' || true)
+          echo "Session ID: '${SESSION_ID}'"
+
+          SESSION_ARGS=()
+          if [[ -n "${SESSION_ID}" ]]; then
+            SESSION_ARGS=("-H" "Mcp-Session-Id: ${SESSION_ID}")
+          fi
+
+          echo "=== MCP notifications/initialized ==="
+          notif_body=$(mktemp)
+          notif_status=$(curl -s \
+            -X POST \
+            -H "Content-Type: application/json" \
+            -H "Accept: application/json, text/event-stream" \
+            "${SESSION_ARGS[@]}" \
+            -o "${notif_body}" \
+            -w "%{http_code}" \
+            --max-time 30 \
+            "${TEMPO_MCP_URL}" \
+            -d '{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}')
+
+          echo "notifications/initialized HTTP status: ${notif_status}"
+          cat "${notif_body}"
+
+          # Spec allows 200 (empty body) or 202 (accepted) for notifications.
+          if [[ "${notif_status}" -ne 200 && "${notif_status}" -ne 202 ]]; then
+            echo "ERROR: notifications/initialized returned HTTP ${notif_status}"
+            exit 1
+          fi
+
+          echo "SUCCESS: MCP server handshake complete"
+      restartPolicy: Never
+  backoffLimit: 4

--- a/tests/e2e/mcp-monolithic/06-assert.yaml
+++ b/tests/e2e/mcp-monolithic/06-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify-mcp-tools
+status:
+  succeeded: 1

--- a/tests/e2e/mcp-monolithic/06-verify-mcp-tools.yaml
+++ b/tests/e2e/mcp-monolithic/06-verify-mcp-tools.yaml
@@ -1,0 +1,192 @@
+# Verify MCP tools/list exposes traceql-search and that traceql-search returns
+# trace data for the traces generated in step-04.
+# Each job starts a fresh MCP session (initialize + notifications/initialized)
+# before calling any tool, as required by the Streamable HTTP transport spec.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify-mcp-tools
+spec:
+  template:
+    spec:
+      containers:
+      - name: verify-mcp-tools
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - /bin/bash
+        - -eux
+        - -c
+        args:
+        - |
+          TEMPO_MCP_URL="http://tempo-simplest:3200/api/mcp"
+
+          # Extract the first JSON object from a response that may be plain JSON
+          # or SSE format ("data: {...}\n\n").
+          extract_json() {
+            local file="$1"
+            if grep -q "^data:" "$file" 2>/dev/null; then
+              grep "^data:" "$file" | grep -v "^data: \[DONE\]" | head -1 | sed 's/^data: //'
+            else
+              cat "$file"
+            fi
+          }
+
+          # ---- Open MCP session ----
+          echo "=== MCP initialize ==="
+          init_body=$(mktemp)
+          init_headers=$(mktemp)
+          http_status=$(curl -s \
+            -X POST \
+            -H "Content-Type: application/json" \
+            -H "Accept: application/json, text/event-stream" \
+            -D "${init_headers}" \
+            -o "${init_body}" \
+            -w "%{http_code}" \
+            --max-time 30 \
+            "${TEMPO_MCP_URL}" \
+            -d '{
+              "jsonrpc": "2.0",
+              "method": "initialize",
+              "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "e2e-test", "version": "1.0.0"}
+              },
+              "id": 1
+            }')
+
+          echo "initialize HTTP status: ${http_status}"
+          cat "${init_body}"
+
+          if [[ "${http_status}" -ne 200 ]]; then
+            echo "ERROR: initialize returned HTTP ${http_status}"
+            exit 1
+          fi
+
+          SESSION_ID=$(grep -i "^mcp-session-id:" "${init_headers}" \
+                       | tr -d '\r' | awk '{print $2}' || true)
+          echo "Session ID: '${SESSION_ID}'"
+
+          SESSION_ARGS=()
+          if [[ -n "${SESSION_ID}" ]]; then
+            SESSION_ARGS=("-H" "Mcp-Session-Id: ${SESSION_ID}")
+          fi
+
+          echo "=== MCP notifications/initialized ==="
+          notif_body=$(mktemp)
+          notif_status=$(curl -s \
+            -X POST \
+            -H "Content-Type: application/json" \
+            -H "Accept: application/json, text/event-stream" \
+            "${SESSION_ARGS[@]}" \
+            -o "${notif_body}" \
+            -w "%{http_code}" \
+            --max-time 30 \
+            "${TEMPO_MCP_URL}" \
+            -d '{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}')
+
+          echo "notifications/initialized HTTP status: ${notif_status}"
+          if [[ "${notif_status}" -ne 200 && "${notif_status}" -ne 202 ]]; then
+            echo "ERROR: notifications/initialized returned HTTP ${notif_status}"
+            exit 1
+          fi
+
+          # ---- tools/list: verify traceql-search is advertised ----
+          echo "=== MCP tools/list ==="
+          tools_body=$(mktemp)
+          http_status=$(curl -s \
+            -X POST \
+            -H "Content-Type: application/json" \
+            -H "Accept: application/json, text/event-stream" \
+            "${SESSION_ARGS[@]}" \
+            -o "${tools_body}" \
+            -w "%{http_code}" \
+            --max-time 30 \
+            "${TEMPO_MCP_URL}" \
+            -d '{"jsonrpc":"2.0","method":"tools/list","params":{},"id":2}')
+
+          echo "tools/list HTTP status: ${http_status}"
+          cat "${tools_body}"
+
+          if [[ "${http_status}" -ne 200 ]]; then
+            echo "ERROR: tools/list returned HTTP ${http_status}"
+            exit 1
+          fi
+
+          tools_json=$(extract_json "${tools_body}")
+
+          # Fail hard on JSON-RPC errors.
+          if echo "${tools_json}" | jq -e '.error' > /dev/null 2>&1; then
+            echo "ERROR: tools/list returned a JSON-RPC error:"
+            echo "${tools_json}" | jq '.error'
+            exit 1
+          fi
+
+          # The traceql-search tool must be advertised.
+          if ! echo "${tools_json}" | jq -e '.result.tools[] | select(.name == "traceql-search")' > /dev/null 2>&1; then
+            echo "ERROR: traceql-search not found in tools/list"
+            echo "Available tools:"
+            echo "${tools_json}" | jq -r '.result.tools[].name'
+            exit 1
+          fi
+
+          echo "SUCCESS: traceql-search tool is advertised"
+
+          # ---- tools/call traceql-search: verify trace data is returned ----
+          echo "=== MCP tools/call traceql-search ==="
+          search_body=$(mktemp)
+          http_status=$(curl -s \
+            -X POST \
+            -H "Content-Type: application/json" \
+            -H "Accept: application/json, text/event-stream" \
+            "${SESSION_ARGS[@]}" \
+            -o "${search_body}" \
+            -w "%{http_code}" \
+            --max-time 30 \
+            "${TEMPO_MCP_URL}" \
+            -d '{
+              "jsonrpc": "2.0",
+              "method": "tools/call",
+              "params": {
+                "name": "traceql-search",
+                "arguments": {"query": "{}"}
+              },
+              "id": 3
+            }')
+
+          echo "traceql-search HTTP status: ${http_status}"
+          cat "${search_body}"
+
+          if [[ "${http_status}" -ne 200 ]]; then
+            echo "ERROR: tools/call traceql-search returned HTTP ${http_status}"
+            exit 1
+          fi
+
+          search_json=$(extract_json "${search_body}")
+
+          # Fail on JSON-RPC protocol errors.
+          if echo "${search_json}" | jq -e '.error' > /dev/null 2>&1; then
+            echo "ERROR: traceql-search returned a JSON-RPC error:"
+            echo "${search_json}" | jq '.error'
+            exit 1
+          fi
+
+          # MCP tool errors are signalled via isError:true in the result.
+          if echo "${search_json}" | jq -e '.result.isError == true' > /dev/null 2>&1; then
+            echo "ERROR: traceql-search returned isError:true"
+            echo "${search_json}" | jq '.result.content'
+            exit 1
+          fi
+
+          # The result content must be non-empty — traces were ingested in step-04.
+          content_text=$(echo "${search_json}" | jq -r '.result.content[0].text // empty')
+          if [[ -z "${content_text}" ]]; then
+            echo "ERROR: traceql-search returned empty content; expected traces from step-04"
+            exit 1
+          fi
+
+          echo "traceql-search content:"
+          echo "${content_text}"
+          echo "SUCCESS: traceql-search returned trace data"
+      restartPolicy: Never
+  backoffLimit: 4

--- a/tests/e2e/mcp-monolithic/chainsaw-test.yaml
+++ b/tests/e2e/mcp-monolithic/chainsaw-test.yaml
@@ -1,0 +1,46 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: mcp-monolithic
+spec:
+  steps:
+  - name: step-01
+    try:
+    - apply:
+        file: 01-install-tempo.yaml
+    - assert:
+        file: 01-assert.yaml
+  - name: step-02
+    try:
+    - script:
+        timeout: 5m
+        content: |
+          kubectl get --namespace $NAMESPACE tempomonolithic simplest \
+            -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' | grep True
+  - name: step-03
+    try:
+    - script:
+        timeout: 2m
+        content: |
+          kubectl get --namespace $NAMESPACE configmap tempo-simplest-config \
+            -o jsonpath='{.data.tempo\.yaml}' | grep -q "mcp_server"
+  - name: step-04
+    try:
+    - apply:
+        file: 04-generate-traces.yaml
+    - assert:
+        file: 04-assert.yaml
+  - name: step-05
+    try:
+    - apply:
+        file: 05-verify-mcp.yaml
+    - assert:
+        file: 05-assert.yaml
+  - name: step-06
+    try:
+    - apply:
+        file: 06-verify-mcp-tools.yaml
+    - assert:
+        file: 06-assert.yaml

--- a/tests/e2e/mcp-tempostack/00-assert.yaml
+++ b/tests/e2e/mcp-tempostack/00-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+status:
+  readyReplicas: 1

--- a/tests/e2e/mcp-tempostack/00-install-storage.yaml
+++ b/tests/e2e/mcp-tempostack/00-install-storage.yaml
@@ -1,0 +1,75 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app.kubernetes.io/name: minio
+  name: minio
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: minio
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: minio
+    spec:
+      containers:
+        - command:
+            - /bin/sh
+            - -c
+            - |
+              mkdir -p /storage/tempo && \
+              minio server /storage
+          env:
+            - name: MINIO_ACCESS_KEY
+              value: tempo
+            - name: MINIO_SECRET_KEY
+              value: supersecret
+          image: quay.io/minio/minio:latest
+          name: minio
+          ports:
+            - containerPort: 9000
+          volumeMounts:
+            - mountPath: /storage
+              name: storage
+      volumes:
+        - name: storage
+          persistentVolumeClaim:
+            claimName: minio
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+spec:
+  ports:
+    - port: 9000
+      protocol: TCP
+      targetPort: 9000
+  selector:
+    app.kubernetes.io/name: minio
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio
+stringData:
+  endpoint: http://minio:9000
+  bucket: tempo
+  access_key_id: tempo
+  access_key_secret: supersecret
+type: Opaque

--- a/tests/e2e/mcp-tempostack/01-assert.yaml
+++ b/tests/e2e/mcp-tempostack/01-assert.yaml
@@ -1,0 +1,136 @@
+apiVersion: tempo.grafana.com/v1alpha1
+kind: TempoStack
+metadata:
+  name: simplest
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tempo-simplest-query-frontend
+  labels:
+    app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: query-frontend
+      app.kubernetes.io/instance: simplest
+      app.kubernetes.io/managed-by: tempo-operator
+      app.kubernetes.io/name: tempo
+status:
+  readyReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tempo-simplest-distributor
+  labels:
+    app.kubernetes.io/component: distributor
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: distributor
+      app.kubernetes.io/instance: simplest
+      app.kubernetes.io/managed-by: tempo-operator
+      app.kubernetes.io/name: tempo
+status:
+  readyReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tempo-simplest-querier
+  labels:
+    app.kubernetes.io/component: querier
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: querier
+      app.kubernetes.io/instance: simplest
+      app.kubernetes.io/managed-by: tempo-operator
+      app.kubernetes.io/name: tempo
+status:
+  readyReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tempo-simplest-compactor
+  labels:
+    app.kubernetes.io/component: compactor
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: compactor
+      app.kubernetes.io/instance: simplest
+      app.kubernetes.io/managed-by: tempo-operator
+      app.kubernetes.io/name: tempo
+status:
+  readyReplicas: 1
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: tempo-simplest-ingester
+  labels:
+    app.kubernetes.io/component: ingester
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: ingester
+      app.kubernetes.io/instance: simplest
+      app.kubernetes.io/managed-by: tempo-operator
+      app.kubernetes.io/name: tempo
+status:
+  readyReplicas: 1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+  name: tempo-simplest-query-frontend
+spec:
+  ports:
+    - name: http
+      port: 3200
+      protocol: TCP
+      targetPort: http
+    - name: grpc
+      port: 9095
+      protocol: TCP
+      targetPort: grpc
+    - name: jaeger-grpc
+      port: 16685
+      protocol: TCP
+      targetPort: jaeger-grpc
+    - name: jaeger-ui
+      port: 16686
+      protocol: TCP
+      targetPort: jaeger-ui
+    - name: jaeger-metrics
+      port: 16687
+      protocol: TCP
+      targetPort: jaeger-metrics
+  selector:
+    app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo

--- a/tests/e2e/mcp-tempostack/01-install-tempo.yaml
+++ b/tests/e2e/mcp-tempostack/01-install-tempo.yaml
@@ -1,0 +1,23 @@
+apiVersion: tempo.grafana.com/v1alpha1
+kind: TempoStack
+metadata:
+  name: simplest
+spec:
+  storage:
+    secret:
+      name: minio
+      type: s3
+  storageSize: 200M
+  resources:
+    total:
+      limits:
+        memory: 2Gi
+        cpu: 2000m
+  template:
+    queryFrontend:
+      jaegerQuery:
+        enabled: true
+        ingress:
+          type: ingress
+      mcpServer:
+        enabled: true

--- a/tests/e2e/mcp-tempostack/04-assert.yaml
+++ b/tests/e2e/mcp-tempostack/04-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: generate-traces
+status:
+  succeeded: 1

--- a/tests/e2e/mcp-tempostack/04-generate-traces.yaml
+++ b/tests/e2e/mcp-tempostack/04-generate-traces.yaml
@@ -1,0 +1,17 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: generate-traces
+spec:
+  template:
+    spec:
+      containers:
+      - name: telemetrygen
+        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
+        args:
+        - traces
+        - --otlp-endpoint=tempo-simplest-distributor:4317
+        - --otlp-insecure
+        - --traces=10
+      restartPolicy: Never
+  backoffLimit: 4

--- a/tests/e2e/mcp-tempostack/05-assert.yaml
+++ b/tests/e2e/mcp-tempostack/05-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify-mcp
+status:
+  succeeded: 1

--- a/tests/e2e/mcp-tempostack/05-verify-mcp.yaml
+++ b/tests/e2e/mcp-tempostack/05-verify-mcp.yaml
@@ -1,0 +1,112 @@
+# Verify the MCP server responds correctly to the initialize handshake.
+# Validates:
+#   - HTTP 200 from /api/mcp
+#   - result.serverInfo present in the response (handles both JSON and SSE body format)
+#   - notifications/initialized acknowledged (HTTP 200 or 202)
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify-mcp
+spec:
+  template:
+    spec:
+      containers:
+      - name: verify-mcp
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - /bin/bash
+        - -eux
+        - -c
+        args:
+        - |
+          TEMPO_MCP_URL="http://tempo-simplest-query-frontend:3200/api/mcp"
+
+          # Extract the first JSON object from a response that may be plain JSON
+          # or SSE format ("data: {...}\n\n").
+          extract_json() {
+            local file="$1"
+            if grep -q "^data:" "$file" 2>/dev/null; then
+              grep "^data:" "$file" | grep -v "^data: \[DONE\]" | head -1 | sed 's/^data: //'
+            else
+              cat "$file"
+            fi
+          }
+
+          echo "=== MCP initialize ==="
+          init_body=$(mktemp)
+          init_headers=$(mktemp)
+          http_status=$(curl -s \
+            -X POST \
+            -H "Content-Type: application/json" \
+            -H "Accept: application/json, text/event-stream" \
+            -D "${init_headers}" \
+            -o "${init_body}" \
+            -w "%{http_code}" \
+            --max-time 30 \
+            "${TEMPO_MCP_URL}" \
+            -d '{
+              "jsonrpc": "2.0",
+              "method": "initialize",
+              "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "e2e-test", "version": "1.0.0"}
+              },
+              "id": 1
+            }')
+
+          echo "initialize HTTP status: ${http_status}"
+          echo "initialize response headers:"
+          cat "${init_headers}"
+          echo "initialize response body:"
+          cat "${init_body}"
+
+          if [[ "${http_status}" -ne 200 ]]; then
+            echo "ERROR: initialize returned HTTP ${http_status}, expected 200"
+            exit 1
+          fi
+
+          init_json=$(extract_json "${init_body}")
+          if ! echo "${init_json}" | jq -e '.result.serverInfo' > /dev/null 2>&1; then
+            echo "ERROR: initialize response missing result.serverInfo"
+            echo "Parsed JSON: ${init_json}"
+            exit 1
+          fi
+
+          echo "serverInfo: $(echo "${init_json}" | jq '.result.serverInfo')"
+
+          # Capture session ID if the server issued one (optional per spec).
+          SESSION_ID=$(grep -i "^mcp-session-id:" "${init_headers}" \
+                       | tr -d '\r' | awk '{print $2}' || true)
+          echo "Session ID: '${SESSION_ID}'"
+
+          SESSION_ARGS=()
+          if [[ -n "${SESSION_ID}" ]]; then
+            SESSION_ARGS=("-H" "Mcp-Session-Id: ${SESSION_ID}")
+          fi
+
+          echo "=== MCP notifications/initialized ==="
+          notif_body=$(mktemp)
+          notif_status=$(curl -s \
+            -X POST \
+            -H "Content-Type: application/json" \
+            -H "Accept: application/json, text/event-stream" \
+            "${SESSION_ARGS[@]}" \
+            -o "${notif_body}" \
+            -w "%{http_code}" \
+            --max-time 30 \
+            "${TEMPO_MCP_URL}" \
+            -d '{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}')
+
+          echo "notifications/initialized HTTP status: ${notif_status}"
+          cat "${notif_body}"
+
+          # Spec allows 200 (empty body) or 202 (accepted) for notifications.
+          if [[ "${notif_status}" -ne 200 && "${notif_status}" -ne 202 ]]; then
+            echo "ERROR: notifications/initialized returned HTTP ${notif_status}"
+            exit 1
+          fi
+
+          echo "SUCCESS: MCP server handshake complete"
+      restartPolicy: Never
+  backoffLimit: 4

--- a/tests/e2e/mcp-tempostack/06-assert.yaml
+++ b/tests/e2e/mcp-tempostack/06-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify-mcp-tools
+status:
+  succeeded: 1

--- a/tests/e2e/mcp-tempostack/06-verify-mcp-tools.yaml
+++ b/tests/e2e/mcp-tempostack/06-verify-mcp-tools.yaml
@@ -1,0 +1,192 @@
+# Verify MCP tools/list exposes traceql-search and that traceql-search returns
+# trace data for the traces generated in step-04.
+# Each job starts a fresh MCP session (initialize + notifications/initialized)
+# before calling any tool, as required by the Streamable HTTP transport spec.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify-mcp-tools
+spec:
+  template:
+    spec:
+      containers:
+      - name: verify-mcp-tools
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - /bin/bash
+        - -eux
+        - -c
+        args:
+        - |
+          TEMPO_MCP_URL="http://tempo-simplest-query-frontend:3200/api/mcp"
+
+          # Extract the first JSON object from a response that may be plain JSON
+          # or SSE format ("data: {...}\n\n").
+          extract_json() {
+            local file="$1"
+            if grep -q "^data:" "$file" 2>/dev/null; then
+              grep "^data:" "$file" | grep -v "^data: \[DONE\]" | head -1 | sed 's/^data: //'
+            else
+              cat "$file"
+            fi
+          }
+
+          # ---- Open MCP session ----
+          echo "=== MCP initialize ==="
+          init_body=$(mktemp)
+          init_headers=$(mktemp)
+          http_status=$(curl -s \
+            -X POST \
+            -H "Content-Type: application/json" \
+            -H "Accept: application/json, text/event-stream" \
+            -D "${init_headers}" \
+            -o "${init_body}" \
+            -w "%{http_code}" \
+            --max-time 30 \
+            "${TEMPO_MCP_URL}" \
+            -d '{
+              "jsonrpc": "2.0",
+              "method": "initialize",
+              "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "e2e-test", "version": "1.0.0"}
+              },
+              "id": 1
+            }')
+
+          echo "initialize HTTP status: ${http_status}"
+          cat "${init_body}"
+
+          if [[ "${http_status}" -ne 200 ]]; then
+            echo "ERROR: initialize returned HTTP ${http_status}"
+            exit 1
+          fi
+
+          SESSION_ID=$(grep -i "^mcp-session-id:" "${init_headers}" \
+                       | tr -d '\r' | awk '{print $2}' || true)
+          echo "Session ID: '${SESSION_ID}'"
+
+          SESSION_ARGS=()
+          if [[ -n "${SESSION_ID}" ]]; then
+            SESSION_ARGS=("-H" "Mcp-Session-Id: ${SESSION_ID}")
+          fi
+
+          echo "=== MCP notifications/initialized ==="
+          notif_body=$(mktemp)
+          notif_status=$(curl -s \
+            -X POST \
+            -H "Content-Type: application/json" \
+            -H "Accept: application/json, text/event-stream" \
+            "${SESSION_ARGS[@]}" \
+            -o "${notif_body}" \
+            -w "%{http_code}" \
+            --max-time 30 \
+            "${TEMPO_MCP_URL}" \
+            -d '{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}')
+
+          echo "notifications/initialized HTTP status: ${notif_status}"
+          if [[ "${notif_status}" -ne 200 && "${notif_status}" -ne 202 ]]; then
+            echo "ERROR: notifications/initialized returned HTTP ${notif_status}"
+            exit 1
+          fi
+
+          # ---- tools/list: verify traceql-search is advertised ----
+          echo "=== MCP tools/list ==="
+          tools_body=$(mktemp)
+          http_status=$(curl -s \
+            -X POST \
+            -H "Content-Type: application/json" \
+            -H "Accept: application/json, text/event-stream" \
+            "${SESSION_ARGS[@]}" \
+            -o "${tools_body}" \
+            -w "%{http_code}" \
+            --max-time 30 \
+            "${TEMPO_MCP_URL}" \
+            -d '{"jsonrpc":"2.0","method":"tools/list","params":{},"id":2}')
+
+          echo "tools/list HTTP status: ${http_status}"
+          cat "${tools_body}"
+
+          if [[ "${http_status}" -ne 200 ]]; then
+            echo "ERROR: tools/list returned HTTP ${http_status}"
+            exit 1
+          fi
+
+          tools_json=$(extract_json "${tools_body}")
+
+          # Fail hard on JSON-RPC errors.
+          if echo "${tools_json}" | jq -e '.error' > /dev/null 2>&1; then
+            echo "ERROR: tools/list returned a JSON-RPC error:"
+            echo "${tools_json}" | jq '.error'
+            exit 1
+          fi
+
+          # The traceql-search tool must be advertised.
+          if ! echo "${tools_json}" | jq -e '.result.tools[] | select(.name == "traceql-search")' > /dev/null 2>&1; then
+            echo "ERROR: traceql-search not found in tools/list"
+            echo "Available tools:"
+            echo "${tools_json}" | jq -r '.result.tools[].name'
+            exit 1
+          fi
+
+          echo "SUCCESS: traceql-search tool is advertised"
+
+          # ---- tools/call traceql-search: verify trace data is returned ----
+          echo "=== MCP tools/call traceql-search ==="
+          search_body=$(mktemp)
+          http_status=$(curl -s \
+            -X POST \
+            -H "Content-Type: application/json" \
+            -H "Accept: application/json, text/event-stream" \
+            "${SESSION_ARGS[@]}" \
+            -o "${search_body}" \
+            -w "%{http_code}" \
+            --max-time 30 \
+            "${TEMPO_MCP_URL}" \
+            -d '{
+              "jsonrpc": "2.0",
+              "method": "tools/call",
+              "params": {
+                "name": "traceql-search",
+                "arguments": {"query": "{}"}
+              },
+              "id": 3
+            }')
+
+          echo "traceql-search HTTP status: ${http_status}"
+          cat "${search_body}"
+
+          if [[ "${http_status}" -ne 200 ]]; then
+            echo "ERROR: tools/call traceql-search returned HTTP ${http_status}"
+            exit 1
+          fi
+
+          search_json=$(extract_json "${search_body}")
+
+          # Fail on JSON-RPC protocol errors.
+          if echo "${search_json}" | jq -e '.error' > /dev/null 2>&1; then
+            echo "ERROR: traceql-search returned a JSON-RPC error:"
+            echo "${search_json}" | jq '.error'
+            exit 1
+          fi
+
+          # MCP tool errors are signalled via isError:true in the result.
+          if echo "${search_json}" | jq -e '.result.isError == true' > /dev/null 2>&1; then
+            echo "ERROR: traceql-search returned isError:true"
+            echo "${search_json}" | jq '.result.content'
+            exit 1
+          fi
+
+          # The result content must be non-empty — traces were ingested in step-04.
+          content_text=$(echo "${search_json}" | jq -r '.result.content[0].text // empty')
+          if [[ -z "${content_text}" ]]; then
+            echo "ERROR: traceql-search returned empty content; expected traces from step-04"
+            exit 1
+          fi
+
+          echo "traceql-search content:"
+          echo "${content_text}"
+          echo "SUCCESS: traceql-search returned trace data"
+      restartPolicy: Never
+  backoffLimit: 4

--- a/tests/e2e/mcp-tempostack/chainsaw-test.yaml
+++ b/tests/e2e/mcp-tempostack/chainsaw-test.yaml
@@ -1,0 +1,52 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: mcp-tempostack
+spec:
+  steps:
+  - name: step-00
+    try:
+    - apply:
+        file: 00-install-storage.yaml
+    - assert:
+        file: 00-assert.yaml
+  - name: step-01
+    try:
+    - apply:
+        file: 01-install-tempo.yaml
+    - assert:
+        file: 01-assert.yaml
+  - name: step-02
+    try:
+    - script:
+        timeout: 5m
+        content: |
+          kubectl get --namespace $NAMESPACE tempostack simplest \
+            -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' | grep True
+  - name: step-03
+    try:
+    - script:
+        timeout: 2m
+        content: |
+          kubectl get --namespace $NAMESPACE configmap tempo-simplest \
+            -o jsonpath='{.data.tempo\.yaml}' | grep -q "mcp_server"
+  - name: step-04
+    try:
+    - apply:
+        file: 04-generate-traces.yaml
+    - assert:
+        file: 04-assert.yaml
+  - name: step-05
+    try:
+    - apply:
+        file: 05-verify-mcp.yaml
+    - assert:
+        file: 05-assert.yaml
+  - name: step-06
+    try:
+    - apply:
+        file: 06-verify-mcp-tools.yaml
+    - assert:
+        file: 06-assert.yaml


### PR DESCRIPTION
## Summary

- Add Chainsaw e2e tests for the MCP (Model Context Protocol) server feature covering both `TempoMonolithic` and `TempoStack` deployments
- Update `tests/Dockerfile` to include ibm cloud CLI and Python 3 as dependencies. 

## Test coverage

### `tests/e2e/mcp-monolithic`
Validates the MCP server on a `TempoMonolithic` instance:
- **step-01**: Deploy `TempoMonolithic` with `mcpServer.enabled: true`, assert StatefulSet, Pod, and Service are ready
- **step-02**: Wait for `Ready=True` condition on the CR
- **step-03**: Verify the generated ConfigMap (`tempo-simplest-config`) contains the `mcp_server` stanza
- **step-04**: Ingest 10 traces via `telemetrygen` over OTLP gRPC
- **step-05**: Run MCP `initialize` handshake against `/api/mcp`, verify HTTP 200 and `result.serverInfo`; send `notifications/initialized` and accept HTTP 200/202
- **step-06**: Open a fresh MCP session, call `tools/list` and assert the `traceql-search` tool is advertised; call `tools/call traceql-search` with `{"query":"{}"}` and verify non-empty trace content is returned

### `tests/e2e/mcp-tempostack`
Validates the MCP server on a `TempoStack` instance (distributed deployment with MinIO object storage):
- **step-00**: Deploy MinIO as local S3-compatible object storage
- **step-01**: Deploy `TempoStack` with `template.queryFrontend.mcpServer.enabled: true`, assert all 5 deployments (query-frontend, distributor, querier, compactor) and the ingester StatefulSet are ready
- **step-02**: Wait for `Ready=True` condition on the CR
- **step-03**: Verify the generated ConfigMap (`tempo-simplest`) contains the `mcp_server` stanza
- **step-04**: Ingest 10 traces via `telemetrygen`
- **step-05**: MCP `initialize` handshake against the query-frontend service
- **step-06**: `tools/list` and `tools/call traceql-search` verification as above

Both suites validate the full MCP Streamable HTTP transport protocol flow: session initialization, session ID tracking via `Mcp-Session-Id` header, and tool invocation with result content validation.

## Test plan
- [x] Ran `mcp-monolithic` against an OCP cluster with the operator from the `mcp` branch — PASS (103s)
- [x] Ran `mcp-tempostack` against an OCP cluster with the operator from the `mcp` branch — PASS (165s)