### PR TITLE
[chore] harden CI and follow GitHub Actions best practices

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -65,6 +65,23 @@ jobs:
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
 
+  # Diffs dependency changes in a PR and flags new CVEs or incompatible licenses.
+  dependency-review:
+    name: Dependency review
+    runs-on: ubuntu-22.04
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      pull-requests: write # to post findings as a PR comment
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Dependency review
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+
   lint:
     name: Code standards (linting)
     runs-on: ubuntu-22.04

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -75,10 +75,13 @@ jobs:
 
     - name: Start a local container registry with TLS
       run: |
-        # install mkcert
-        curl -JLO "https://dl.filippo.io/mkcert/latest?for=linux/amd64"
-        chmod +x mkcert-v*-linux-amd64
-        sudo cp mkcert-v*-linux-amd64 /usr/local/bin/mkcert
+        # install mkcert with pinned version and checksum for reproducible builds
+        MKCERT_VERSION=v1.4.4
+        MKCERT_SHA256=6d31c65b03972c6dc4a14ab429f2928300518b26503f58723e532d1b0a3bbb52
+        curl -sLo mkcert "https://github.com/FiloSottile/mkcert/releases/download/${MKCERT_VERSION}/mkcert-${MKCERT_VERSION}-linux-amd64"
+        echo "${MKCERT_SHA256}  mkcert" | sha256sum -c
+        chmod +x mkcert
+        sudo cp mkcert /usr/local/bin/mkcert
 
         # create and install root CA in system store
         sudo mkcert -install

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -32,7 +32,7 @@ jobs:
         with:
           repository: ${{ env.OPERATOR_BOT_USER }}/${{ github.event.repository.name }}
           token: ${{ secrets.TEMPOOPERATORBOT_GITHUB_TOKEN }}
-          persist-credentials: true
+          persist-credentials: false
 
 
       - name: Set up Go
@@ -64,6 +64,7 @@ jobs:
           git checkout -b releases/${VERSION}
           git add -A
           git commit -m "Prepare Release ${VERSION}" --author="${ACTOR} <${ACTOR}@users.noreply.github.com>"
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${OPERATOR_BOT_USER}/${REPOSITORY_NAME}"
           git push -f --set-upstream origin releases/${VERSION}
           gh pr create --title="Prepare release v${VERSION}" --body=v${VERSION} --repo ${{ github.repository }}
 
@@ -71,3 +72,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.TEMPOOPERATORBOT_GITHUB_TOKEN }}
           VERSION: ${{ inputs.version }}
           ACTOR: ${{ github.actor }}
+          REPOSITORY_NAME: ${{ github.event.repository.name }}

--- a/.github/workflows/reusable-operator-hub-release.yaml
+++ b/.github/workflows/reusable-operator-hub-release.yaml
@@ -46,7 +46,7 @@ jobs:
         with:
           repository: tempooperatorbot/${{ inputs.repo }}
           token: ${{ secrets.TEMPOOPERATORBOT_GITHUB_TOKEN }}
-          persist-credentials: true
+          persist-credentials: false
 
       - name: Checkout tempo-operator to tmp/ directory
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -95,5 +95,6 @@ jobs:
           git checkout -b $branch
           git add -A
           git commit -s -m "$message"
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/tempooperatorbot/${REPO}"
           git push -f --set-upstream origin $branch
           gh pr create --title "$message" --body "$body" --repo ${ORG}/${REPO} --base main


### PR DESCRIPTION
- Add `dependency-review` job to flag new CVEs and incompatible licenses on PRs
- Pin mkcert to v1.4.4 with SHA256 checksum verification in e2e upgrade tests
- Set `persist-credentials: false` on bot checkouts in `prepare-release` and
  `reusable-operator-hub-release`; inject token via `git remote set-url` just
  before push so credentials are not left in git config for the job lifetime