### PR TITLE
Bump Tempo to 2.10.5 and observatorium/api gateway

### DIFF
--- a/.chloggen/bump-observatorium-api.yaml
+++ b/.chloggen/bump-observatorium-api.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. tempostack, tempomonolithic, github action)
+component: operator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Bump observatorium/api gateway image to main-2026-05-19-489f301
+
+# One or more tracking issues related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/bump-observatorium-api.yaml
+++ b/.chloggen/bump-observatorium-api.yaml
@@ -8,7 +8,7 @@ component: operator
 note: Bump observatorium/api gateway image to main-2026-05-19-489f301
 
 # One or more tracking issues related to the change
-issues: []
+issues: [1459]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/bump-tempo-2.10.5.yaml
+++ b/.chloggen/bump-tempo-2.10.5.yaml
@@ -8,7 +8,7 @@ component: operator
 note: Bump Tempo to 2.10.5
 
 # One or more tracking issues related to the change
-issues: []
+issues: [1459]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/bump-tempo-2.10.5.yaml
+++ b/.chloggen/bump-tempo-2.10.5.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. tempostack, tempomonolithic, github action)
+component: operator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Bump Tempo to 2.10.5
+
+# One or more tracking issues related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Current Operator version
 OPERATOR_VERSION ?= 0.20.0
-TEMPO_VERSION ?= 2.10.0
+TEMPO_VERSION ?= 2.10.5
 JAEGER_QUERY_VERSION ?= 1.68.0
 TEMPO_QUERY_VERSION ?= $(TEMPO_VERSION)
 # https://quay.io/repository/observatorium/api

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ TEMPO_VERSION ?= 2.10.5
 JAEGER_QUERY_VERSION ?= 1.68.0
 TEMPO_QUERY_VERSION ?= $(TEMPO_VERSION)
 # https://quay.io/repository/observatorium/api
-TEMPO_GATEWAY_VERSION ?= main-2026-03-02-4f749a8
+TEMPO_GATEWAY_VERSION ?= main-2026-05-19-489f301
 # https://quay.io/repository/observatorium/opa-openshift
 TEMPO_GATEWAY_OPA_VERSION ?= main-2025-06-16-ecdeca0
 OAUTH_PROXY_VERSION=4.14

--- a/bundle/community/manifests/tempo-operator.clusterserviceversion.yaml
+++ b/bundle/community/manifests/tempo-operator.clusterserviceversion.yaml
@@ -1717,11 +1717,11 @@ spec:
                 - start
                 env:
                 - name: RELATED_IMAGE_TEMPO
-                  value: docker.io/grafana/tempo:2.10.0
+                  value: docker.io/grafana/tempo:2.10.5
                 - name: RELATED_IMAGE_JAEGER_QUERY
                   value: docker.io/jaegertracing/jaeger-query:1.68.0
                 - name: RELATED_IMAGE_TEMPO_QUERY
-                  value: docker.io/grafana/tempo-query:2.10.0
+                  value: docker.io/grafana/tempo-query:2.10.5
                 - name: RELATED_IMAGE_TEMPO_GATEWAY
                   value: quay.io/observatorium/api:main-2026-03-02-4f749a8
                 - name: RELATED_IMAGE_TEMPO_GATEWAY_OPA
@@ -1840,11 +1840,11 @@ spec:
   provider:
     name: Grafana Tempo Operator SIG
   relatedImages:
-  - image: docker.io/grafana/tempo:2.10.0
+  - image: docker.io/grafana/tempo:2.10.5
     name: tempo
   - image: docker.io/jaegertracing/jaeger-query:1.68.0
     name: jaeger-query
-  - image: docker.io/grafana/tempo-query:2.10.0
+  - image: docker.io/grafana/tempo-query:2.10.5
     name: tempo-query
   - image: quay.io/observatorium/api:main-2026-03-02-4f749a8
     name: tempo-gateway

--- a/bundle/community/manifests/tempo-operator.clusterserviceversion.yaml
+++ b/bundle/community/manifests/tempo-operator.clusterserviceversion.yaml
@@ -1723,7 +1723,7 @@ spec:
                 - name: RELATED_IMAGE_TEMPO_QUERY
                   value: docker.io/grafana/tempo-query:2.10.5
                 - name: RELATED_IMAGE_TEMPO_GATEWAY
-                  value: quay.io/observatorium/api:main-2026-03-02-4f749a8
+                  value: quay.io/observatorium/api:main-2026-05-19-489f301
                 - name: RELATED_IMAGE_TEMPO_GATEWAY_OPA
                   value: quay.io/observatorium/opa-openshift:main-2025-06-16-ecdeca0
                 - name: RELATED_IMAGE_OAUTH_PROXY
@@ -1846,7 +1846,7 @@ spec:
     name: jaeger-query
   - image: docker.io/grafana/tempo-query:2.10.5
     name: tempo-query
-  - image: quay.io/observatorium/api:main-2026-03-02-4f749a8
+  - image: quay.io/observatorium/api:main-2026-05-19-489f301
     name: tempo-gateway
   - image: quay.io/observatorium/opa-openshift:main-2025-06-16-ecdeca0
     name: tempo-gateway-opa

--- a/bundle/openshift/manifests/tempo-operator.clusterserviceversion.yaml
+++ b/bundle/openshift/manifests/tempo-operator.clusterserviceversion.yaml
@@ -1728,11 +1728,11 @@ spec:
                 - --metrics-tls-cert-dir=/var/run/tls/server/
                 env:
                 - name: RELATED_IMAGE_TEMPO
-                  value: docker.io/grafana/tempo:2.10.0
+                  value: docker.io/grafana/tempo:2.10.5
                 - name: RELATED_IMAGE_JAEGER_QUERY
                   value: docker.io/jaegertracing/jaeger-query:1.68.0
                 - name: RELATED_IMAGE_TEMPO_QUERY
-                  value: docker.io/grafana/tempo-query:2.10.0
+                  value: docker.io/grafana/tempo-query:2.10.5
                 - name: RELATED_IMAGE_TEMPO_GATEWAY
                   value: quay.io/observatorium/api:main-2026-03-02-4f749a8
                 - name: RELATED_IMAGE_TEMPO_GATEWAY_OPA
@@ -1863,11 +1863,11 @@ spec:
   provider:
     name: Grafana Tempo Operator SIG
   relatedImages:
-  - image: docker.io/grafana/tempo:2.10.0
+  - image: docker.io/grafana/tempo:2.10.5
     name: tempo
   - image: docker.io/jaegertracing/jaeger-query:1.68.0
     name: jaeger-query
-  - image: docker.io/grafana/tempo-query:2.10.0
+  - image: docker.io/grafana/tempo-query:2.10.5
     name: tempo-query
   - image: quay.io/observatorium/api:main-2026-03-02-4f749a8
     name: tempo-gateway

--- a/bundle/openshift/manifests/tempo-operator.clusterserviceversion.yaml
+++ b/bundle/openshift/manifests/tempo-operator.clusterserviceversion.yaml
@@ -1734,7 +1734,7 @@ spec:
                 - name: RELATED_IMAGE_TEMPO_QUERY
                   value: docker.io/grafana/tempo-query:2.10.5
                 - name: RELATED_IMAGE_TEMPO_GATEWAY
-                  value: quay.io/observatorium/api:main-2026-03-02-4f749a8
+                  value: quay.io/observatorium/api:main-2026-05-19-489f301
                 - name: RELATED_IMAGE_TEMPO_GATEWAY_OPA
                   value: quay.io/observatorium/opa-openshift:main-2025-06-16-ecdeca0
                 - name: RELATED_IMAGE_OAUTH_PROXY
@@ -1869,7 +1869,7 @@ spec:
     name: jaeger-query
   - image: docker.io/grafana/tempo-query:2.10.5
     name: tempo-query
-  - image: quay.io/observatorium/api:main-2026-03-02-4f749a8
+  - image: quay.io/observatorium/api:main-2026-05-19-489f301
     name: tempo-gateway
   - image: quay.io/observatorium/opa-openshift:main-2025-06-16-ecdeca0
     name: tempo-gateway-opa

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -44,7 +44,7 @@ spec:
         - name: RELATED_IMAGE_TEMPO_QUERY
           value: docker.io/grafana/tempo-query:2.10.5
         - name: RELATED_IMAGE_TEMPO_GATEWAY
-          value: quay.io/observatorium/api:main-2026-03-02-4f749a8
+          value: quay.io/observatorium/api:main-2026-05-19-489f301
         - name: RELATED_IMAGE_TEMPO_GATEWAY_OPA
           value: quay.io/observatorium/opa-openshift:main-2025-06-16-ecdeca0
         - name: RELATED_IMAGE_OAUTH_PROXY

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -38,11 +38,11 @@ spec:
         image: controller:latest
         env:
         - name: RELATED_IMAGE_TEMPO
-          value: docker.io/grafana/tempo:2.10.0
+          value: docker.io/grafana/tempo:2.10.5
         - name: RELATED_IMAGE_JAEGER_QUERY
           value: docker.io/jaegertracing/jaeger-query:1.68.0
         - name: RELATED_IMAGE_TEMPO_QUERY
-          value: docker.io/grafana/tempo-query:2.10.0
+          value: docker.io/grafana/tempo-query:2.10.5
         - name: RELATED_IMAGE_TEMPO_GATEWAY
           value: quay.io/observatorium/api:main-2026-03-02-4f749a8
         - name: RELATED_IMAGE_TEMPO_GATEWAY_OPA


### PR DESCRIPTION
## Summary

- Bump Tempo from `2.10.0` to `2.10.5` (latest stable patch in the 2.10.x line).
- Bump `observatorium/api` gateway image from `main-2026-03-02-4f749a8` to `main-2026-05-19-489f301` (15 commits ahead).
- Updates `Makefile`, `config/manager/manager.yaml`, and both community/openshift CSV bundles.
- Adds chloggen entries.

## Tempo 2.10.0 → 2.10.5 compatibility review

Reviewed each patch in the 2.10.x series against the operator's config generation:

- **2.10.1** — Go 1.25.7 + bug fixes. No config impact.
- **2.10.2** — Changed default `max_result_limit` to 256*1024. Operator does not set this field, so the new default applies transparently.
- **2.10.3** — SSE-C `encryption_key` now treated as a secret (CVE-2026-28377). Operator does not generate SSE-C config, so no impact.
- **2.10.4** — Added `--frontend.mcp-server.enabled=true` CLI flag as an alternative way to enable MCP. The operator already configures MCP via the existing `query_frontend.mcp_server.enabled` YAML key, which is unchanged.
- **2.10.5** — Internal Go dependency bump only. No impact.

## observatorium/api gateway bump

Diff between the two SHAs (15 commits):
- `Use SystemCertPool for OpenShift OAuth token exchange`
- New `/silence/{silenceID}` endpoint on alertmanager
- Dependency bumps (grpc, otel, go-jose, oapi-codegen)
- e2e test stability fixes

No breaking changes for how the operator consumes the gateway.

## Test plan

- [x] `go build ./...` succeeds
- [x] `make test` — all manifest, config, controller, upgrade, gateway, and webhook unit tests pass
- [ ] CI checks