### PR TITLE
fix: mark managementState and tenants.mode optional

### DIFF
--- a/.chloggen/optional-defaulted-required-fields.yaml
+++ b/.chloggen/optional-defaulted-required-fields.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. tempostack, tempomonolithic, github action)
+component: tempostack
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Mark `spec.managementState` and `spec.tenants.mode` optional so they are no longer listed as required in the generated CRDs. Both have defaults, so offline validators (e.g. kubeconform) no longer reject valid resources that omit them.
+
+# One or more tracking issues related to the change
+issues: [1491]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/api/tempo/v1alpha1/auth.go
+++ b/api/tempo/v1alpha1/auth.go
@@ -19,11 +19,11 @@ const (
 type TenantsSpec struct {
 	// Mode defines the multitenancy mode.
 	//
-	// +required
-	// +kubebuilder:validation:Required
+	// +optional
+	// +kubebuilder:validation:Optional
 	// +kubebuilder:default:=static
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:select:static","urn:alm:descriptor:com.tectonic.ui:select:openshift"},displayName="Mode"
-	Mode ModeType `json:"mode"`
+	Mode ModeType `json:"mode,omitempty"`
 
 	// Authentication defines the tempo-gateway component authentication configuration spec per tenant.
 	//

--- a/api/tempo/v1alpha1/tempostack_types.go
+++ b/api/tempo/v1alpha1/tempostack_types.go
@@ -53,8 +53,8 @@ type TempoStackSpec struct {
 	// ManagementState defines if the CR should be managed by the operator or not.
 	// Default is managed.
 	//
-	// +required
-	// +kubebuilder:validation:Required
+	// +optional
+	// +kubebuilder:validation:Optional
 	// +kubebuilder:default:=Managed
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:select:Managed","urn:alm:descriptor:com.tectonic.ui:select:Unmanaged"},displayName="Management State"
 	ManagementState ManagementStateType `json:"managementState,omitempty"`

--- a/bundle/community/manifests/tempo.grafana.com_tempomonolithics.yaml
+++ b/bundle/community/manifests/tempo.grafana.com_tempomonolithics.yaml
@@ -1769,7 +1769,6 @@ spec:
                     type: object
                 required:
                 - enabled
-                - mode
                 type: object
               nodeSelector:
                 additionalProperties:

--- a/bundle/community/manifests/tempo.grafana.com_tempostacks.yaml
+++ b/bundle/community/manifests/tempo.grafana.com_tempostacks.yaml
@@ -3429,8 +3429,6 @@ spec:
                     - static
                     - openshift
                     type: string
-                required:
-                - mode
                 type: object
               timeout:
                 description: |-
@@ -3439,7 +3437,6 @@ spec:
                   Defaults to 30 seconds.
                 type: string
             required:
-            - managementState
             - storage
             type: object
           status:

--- a/bundle/openshift/manifests/tempo.grafana.com_tempomonolithics.yaml
+++ b/bundle/openshift/manifests/tempo.grafana.com_tempomonolithics.yaml
@@ -1769,7 +1769,6 @@ spec:
                     type: object
                 required:
                 - enabled
-                - mode
                 type: object
               nodeSelector:
                 additionalProperties:

--- a/bundle/openshift/manifests/tempo.grafana.com_tempostacks.yaml
+++ b/bundle/openshift/manifests/tempo.grafana.com_tempostacks.yaml
@@ -3429,8 +3429,6 @@ spec:
                     - static
                     - openshift
                     type: string
-                required:
-                - mode
                 type: object
               timeout:
                 description: |-
@@ -3439,7 +3437,6 @@ spec:
                   Defaults to 30 seconds.
                 type: string
             required:
-            - managementState
             - storage
             type: object
           status:

--- a/config/crd/bases/tempo.grafana.com_tempomonolithics.yaml
+++ b/config/crd/bases/tempo.grafana.com_tempomonolithics.yaml
@@ -1765,7 +1765,6 @@ spec:
                     type: object
                 required:
                 - enabled
-                - mode
                 type: object
               nodeSelector:
                 additionalProperties:

--- a/config/crd/bases/tempo.grafana.com_tempostacks.yaml
+++ b/config/crd/bases/tempo.grafana.com_tempostacks.yaml
@@ -3425,8 +3425,6 @@ spec:
                     - static
                     - openshift
                     type: string
-                required:
-                - mode
                 type: object
               timeout:
                 description: |-
@@ -3435,7 +3433,6 @@ spec:
                   Defaults to 30 seconds.
                 type: string
             required:
-            - managementState
             - storage
             type: object
           status:


### PR DESCRIPTION
## Description

`TempoStackSpec.ManagementState` and `TenantsSpec.Mode` each declare a `+kubebuilder:default` (`Managed` and `static` respectively) **and** are marked `+required` / `+kubebuilder:validation:Required`. A field that the API server always populates via structural-schema defaulting cannot meaningfully be a required *input*.

The practical effect is that static schema validators that don't apply defaults — e.g. `kubeconform`, used widely in GitOps/CI pipelines — reject otherwise-valid resources that omit these fields:

```
TempoStack foo is invalid: jsonschema validation failed
  - at '/spec': missing property 'managementState'
  - at '/spec/tenants': missing property 'mode'
```

These resources apply cleanly and run correctly against a live cluster (the API server defaults the fields before validation) — only offline validators trip on them.

## Changes

- Mark `ManagementState` and `Mode` `+optional` / `+kubebuilder:validation:Optional`, keeping their `+kubebuilder:default` markers.
- Add `omitempty` to the `Mode` json tag for consistency with other optional+defaulted fields (e.g. `ManagementState`).
- Regenerate CRDs and OLM bundle manifests.

Behaviour is unchanged: the API server still defaults both fields to `Managed` / `static`. The only difference is the generated CRD no longer lists them under `required`, so `TempoStack` and `TempoMonolithic` (which shares `TenantsSpec`) validate cleanly with offline tooling.

The diff is limited strictly to the two markers and the `required` lists they drive in the generated manifests.