### PR TITLE
[Chore] Add Claude Code CLI standalone binary to Dockerfile used by OCP CI.

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -91,6 +91,16 @@ RUN curl -fsSL "https://download.clis.cloud.ibm.com/ibm-cloud-cli-dn/${IBM_CLI_V
 # Add gcloud to PATH
 ENV PATH="/tmp/google-cloud-sdk/bin:${PATH}"
 
+# Install Claude Code CLI via signed apt repository
+RUN install -d -m 0755 /etc/apt/keyrings \
+    && curl -fsSL https://downloads.claude.ai/keys/claude-code.asc \
+         -o /etc/apt/keyrings/claude-code.asc \
+    && echo "deb [signed-by=/etc/apt/keyrings/claude-code.asc] https://downloads.claude.ai/claude-code/apt/stable stable main" \
+         > /etc/apt/sources.list.d/claude-code.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends claude-code \
+    && rm -rf /var/lib/apt/lists/*
+
 # Switch to non-root before the build step.
 # chown /tmp/tempo-operator: COPY above ran as root; make build writes bin/ inside this dir.
 # chown /tmp/google-cloud-sdk: install.sh writes update configs back here at runtime.


### PR DESCRIPTION
## Summary

- Adds Claude Code CLI to `tests/Dockerfile` using Anthropic's official signed apt repository
- Registers the signed apt repo at `https://downloads.claude.ai/claude-code/apt/stable` and installs the `claude-code` package
- Package manager installation ensures GPG signature verification is handled natively by apt — no manual key import or hardcoded checksums required
- Placed before the `USER tempo` switch so the binary lands in root-owned `/usr/bin`
- The `claude` binary is installed to `/usr/bin/claude` and is globally accessible to all users

## Test plan

- [x] `tests/Dockerfile` built successfully with `podman build --platform=linux/amd64`
- [x] `claude --version` confirmed working inside the container (`2.1.153 (Claude Code)`)
- [x] Binary available at `/usr/bin/claude`

🤖 Generated with [Claude Code](https://claude.com/claude-code)