### PR TITLE
[Chore]: update operator-metrics thresholds and chainsaw apply timeout

### DIFF
--- a/.chainsaw-openshift.yaml
+++ b/.chainsaw-openshift.yaml
@@ -10,4 +10,4 @@ spec:
     delete: 5m00s
     error: 5m00s
     exec: 5m00s
-    apply: 10s
+    apply: 30s

--- a/tests/operator-metrics/max-loops/01-verify-metrics.yaml
+++ b/tests/operator-metrics/max-loops/01-verify-metrics.yaml
@@ -13,7 +13,7 @@ spec:
             - name: TEMPOMONOLITHIC_THRESHOLD
               value: "1000"
             - name: TEMPOSTACK_THRESHOLD
-              value: "1000"
+              value: "2500"
           command:
             - /bin/bash
             - -eux


### PR DESCRIPTION
## Summary

- **Raise `TEMPOSTACK_THRESHOLD`** from 1000 → 2500 in `tests/operator-metrics/max-loops/01-verify-metrics.yaml`. The old threshold predates several new test suites added after this test was written. Observed peak across the full OpenShift e2e test suite run was 2051; new value includes ~20% headroom.
- **Increase chainsaw `apply` timeout** from 10s → 30s in `.chainsaw-openshift.yaml` to prevent spurious `context deadline exceeded` failures when the API server is under load during concurrent test suite runs.

## Test plan

- [ ] Run `chainsaw test --test-dir ./tests/operator-metrics --config .chainsaw-openshift.yaml` after a full e2e suite run and confirm the job exits 0
- [ ] Confirm no regressions in other test suites (apply steps no longer time out prematurely)