### PR TITLE
[Chore] e2e-openshift-tls-profile): wait for MCP stabilization before chainsaw cleanup in 03-tls-profile

### DIFF
--- a/tests/e2e-openshift-tls-profile/03-tls-profile/11-revert-apiserver.sh
+++ b/tests/e2e-openshift-tls-profile/03-tls-profile/11-revert-apiserver.sh
@@ -4,9 +4,56 @@ oc patch apiserver cluster --type json \
   -p '[{"op":"remove","path":"/spec/tlsSecurityProfile"}]'
 echo "APIServer TLS profile reverted to default (nil)"
 
-# Wait for the operator to restart and its webhook to become available.
-# The APIServer revert triggers SecurityProfileWatcher to restart the operator,
-# and chainsaw cleanup will fail if the webhook is unavailable when deleting the TempoStack.
+# Wait for the operator to restart (SecurityProfileWatcher triggers graceful restart on TLS profile change).
+echo "Waiting for operator restart after revert..."
+kubectl rollout status deployment/tempo-operator-controller -n openshift-tempo-operator --timeout=5m || true
+echo "Operator rollout check done"
+
+# Wait for all nodes to finish MCP reconciliation triggered by the APIServer revert.
+# Same pattern as 07-patch-modern.sh: the APIServer revert causes another full node-by-node
+# drain cycle. If MCP is still draining nodes during chainsaw cleanup, the operator pod can be
+# evicted making the admission webhook unavailable when chainsaw deletes TempoStack/TempoMonolithic CRs.
+echo "Waiting for all nodes to be Ready and schedulable after APIServer revert..."
+for i in $(seq 1 90); do
+  NOT_READY=$(kubectl get nodes --no-headers | grep -c "SchedulingDisabled" || true)
+  if [ "$NOT_READY" -eq 0 ]; then
+    echo "All nodes Ready and schedulable"
+    break
+  fi
+  if [ $i -eq 90 ]; then
+    echo "WARNING: Some nodes still SchedulingDisabled after 15 minutes, proceeding anyway"
+    kubectl get nodes
+    break
+  fi
+  echo "  Nodes with SchedulingDisabled: $NOT_READY (attempt $i/90)"
+  sleep 10
+done
+
+# Wait for MachineConfigPool to report fully updated for both pools.
+echo "Waiting for MachineConfigPools to finish updating..."
+for pool in master worker; do
+  for i in $(seq 1 60); do
+    UPDATED=$(kubectl get mcp "$pool" -o jsonpath='{.status.conditions[?(@.type=="Updated")].status}' 2>/dev/null || echo "")
+    UPDATING=$(kubectl get mcp "$pool" -o jsonpath='{.status.conditions[?(@.type=="Updating")].status}' 2>/dev/null || echo "")
+    if [ "$UPDATED" = "True" ] && [ "$UPDATING" = "False" ]; then
+      echo "MCP $pool: UPDATED=True UPDATING=False"
+      break
+    fi
+    if [ $i -eq 60 ]; then
+      echo "WARNING: MCP $pool not fully updated after 10 minutes (UPDATED=$UPDATED UPDATING=$UPDATING)"
+      break
+    fi
+    echo "  MCP $pool: UPDATED=$UPDATED UPDATING=$UPDATING (attempt $i/60)"
+    sleep 10
+  done
+done
+
+# After MCP stabilizes the operator pod may have been re-evicted; wait for its rollout again.
+echo "Waiting for operator deployment to be stable after MCP stabilization..."
+kubectl rollout status deployment/tempo-operator-controller -n openshift-tempo-operator --timeout=5m
+
+# Wait for the operator webhook endpoint to be available and remain stable.
+# The operator must be Running and its webhook ready before chainsaw cleanup deletes TempoStack/TempoMonolithic CRs.
 echo "Waiting for operator webhook to become available after revert..."
 for i in $(seq 1 60); do
   ENDPOINTS=$(kubectl get endpoints tempo-operator-controller-service -n openshift-tempo-operator -o jsonpath='{.subsets[0].addresses[0].ip}' 2>/dev/null || echo "")
@@ -19,3 +66,7 @@ for i in $(seq 1 60); do
   fi
   sleep 5
 done
+
+# Brief stabilization before chainsaw cleanup begins.
+sleep 10
+echo "APIServer revert complete and operator stable"

--- a/tests/e2e-openshift-tls-profile/03-tls-profile/chainsaw-test.yaml
+++ b/tests/e2e-openshift-tls-profile/03-tls-profile/chainsaw-test.yaml
@@ -83,5 +83,5 @@ spec:
   - name: step-11
     try:
     - script:
-        timeout: 5m
+        timeout: 30m
         content: ./11-revert-apiserver.sh


### PR DESCRIPTION
## Summary

- Extends `11-revert-apiserver.sh` to wait for full MCP node reconciliation before returning, preventing the operator pod from being evicted during chainsaw's cleanup phase
- Bumps the step-11 chainsaw timeout from `5m` to `30m` to accommodate the new wait logic

## Problem

The `03-tls-profile` test patches the cluster-wide APIServer TLS profile to Modern (step-07) and then reverts it (step-11). **Each change triggers a full MachineConfig update cycle across all 6 cluster nodes** (3 masters + 3 workers), causing node-by-node drain and reboot.

`07-patch-modern.sh` already handles this with a two-pass rollout wait and a node schedulability loop. However, `11-revert-apiserver.sh` only checked that the webhook endpoint appeared once — it did not wait for the revert's own MCP drain cycle to finish.

As a result, MCP could still be draining nodes *after* step-11 returned. The operator pod would be evicted during chainsaw's automatic cleanup phase, making the admission webhook (`vtempostack.tempo.grafana.com`, `vtempomonolithic.kb.io`) unavailable when chainsaw deleted TempoStack/TempoMonolithic CRs:

```
no endpoints available for service "tempo-operator-controller-service"
```

## Fix

Apply the same MCP stabilization pattern from `07-patch-modern.sh` to `11-revert-apiserver.sh`:

1. **First operator rollout wait** (tolerating failure) — catches the immediate SecurityProfileWatcher-triggered restart
2. **Node schedulability loop** (90 × 10s = 15 min max) — waits until no nodes are in `SchedulingDisabled`
3. **MachineConfigPool condition check** (60 × 10s = 10 min per pool) — waits for both `master` and `worker` MCPs to report `UPDATED=True, UPDATING=False`
4. **Second operator rollout wait** (strict, 5m) — ensures the operator that survived or was rescheduled after MCP draining is fully ready
5. **Webhook endpoint loop** — existing check, now after MCP is stable
6. **`sleep 10` stabilization buffer** — brief pause before chainsaw cleanup begins

## Test plan

- [x] Run `chainsaw test --test-dir ./tests/e2e-openshift-tls-profile/03-tls-profile` on an OpenShift cluster and verify step-11 waits for MCP stability and cleanup completes without webhook errors