### PR TITLE
[Chore] fix(tests): make GCP WIF test scripts idempotent and avoid project-level IAM bindings

### DIFF
--- a/tests/e2e-openshift-object-stores/gcp-wif-monolithic/gcp-wif-create.sh
+++ b/tests/e2e-openshift-object-stores/gcp-wif-monolithic/gcp-wif-create.sh
@@ -6,27 +6,29 @@ SERVICE_ACCOUNT_NAME="ikanse-gcp-wif-mono-sa"
 GCS_KEY_FILE="/tmp/gcp-wif-mono.json"
 BUCKET_NAME="ikanse-gcp-wif-mono"
 
-# Create GCP service account
-SERVICE_ACCOUNT_EMAIL=$(gcloud iam service-accounts create "$SERVICE_ACCOUNT_NAME" \
-    --display-name="TempoMonolithic Account" \
-    --project "$PROJECT_ID" \
-    --format='value(email)' \
-    --quiet)
-
-# Wait for the service account to be ready
-echo "Waiting for service account $SERVICE_ACCOUNT_EMAIL to be ready..."
-MAX_RETRIES=10
-RETRY_COUNT=0
-while ! gcloud iam service-accounts describe "$SERVICE_ACCOUNT_EMAIL" --project "$PROJECT_ID" &> /dev/null; do
-    if [ $RETRY_COUNT -ge $MAX_RETRIES ]; then
-        echo "Error: Service account $SERVICE_ACCOUNT_EMAIL not found after $MAX_RETRIES retries. Exiting."
-        exit 1
-    fi
-    echo "Service account not yet available. Retrying in 5 seconds..."
-    sleep 5
-    RETRY_COUNT=$((RETRY_COUNT + 1))
-done
-echo "Service account $SERVICE_ACCOUNT_EMAIL is ready."
+# Create GCP service account (idempotent: reuse if already exists)
+SERVICE_ACCOUNT_EMAIL="${SERVICE_ACCOUNT_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
+if gcloud iam service-accounts describe "$SERVICE_ACCOUNT_EMAIL" --project "$PROJECT_ID" &>/dev/null; then
+    echo "Service account $SERVICE_ACCOUNT_EMAIL already exists, reusing it."
+else
+    gcloud iam service-accounts create "$SERVICE_ACCOUNT_NAME" \
+        --display-name="TempoMonolithic Account" \
+        --project "$PROJECT_ID" \
+        --quiet
+    echo "Waiting for service account $SERVICE_ACCOUNT_EMAIL to be ready..."
+    MAX_RETRIES=10
+    RETRY_COUNT=0
+    while ! gcloud iam service-accounts describe "$SERVICE_ACCOUNT_EMAIL" --project "$PROJECT_ID" &>/dev/null; do
+        if [ $RETRY_COUNT -ge $MAX_RETRIES ]; then
+            echo "Error: Service account $SERVICE_ACCOUNT_EMAIL not found after $MAX_RETRIES retries. Exiting."
+            exit 1
+        fi
+        echo "Service account not yet available. Retrying in 5 seconds..."
+        sleep 5
+        RETRY_COUNT=$((RETRY_COUNT + 1))
+    done
+    echo "Service account $SERVICE_ACCOUNT_EMAIL is ready."
+fi
 
 # Set the GCP and TempoStack vars
 TEMPO_NAME="gcpwifmn"
@@ -35,23 +37,10 @@ PROJECT_NUMBER=$(gcloud projects describe "$PROJECT_ID" --format='value(projectN
 OIDC_ISSUER=$(oc get authentication.config cluster -o jsonpath='{.spec.serviceAccountIssuer}')
 POOL_ID=$(echo "$OIDC_ISSUER" | awk -F'/' '{print $NF}' | sed 's/-oidc$//')
 
-# Bind the required GCP roles to the created SA at the project level
-gcloud projects add-iam-policy-binding "$PROJECT_ID" \
-  --member="serviceAccount:$SERVICE_ACCOUNT_EMAIL" \
-  --role="roles/storage.objectAdmin" \
-  --format=none \
-  --quiet
-
-# Workload Identity Bindings: Allow Kubernetes Service Accounts to impersonate the Google Service Account
+# Workload Identity Bindings: Allow Kubernetes Service Account to impersonate the Google Service Account
 gcloud iam service-accounts add-iam-policy-binding "$SERVICE_ACCOUNT_EMAIL" \
   --role="roles/iam.workloadIdentityUser" \
   --member="principal://iam.googleapis.com/projects/$PROJECT_NUMBER/locations/global/workloadIdentityPools/$POOL_ID/subject/system:serviceaccount:${TEMPO_NAMESPACE}:tempo-${TEMPO_NAME}" \
-  --project="$PROJECT_ID" \
-  --quiet
-
-gcloud iam service-accounts add-iam-policy-binding "$SERVICE_ACCOUNT_EMAIL" \
-  --role="roles/iam.workloadIdentityUser" \
-  --member="principal://iam.googleapis.com/projects/$PROJECT_NUMBER/locations/global/workloadIdentityPools/$POOL_ID/subject/system:serviceaccount:${TEMPO_NAMESPACE}:tempo-${TEMPO_NAME}-query-frontend" \
   --project="$PROJECT_ID" \
   --quiet
 

--- a/tests/e2e-openshift-object-stores/gcp-wif-monolithic/gcp-wif-delete.sh
+++ b/tests/e2e-openshift-object-stores/gcp-wif-monolithic/gcp-wif-delete.sh
@@ -32,31 +32,14 @@ gcloud storage buckets remove-iam-policy-binding "gs://$BUCKET_NAME" \
     --quiet
 echo "Bucket-level IAM policy binding removed."
 
-# Remove IAM policy bindings for the created service account (project level)
-echo "Removing project-level IAM policy bindings for service account '**$SERVICE_ACCOUNT_EMAIL**'..."
-gcloud projects remove-iam-policy-binding "$PROJECT_ID" \
-  --member="serviceAccount:$SERVICE_ACCOUNT_EMAIL" \
-  --role="roles/storage.objectAdmin" --quiet
-echo "Project-level IAM policy bindings for service account '**$SERVICE_ACCOUNT_EMAIL**' removed."
-
-# Remove IAM policy bindings for TempoStack service accounts (Workload Identity Principals)
-# These were added directly to the Google Service Account's IAM policy
-echo "Removing Workload Identity bindings from Google Service Account '**$SERVICE_ACCOUNT_EMAIL**'..."
-
-# tempo-${TEMPO_NAME} bindings
+# Remove Workload Identity binding from the Google Service Account
+echo "Removing Workload Identity binding from Google Service Account '**$SERVICE_ACCOUNT_EMAIL**'..."
 gcloud iam service-accounts remove-iam-policy-binding "$SERVICE_ACCOUNT_EMAIL" \
   --role="roles/iam.workloadIdentityUser" \
   --member="principal://iam.googleapis.com/projects/$PROJECT_NUMBER/locations/global/workloadIdentityPools/$POOL_ID/subject/system:serviceaccount:${TEMPO_NAMESPACE}:tempo-${TEMPO_NAME}" \
   --project="$PROJECT_ID" \
   --quiet
-
-# tempo-${TEMPO_NAME}-query-frontend bindings
-gcloud iam service-accounts remove-iam-policy-binding "$SERVICE_ACCOUNT_EMAIL" \
-  --role="roles/iam.workloadIdentityUser" \
-  --member="principal://iam.googleapis.com/projects/$PROJECT_NUMBER/locations/global/workloadIdentityPools/$POOL_ID/subject/system:serviceaccount:${TEMPO_NAMESPACE}:tempo-${TEMPO_NAME}-query-frontend" \
-  --project="$PROJECT_ID" \
-  --quiet
-echo "Workload Identity bindings removed from Google Service Account '**$SERVICE_ACCOUNT_EMAIL**'."
+echo "Workload Identity binding removed from Google Service Account '**$SERVICE_ACCOUNT_EMAIL**'."
 
 # Delete the GCP service account
 echo "Deleting service account '**$SERVICE_ACCOUNT_EMAIL**'..."

--- a/tests/e2e-openshift-object-stores/gcp-wif-tempostack/gcp-wif-create.sh
+++ b/tests/e2e-openshift-object-stores/gcp-wif-tempostack/gcp-wif-create.sh
@@ -6,27 +6,29 @@ SERVICE_ACCOUNT_NAME="ikanse-gcp-wif-tempo-sa"
 GCS_KEY_FILE="/tmp/gcp-wif-tempo.json"
 BUCKET_NAME="ikanse-gcp-wif-tempo"
 
-# Create GCP service account
-SERVICE_ACCOUNT_EMAIL=$(gcloud iam service-accounts create "$SERVICE_ACCOUNT_NAME" \
-    --display-name="TempoStack Account" \
-    --project "$PROJECT_ID" \
-    --format='value(email)' \
-    --quiet)
-
-# Wait for the service account to be ready
-echo "Waiting for service account $SERVICE_ACCOUNT_EMAIL to be ready..."
-MAX_RETRIES=10
-RETRY_COUNT=0
-while ! gcloud iam service-accounts describe "$SERVICE_ACCOUNT_EMAIL" --project "$PROJECT_ID" &> /dev/null; do
-    if [ $RETRY_COUNT -ge $MAX_RETRIES ]; then
-        echo "Error: Service account $SERVICE_ACCOUNT_EMAIL not found after $MAX_RETRIES retries. Exiting."
-        exit 1
-    fi
-    echo "Service account not yet available. Retrying in 5 seconds..."
-    sleep 5
-    RETRY_COUNT=$((RETRY_COUNT + 1))
-done
-echo "Service account $SERVICE_ACCOUNT_EMAIL is ready."
+# Create GCP service account (idempotent: reuse if already exists)
+SERVICE_ACCOUNT_EMAIL="${SERVICE_ACCOUNT_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
+if gcloud iam service-accounts describe "$SERVICE_ACCOUNT_EMAIL" --project "$PROJECT_ID" &>/dev/null; then
+    echo "Service account $SERVICE_ACCOUNT_EMAIL already exists, reusing it."
+else
+    gcloud iam service-accounts create "$SERVICE_ACCOUNT_NAME" \
+        --display-name="TempoStack Account" \
+        --project "$PROJECT_ID" \
+        --quiet
+    echo "Waiting for service account $SERVICE_ACCOUNT_EMAIL to be ready..."
+    MAX_RETRIES=10
+    RETRY_COUNT=0
+    while ! gcloud iam service-accounts describe "$SERVICE_ACCOUNT_EMAIL" --project "$PROJECT_ID" &>/dev/null; do
+        if [ $RETRY_COUNT -ge $MAX_RETRIES ]; then
+            echo "Error: Service account $SERVICE_ACCOUNT_EMAIL not found after $MAX_RETRIES retries. Exiting."
+            exit 1
+        fi
+        echo "Service account not yet available. Retrying in 5 seconds..."
+        sleep 5
+        RETRY_COUNT=$((RETRY_COUNT + 1))
+    done
+    echo "Service account $SERVICE_ACCOUNT_EMAIL is ready."
+fi
 
 # Set the GCP and TempoStack vars
 TEMPO_NAME="gcpwiftm"
@@ -34,13 +36,6 @@ TEMPO_NAMESPACE="chainsaw-gcpwif-tempo"
 PROJECT_NUMBER=$(gcloud projects describe "$PROJECT_ID" --format='value(projectNumber)')
 OIDC_ISSUER=$(oc get authentication.config cluster -o jsonpath='{.spec.serviceAccountIssuer}')
 POOL_ID=$(echo "$OIDC_ISSUER" | awk -F'/' '{print $NF}' | sed 's/-oidc$//')
-
-# Bind the required GCP roles to the created SA at the project level
-gcloud projects add-iam-policy-binding "$PROJECT_ID" \
-  --member="serviceAccount:$SERVICE_ACCOUNT_EMAIL" \
-  --role="roles/storage.objectAdmin" \
-  --format=none \
-  --quiet
 
 # Workload Identity Bindings: Allow Kubernetes Service Accounts to impersonate the Google Service Account
 gcloud iam service-accounts add-iam-policy-binding "$SERVICE_ACCOUNT_EMAIL" \

--- a/tests/e2e-openshift-object-stores/gcp-wif-tempostack/gcp-wif-delete.sh
+++ b/tests/e2e-openshift-object-stores/gcp-wif-tempostack/gcp-wif-delete.sh
@@ -32,13 +32,6 @@ gcloud storage buckets remove-iam-policy-binding "gs://$BUCKET_NAME" \
     --quiet
 echo "Bucket-level IAM policy binding removed."
 
-# Remove IAM policy bindings for the created service account (project level)
-echo "Removing project-level IAM policy bindings for service account '**$SERVICE_ACCOUNT_EMAIL**'..."
-gcloud projects remove-iam-policy-binding "$PROJECT_ID" \
-  --member="serviceAccount:$SERVICE_ACCOUNT_EMAIL" \
-  --role="roles/storage.objectAdmin" --quiet
-echo "Project-level IAM policy bindings for service account '**$SERVICE_ACCOUNT_EMAIL**' removed."
-
 # Remove IAM policy bindings for TempoStack service accounts (Workload Identity Principals)
 # These were added directly to the Google Service Account's IAM policy
 echo "Removing Workload Identity bindings from Google Service Account '**$SERVICE_ACCOUNT_EMAIL**'..."


### PR DESCRIPTION
## Summary

- **Idempotent SA creation**: Both `gcp-wif-create.sh` scripts now check whether the GCP service account already exists before trying to create it, so reruns after a partial failure no longer abort with a conflict error.
- **Bucket-level IAM only**: Removed the `gcloud projects add-iam-policy-binding` call that granted `roles/storage.objectAdmin` at the project level. The bucket-level `roles/storage.admin` binding (added after bucket creation) is sufficient for GCS access and avoids hitting GCP's hard limit of 1,500 members in a project IAM policy.
- **Fix spurious WIF binding in monolithic scripts**: Removed the `tempo-<name>-query-frontend` Workload Identity binding from the monolithic create/delete scripts — `TempoMonolithic` only creates a single `tempo-<name>` service account, not a separate query-frontend one.

## Test plan

- [x] Ran `chainsaw test tests/e2e-openshift-object-stores/gcp-wif-tempostack tests/e2e-openshift-object-stores/gcp-wif-monolithic` twice on a live OpenShift/GCP cluster — both tests passed both times (including full cleanup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)