### PR TITLE
[Chore] Fix flaky service mesh tests

### DIFF
--- a/tests/e2e-openshift-ossm/ossm-tempostack-otel/chainsaw-test.yaml
+++ b/tests/e2e-openshift-ossm/ossm-tempostack-otel/chainsaw-test.yaml
@@ -66,6 +66,7 @@ spec:
     - apply:
         file: verify-traces.yaml
     - assert:
+        timeout: 10m
         file: verify-traces-assert.yaml
   - name: Generate traces and send it to OTEL collector via OTLP GRPC and HTTP
     try:

--- a/tests/e2e-openshift-ossm/ossm-tempostack-otel/verify-traces.yaml
+++ b/tests/e2e-openshift-ossm/ossm-tempostack-otel/verify-traces.yaml
@@ -15,11 +15,20 @@ spec:
         - |
             TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
             KIALI_URL=https://kiali.istio-system.svc.cluster.local:20001
-            START_MICROS=$(awk "BEGIN {print int($(date +%s) - 60*60)*1000000}")
-            OUTPUT=$(curl -k -H "Authorization: Bearer $TOKEN" "$KIALI_URL/api/namespaces/bookinfo/services/productpage/traces?startMicros=$START_MICROS&tags=&limit=100")
-            if echo "$OUTPUT" | grep -q '"serviceName":"productpage.bookinfo"'; then
-              exit 0
-            else
-              exit 1
-            fi
+            for attempt in $(seq 1 12); do
+              echo "Attempt $attempt of 12"
+              START_MICROS=$(awk "BEGIN {print int($(date +%s) - 60*60)*1000000}")
+              OUTPUT=$(curl -sk -H "Authorization: Bearer $TOKEN" "$KIALI_URL/api/namespaces/bookinfo/services/productpage/traces?startMicros=$START_MICROS&tags=&limit=100")
+              echo "Response: $OUTPUT"
+              if echo "$OUTPUT" | grep -q '"serviceName":"productpage.bookinfo"'; then
+                echo "Traces found on attempt $attempt"
+                exit 0
+              fi
+              if [ "$attempt" -lt 12 ]; then
+                echo "Traces not found yet, waiting 15s..."
+                sleep 15
+              fi
+            done
+            echo "Traces not found after 12 attempts"
+            exit 1
       restartPolicy: Never

--- a/tests/e2e-openshift-ossm/ossm-tempostack/chainsaw-test.yaml
+++ b/tests/e2e-openshift-ossm/ossm-tempostack/chainsaw-test.yaml
@@ -61,5 +61,5 @@ spec:
     - apply:
         file: verify-traces.yaml
     - assert:
+        timeout: 10m
         file: verify-traces-assert.yaml
-

--- a/tests/e2e-openshift-ossm/ossm-tempostack/verify-traces.yaml
+++ b/tests/e2e-openshift-ossm/ossm-tempostack/verify-traces.yaml
@@ -15,11 +15,20 @@ spec:
         - |
             TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
             KIALI_URL=https://kiali.istio-system.svc.cluster.local:20001
-            START_MICROS=$(awk "BEGIN {print int($(date +%s) - 60*60)*1000000}")
-            OUTPUT=$(curl -k -H "Authorization: Bearer $TOKEN" "$KIALI_URL/api/namespaces/bookinfo/services/productpage/traces?startMicros=$START_MICROS&tags=&limit=100")
-            if echo "$OUTPUT" | grep -q '"serviceName":"productpage.bookinfo"'; then
-              exit 0
-            else
-              exit 1
-            fi
+            for attempt in $(seq 1 12); do
+              echo "Attempt $attempt of 12"
+              START_MICROS=$(awk "BEGIN {print int($(date +%s) - 60*60)*1000000}")
+              OUTPUT=$(curl -sk -H "Authorization: Bearer $TOKEN" "$KIALI_URL/api/namespaces/bookinfo/services/productpage/traces?startMicros=$START_MICROS&tags=&limit=100")
+              echo "Response: $OUTPUT"
+              if echo "$OUTPUT" | grep -q '"serviceName":"productpage.bookinfo"'; then
+                echo "Traces found on attempt $attempt"
+                exit 0
+              fi
+              if [ "$attempt" -lt 12 ]; then
+                echo "Traces not found yet, waiting 15s..."
+                sleep 15
+              fi
+            done
+            echo "Traces not found after 12 attempts"
+            exit 1
       restartPolicy: Never


### PR DESCRIPTION
Observed flakiness of the tests in OCP CI job. 
https://qe-private-deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gs/qe-private-deck/pr-logs/pull/openshift_release/80345/rehearse-80345-periodic-ci-openshift-grafana-tempo-operator-main-tempo-product-ocp-4.12-stage-tempo-stage-tests/2065276143128285184

QE agent reran, analysed and added test fix:
https://gcsweb-qe-private-deck-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/qe-private-deck/pr-logs/pull/openshift_release/80345/rehearse-80345-periodic-ci-openshift-grafana-tempo-operator-main-tempo-product-ocp-4.12-stage-tempo-stage-tests/2065276143128285184/artifacts/tempo-stage-tests/openshift-observability-qe-agent/artifacts/ 

