### PR TITLE
[Chore] test(e2e-openshift): use upstream must-gather image in route tests

### DIFF
--- a/tests/e2e-openshift/monolithic-route/check-must-gather.sh
+++ b/tests/e2e-openshift/monolithic-route/check-must-gather.sh
@@ -4,7 +4,7 @@
 MUST_GATHER_DIR=$(mktemp -d)
 
 # Run the must-gather script
-oc adm must-gather --dest-dir=$MUST_GATHER_DIR --image=quay.io/rhn_support_ikanse/tempo-must-gather:latest -- /usr/bin/must-gather --operator-namespace $temponamespace
+oc adm must-gather --dest-dir=$MUST_GATHER_DIR --image=ghcr.io/grafana/tempo-operator/must-gather:v0.21.0 -- /usr/bin/must-gather --operator-namespace $temponamespace
 
 # Define required files and directories
 REQUIRED_ITEMS=(

--- a/tests/e2e-openshift/route/check-must-gather.sh
+++ b/tests/e2e-openshift/route/check-must-gather.sh
@@ -4,7 +4,7 @@
 MUST_GATHER_DIR=$(mktemp -d)
 
 # Run the must-gather script
-oc adm must-gather --dest-dir=$MUST_GATHER_DIR --image=quay.io/rhn_support_ikanse/tempo-must-gather:latest -- /usr/bin/must-gather --operator-namespace $temponamespace
+oc adm must-gather --dest-dir=$MUST_GATHER_DIR --image=ghcr.io/grafana/tempo-operator/must-gather:v0.21.0 -- /usr/bin/must-gather --operator-namespace $temponamespace
 
 # Define required files and directories
 REQUIRED_ITEMS=(


### PR DESCRIPTION
## Summary

- Switch the must-gather image in `route` and `monolithic-route` e2e tests from the local dev image (`quay.io/rhn_support_ikanse/tempo-must-gather:latest`) to the canonical upstream release image `ghcr.io/grafana/tempo-operator/must-gather:v0.21.0`
- Both tests verified passing locally against an OpenShift 4.21 nightly cluster

## Test plan

- [x] `chainsaw test tests/e2e-openshift/route` — PASS
- [x] `chainsaw test tests/e2e-openshift/monolithic-route` — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)