### PR TITLE
[chore] fix: harden must-gather operator discovery

### DIFF
--- a/cmd/gather/cluster/cluster.go
+++ b/cmd/gather/cluster/cluster.go
@@ -60,19 +60,32 @@ func (c *cluster) getOperatorNamespace() (string, error) {
 }
 
 func (c *cluster) getOperatorDeployment() (appsv1.Deployment, error) {
-	operatorDeployments := appsv1.DeploymentList{}
-	err := c.config.KubernetesClient.List(context.TODO(), &operatorDeployments, &client.ListOptions{
-		LabelSelector: labels.SelectorFromSet(labels.Set{
-			"app.kubernetes.io/name": "tempo-operator",
+	listOptions := []client.ListOption{
+		client.MatchingLabels(map[string]string{
+			"app.kubernetes.io/name": c.config.OperatorName,
 		}),
-	})
+	}
+	if c.config.OperatorNamespace != "" {
+		listOptions = append(listOptions, client.InNamespace(c.config.OperatorNamespace))
+	}
+
+	operatorDeployments := appsv1.DeploymentList{}
+	err := c.config.KubernetesClient.List(context.TODO(), &operatorDeployments, listOptions...)
 
 	if err != nil {
 		return appsv1.Deployment{}, err
 	}
 
 	if len(operatorDeployments.Items) == 0 {
-		return appsv1.Deployment{}, fmt.Errorf("operator not found")
+		return appsv1.Deployment{}, fmt.Errorf("operator deployment with app.kubernetes.io/name=%q not found", c.config.OperatorName)
+	}
+
+	if len(operatorDeployments.Items) > 1 {
+		deployments := make([]string, 0, len(operatorDeployments.Items))
+		for _, deployment := range operatorDeployments.Items {
+			deployments = append(deployments, fmt.Sprintf("%s/%s", deployment.Namespace, deployment.Name))
+		}
+		return appsv1.Deployment{}, fmt.Errorf("found multiple operator deployments for app.kubernetes.io/name=%q: %s", c.config.OperatorName, strings.Join(deployments, ", "))
 	}
 
 	return operatorDeployments.Items[0], nil
@@ -93,6 +106,10 @@ func (c *cluster) GetOperatorLogs() error {
 	})
 	if err != nil {
 		return err
+	}
+
+	if len(operatorPods.Items) == 0 {
+		return fmt.Errorf("no pods found for operator deployment %s/%s", deployment.Namespace, deployment.Name)
 	}
 
 	pod := operatorPods.Items[0]

--- a/cmd/gather/cluster/cluster_test.go
+++ b/cmd/gather/cluster/cluster_test.go
@@ -1,0 +1,129 @@
+package cluster
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/grafana/tempo-operator/cmd/gather/config"
+)
+
+func TestGetOperatorDeploymentUsesConfiguredNameAndNamespace(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	deploymentA := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tempo-operator-a",
+			Namespace: "ns-a",
+			Labels: map[string]string{
+				"app.kubernetes.io/name": "tempo-operator-a",
+			},
+		},
+	}
+	deploymentB := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tempo-operator-b",
+			Namespace: "ns-b",
+			Labels: map[string]string{
+				"app.kubernetes.io/name": "tempo-operator-b",
+			},
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(deploymentA, deploymentB).
+		Build()
+
+	c := NewCluster(&config.Config{
+		OperatorName:      "tempo-operator-b",
+		OperatorNamespace: "ns-b",
+		KubernetesClient:  k8sClient,
+	})
+
+	deployment, err := c.getOperatorDeployment()
+	require.NoError(t, err)
+	require.Equal(t, "tempo-operator-b", deployment.Name)
+	require.Equal(t, "ns-b", deployment.Namespace)
+}
+
+func TestGetOperatorDeploymentReturnsErrorForMultipleMatches(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	deploymentA := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tempo-operator-a",
+			Namespace: "ns-a",
+			Labels: map[string]string{
+				"app.kubernetes.io/name": "tempo-operator",
+			},
+		},
+	}
+	deploymentB := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tempo-operator-b",
+			Namespace: "ns-b",
+			Labels: map[string]string{
+				"app.kubernetes.io/name": "tempo-operator",
+			},
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(deploymentA, deploymentB).
+		Build()
+
+	c := NewCluster(&config.Config{
+		OperatorName:     "tempo-operator",
+		KubernetesClient: k8sClient,
+	})
+
+	_, err := c.getOperatorDeployment()
+	require.EqualError(t, err, `found multiple operator deployments for app.kubernetes.io/name="tempo-operator": ns-a/tempo-operator-a, ns-b/tempo-operator-b`)
+}
+
+func TestGetOperatorLogsReturnsErrorWhenNoPodsFound(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tempo-operator",
+			Namespace: "operators",
+			Labels: map[string]string{
+				"app.kubernetes.io/name": "tempo-operator",
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app.kubernetes.io/name": "tempo-operator",
+				},
+			},
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(deployment).
+		Build()
+
+	c := NewCluster(&config.Config{
+		OperatorName:     "tempo-operator",
+		KubernetesClient: k8sClient,
+	})
+
+	err := c.GetOperatorLogs()
+	require.EqualError(t, err, "no pods found for operator deployment operators/tempo-operator")
+}


### PR DESCRIPTION
this fixes 2 small must-gather footguns.

`--operator-name` was ignored, so the code always looked for `app.kubernetes.io/name=tempo-operator`.
also, if the operator Deployment existed but had no matching Pods yet, `must-gather` indexed `operatorPods.Items[0]` and blew up.

repro
1. run `must-gather` while the operator Deployment exists but the pod is temporarily gone. pretty easy to hit during rollout, `ImagePullBackOff`, `CrashLoopBackOff`, `Pending`, or right after deleting the pod.
2. before this patch, it panics on `operatorPods.Items[0]`.
3. run `./bin/must-gather --operator-name foo`.
4. before this patch, it still searched for `tempo-operator`.

now it honors `--operator-name` and `--operator-namespace`, and returns a clear error when no operator pod is found.
