### PR TITLE
Fix flaky upgrade test by increasing webhook readiness timeout

### DIFF
--- a/tests/e2e-upgrade/upgrade/chainsaw-test.yaml
+++ b/tests/e2e-upgrade/upgrade/chainsaw-test.yaml
@@ -25,6 +25,7 @@ spec:
   - name: step-21
     try:
     - apply:
+        timeout: 2m
         file: tempostack.yaml
     - delete:
         ref:


### PR DESCRIPTION
The upgrade test step-21 creates a TempoStack to verify the operator webhook is ready, but the default apply timeout (~5s) is too short — the webhook may not be reachable yet even though the operator pod is marked ready, causing intermittent failures.