### PR TITLE
[Chore] Make tls-profile test compatible with older OCP versions

### DIFF
--- a/tests/e2e-openshift-tls-profile/03-tls-profile/07-patch-modern.sh
+++ b/tests/e2e-openshift-tls-profile/03-tls-profile/07-patch-modern.sh
@@ -1,6 +1,17 @@
 #!/bin/bash
 set -euo pipefail
 
+# Check if Modern TLS profile is supported on this cluster version.
+# OCP < 4.15 only supports Old, Intermediate, and Custom.
+if ! oc patch apiserver cluster --type merge --dry-run=server \
+  -p '{"spec":{"tlsSecurityProfile":{"type":"Modern","modern":{}}}}' 2>/dev/null; then
+  echo "SKIP: Modern TLS profile not supported on this cluster (OCP $(oc get clusterversion version -o jsonpath='{.status.desired.version}' 2>/dev/null || echo 'unknown'))"
+  echo "Supported types: Old, Intermediate, Custom"
+  echo "unsupported" > /tmp/modern-tls-unsupported
+  exit 0
+fi
+rm -f /tmp/modern-tls-unsupported
+
 # Patch APIServer to Modern profile
 oc patch apiserver cluster --type merge \
   -p '{"spec":{"tlsSecurityProfile":{"type":"Modern","modern":{}}}}'

--- a/tests/e2e-openshift-tls-profile/03-tls-profile/08-verify-modern.sh
+++ b/tests/e2e-openshift-tls-profile/03-tls-profile/08-verify-modern.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 set -euo pipefail
 
+# Skip if Modern TLS profile is not supported on this cluster
+if [ -f /tmp/modern-tls-unsupported ]; then
+  echo "SKIP: Modern TLS profile not supported on this cluster — skipping verification"
+  exit 0
+fi
+
 # Detect FIPS mode from machineconfig
 IS_FIPS=false
 if kubectl get machineconfig 99-master-fips -o jsonpath='{.spec.fips}' 2>/dev/null | grep -q true; then

--- a/tests/e2e-openshift-tls-profile/03-tls-profile/11-revert-apiserver.sh
+++ b/tests/e2e-openshift-tls-profile/03-tls-profile/11-revert-apiserver.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 set -euo pipefail
+
+# If Modern TLS profile was not supported, nothing was patched — skip revert.
+if [ -f /tmp/modern-tls-unsupported ]; then
+  echo "SKIP: Modern TLS profile was not applied (unsupported on this cluster) — no revert needed"
+  rm -f /tmp/modern-tls-unsupported
+  exit 0
+fi
+
 oc patch apiserver cluster --type json \
   -p '[{"op":"remove","path":"/spec/tlsSecurityProfile"}]'
 echo "APIServer TLS profile reverted to default (nil)"


### PR DESCRIPTION
We were skipping this test in older OCP versions. With this fix, we can run the test on OCP version < 4.15
QE Agent analysis, report and fixes: https://gcsweb-qe-private-deck-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/qe-private-deck/pr-logs/pull/openshift_release/80642/rehearse-80642-pull-ci-openshift-grafana-tempo-operator-main-upstream-ocp-4.12-amd64-tempo-upstream-tests/2067111421094662144/artifacts/tempo-upstream-tests/openshift-observability-qe-agent/artifacts/ 

# Test Fix Summary

## Failing test
tests/e2e-openshift-tls-profile/03-tls-profile / tls-profile

## Root cause
The test unconditionally patches the cluster-wide APIServer resource to use the "Modern" TLS security profile in step 07 (`07-patch-modern.sh`). However, OpenShift 4.12 (Kubernetes v1.25) does not support the "Modern" TLS profile type — the API only accepts `Old`, `Intermediate`, and `Custom`. The `oc patch` command fails with: `spec.tlsSecurityProfile.type: Unsupported value: "Modern": supported values: "Old", "Intermediate", "Custom"`. This causes step 07 to exit with status 1, failing the entire test. The "Modern" TLS profile type was introduced in later OpenShift versions (4.15+).

## Fix applied
Added a dry-run detection check at the beginning of `07-patch-modern.sh` to test whether the "Modern" TLS profile type is accepted by the cluster's APIServer API before attempting the actual patch. When "Modern" is not supported, the script creates a marker file (`/tmp/modern-tls-unsupported`) and exits 0 (skip). The subsequent scripts `08-verify-modern.sh` and `11-revert-apiserver.sh` check for this marker file and skip their Modern-specific logic accordingly. The remaining test steps (09-10) generate and verify traces, which work correctly regardless of TLS profile and pass without modification.

## Files changed
- `tests/e2e-openshift-tls-profile/03-tls-profile/07-patch-modern.sh` — added Modern profile support detection via `--dry-run=server`; skips with marker file if unsupported
- `tests/e2e-openshift-tls-profile/03-tls-profile/08-verify-modern.sh` — added marker file check to skip Modern profile verification when unsupported
- `tests/e2e-openshift-tls-profile/03-tls-profile/11-revert-apiserver.sh` — added marker file check to skip APIServer revert when Modern was never applied

## Verification
Rerun result after fix: PASS (626s, full test completion)