### PR TITLE
Fix stale status field by watching Deployment/StatefulSet status changes

### DIFF
--- a/.chloggen/fix-status-reconciliation.yaml
+++ b/.chloggen/fix-status-reconciliation.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. tempostack, tempomonolithic, github action)
+component: operator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix stale status field by watching Deployment/StatefulSet status changes.
+
+# One or more tracking issues related to the change
+issues: [1533]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/internal/controller/tempo/common.go
+++ b/internal/controller/tempo/common.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/google/go-cmp/cmp"
+	appsv1 "k8s.io/api/apps/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -13,9 +15,12 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlbuilder "sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	configv1alpha1 "github.com/grafana/tempo-operator/api/config/v1alpha1"
 	"github.com/grafana/tempo-operator/api/tempo/v1alpha1"
@@ -25,6 +30,38 @@ import (
 	"github.com/grafana/tempo-operator/internal/status"
 	"github.com/grafana/tempo-operator/internal/webhooks"
 )
+
+var (
+	updateOrDeleteWithStatusPred = ctrlbuilder.WithPredicates(predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration() || statusDifferent(e)
+		},
+		CreateFunc: func(_ event.CreateEvent) bool {
+			return false
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			// DeleteStateUnknown evaluates to false only if the object
+			// has been confirmed as deleted by the api server.
+			return !e.DeleteStateUnknown
+		},
+		GenericFunc: func(_ event.GenericEvent) bool {
+			return false
+		},
+	})
+)
+
+func statusDifferent(e event.UpdateEvent) bool {
+	switch old := e.ObjectOld.(type) {
+	case *appsv1.Deployment:
+		newObject := e.ObjectNew.(*appsv1.Deployment)
+		return !cmp.Equal(old.Status, newObject.Status)
+	case *appsv1.StatefulSet:
+		newObject := e.ObjectNew.(*appsv1.StatefulSet)
+		return !cmp.Equal(old.Status, newObject.Status)
+	default:
+		return false
+	}
+}
 
 func isNamespaceScoped(obj client.Object) bool {
 	switch obj.(type) {

--- a/internal/controller/tempo/tempomonolithic_controller.go
+++ b/internal/controller/tempo/tempomonolithic_controller.go
@@ -421,7 +421,7 @@ func (r *TempoMonolithicReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&corev1.Secret{}).
 		Owns(&corev1.Service{}).
 		Owns(&corev1.ServiceAccount{}).
-		Owns(&appsv1.StatefulSet{}).
+		Owns(&appsv1.StatefulSet{}, updateOrDeleteWithStatusPred).
 		Owns(&networkingv1.Ingress{}).
 		Owns(&rbacv1.ClusterRole{}).
 		Owns(&rbacv1.ClusterRoleBinding{}).

--- a/internal/controller/tempo/tempostack_controller.go
+++ b/internal/controller/tempo/tempostack_controller.go
@@ -248,8 +248,8 @@ func (r *TempoStackReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&corev1.ServiceAccount{}).
 		Owns(&corev1.Service{}).
 		Owns(&corev1.Secret{}).
-		Owns(&appsv1.StatefulSet{}).
-		Owns(&appsv1.Deployment{}).
+		Owns(&appsv1.StatefulSet{}, updateOrDeleteWithStatusPred).
+		Owns(&appsv1.Deployment{}, updateOrDeleteWithStatusPred).
 		Owns(&networkingv1.Ingress{}).
 		Owns(&rbacv1.ClusterRole{}).
 		Owns(&rbacv1.ClusterRoleBinding{}).


### PR DESCRIPTION
Add status-aware watch predicates for Deployments and StatefulSets to ensure controllers reconcile on both spec and status changes. This prevents stalled status updates when pods transition through their lifecycle.

The logic is identical to Loki Operator's status update logic.