### PR TITLE
chore: add minio, hydra and telemetrygen to test-utils image

### DIFF
--- a/tests/Dockerfile.utils
+++ b/tests/Dockerfile.utils
@@ -3,9 +3,11 @@ RUN apk add --no-cache git gcc musl-dev
 # SQLite (needed for memory DSN) requires CGO
 RUN git clone --depth 1 --branch v26.2.0 https://github.com/ory/hydra.git /hydra && \
     cd /hydra && CGO_ENABLED=1 go build -tags sqlite -o /go/bin/hydra .
+RUN go install github.com/open-telemetry/opentelemetry-collector-contrib/cmd/telemetrygen@v0.135.0
 
 FROM alpine:3.23@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
 RUN apk add --no-cache curl jq bash minio
 COPY --from=builder /go/bin/hydra /usr/local/bin/hydra
+COPY --from=builder /go/bin/telemetrygen /usr/local/bin/telemetrygen
 
 CMD ["bash"]

--- a/tests/Dockerfile.utils
+++ b/tests/Dockerfile.utils
@@ -4,10 +4,12 @@ RUN apk add --no-cache git gcc musl-dev
 RUN git clone --depth 1 --branch v26.2.0 https://github.com/ory/hydra.git /hydra && \
     cd /hydra && CGO_ENABLED=1 go build -tags sqlite -o /go/bin/hydra .
 RUN go install github.com/open-telemetry/opentelemetry-collector-contrib/cmd/telemetrygen@v0.135.0
+RUN go install github.com/openshift/tls-scanner/cmd/tls-scanner@b6d99c72ebb7d781fe234ba93c972c787cc980cf
 
 FROM alpine:3.23@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
-RUN apk add --no-cache curl jq bash minio
+RUN apk add --no-cache curl jq bash minio nmap
 COPY --from=builder /go/bin/hydra /usr/local/bin/hydra
 COPY --from=builder /go/bin/telemetrygen /usr/local/bin/telemetrygen
+COPY --from=builder /go/bin/tls-scanner /usr/local/bin/tls-scanner
 
 CMD ["bash"]

--- a/tests/Dockerfile.utils
+++ b/tests/Dockerfile.utils
@@ -7,9 +7,19 @@ RUN go install github.com/open-telemetry/opentelemetry-collector-contrib/cmd/tel
 RUN go install github.com/openshift/tls-scanner/cmd/tls-scanner@b6d99c72ebb7d781fe234ba93c972c787cc980cf
 
 FROM alpine:3.23@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
-RUN apk add --no-cache curl jq bash minio nmap
+RUN apk add --no-cache coreutils procps curl jq bash minio nmap
 COPY --from=builder /go/bin/hydra /usr/local/bin/hydra
 COPY --from=builder /go/bin/telemetrygen /usr/local/bin/telemetrygen
 COPY --from=builder /go/bin/tls-scanner /usr/local/bin/tls-scanner
+
+# Install testssl.sh (required by tls-scanner)
+# testssl.sh requires coreutils and procps
+ARG TESTSSL_VERSION=3.2.2
+RUN curl -L "https://testssl.sh/testssl.sh-${TESTSSL_VERSION}.tar.gz" -o /tmp/testssl.tar.gz && \
+    mkdir -p /opt/testssl && \
+    tar -xzf /tmp/testssl.tar.gz -C /opt/testssl --strip-components=1 && \
+    chmod +x /opt/testssl/testssl.sh && \
+    ln -s /opt/testssl/testssl.sh /usr/local/bin/testssl.sh && \
+    rm -f /tmp/testssl.tar.gz
 
 CMD ["bash"]

--- a/tests/Dockerfile.utils
+++ b/tests/Dockerfile.utils
@@ -7,7 +7,7 @@ RUN go install github.com/open-telemetry/opentelemetry-collector-contrib/cmd/tel
 RUN go install github.com/openshift/tls-scanner/cmd/tls-scanner@b6d99c72ebb7d781fe234ba93c972c787cc980cf
 
 FROM alpine:3.23@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
-RUN apk add --no-cache coreutils procps curl jq bash minio nmap
+RUN apk add --no-cache coreutils procps curl jq bash minio nmap nmap-scripts
 COPY --from=builder /go/bin/hydra /usr/local/bin/hydra
 COPY --from=builder /go/bin/telemetrygen /usr/local/bin/telemetrygen
 COPY --from=builder /go/bin/tls-scanner /usr/local/bin/tls-scanner

--- a/tests/Dockerfile.utils
+++ b/tests/Dockerfile.utils
@@ -1,7 +1,8 @@
 FROM golang:1.26-alpine AS builder
-RUN apk add --no-cache git
+RUN apk add --no-cache git gcc musl-dev
+# SQLite (needed for memory DSN) requires CGO
 RUN git clone --depth 1 --branch v26.2.0 https://github.com/ory/hydra.git /hydra && \
-    cd /hydra && go build -o /go/bin/hydra .
+    cd /hydra && CGO_ENABLED=1 go build -tags sqlite -o /go/bin/hydra .
 
 FROM alpine:3.23@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
 RUN apk add --no-cache curl jq bash minio

--- a/tests/Dockerfile.utils
+++ b/tests/Dockerfile.utils
@@ -2,9 +2,9 @@ FROM golang:1.26-alpine AS builder
 RUN apk add --no-cache git gcc musl-dev
 # SQLite (needed for memory DSN) requires CGO
 RUN git clone --depth 1 --branch v26.2.0 https://github.com/ory/hydra.git /hydra && \
-    cd /hydra && CGO_ENABLED=1 go build -tags sqlite -o /go/bin/hydra .
-RUN go install github.com/open-telemetry/opentelemetry-collector-contrib/cmd/telemetrygen@v0.135.0
-RUN go install github.com/openshift/tls-scanner/cmd/tls-scanner@b6d99c72ebb7d781fe234ba93c972c787cc980cf
+    cd /hydra && CGO_ENABLED=1 go build -tags sqlite -ldflags="-s -w" -o /go/bin/hydra .
+RUN go install -ldflags="-s -w" github.com/open-telemetry/opentelemetry-collector-contrib/cmd/telemetrygen@v0.135.0
+RUN go install -ldflags="-s -w" github.com/openshift/tls-scanner/cmd/tls-scanner@b6d99c72ebb7d781fe234ba93c972c787cc980cf
 
 FROM alpine:3.23@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
 # coreutils, procps: required by testssl.sh

--- a/tests/Dockerfile.utils
+++ b/tests/Dockerfile.utils
@@ -1,7 +1,10 @@
+FROM golang:1.26-alpine AS builder
+RUN apk add --no-cache git
+RUN git clone --depth 1 --branch v26.2.0 https://github.com/ory/hydra.git /hydra && \
+    cd /hydra && go build -o /go/bin/hydra .
+
 FROM alpine:3.23@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
+RUN apk add --no-cache curl jq bash minio
+COPY --from=builder /go/bin/hydra /usr/local/bin/hydra
 
-RUN apk update &&       \
-    apk add --no-cache curl jq bash &&  \
-    rm -rf /var/cache/apk/*
-
-CMD [ "bash" ]
+CMD ["bash"]

--- a/tests/Dockerfile.utils
+++ b/tests/Dockerfile.utils
@@ -7,13 +7,19 @@ RUN go install github.com/open-telemetry/opentelemetry-collector-contrib/cmd/tel
 RUN go install github.com/openshift/tls-scanner/cmd/tls-scanner@b6d99c72ebb7d781fe234ba93c972c787cc980cf
 
 FROM alpine:3.23@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
+# coreutils, procps: required by testssl.sh
+# curl, jq, bash: required by most e2e test scripts
+# minio: s3 storage for e2e tests
+# nmap, nmap-scripts: required in e2e-openshift-tls-profile tests
 RUN apk add --no-cache coreutils procps curl jq bash minio nmap nmap-scripts
+# hydra: required by multitenancy auth tests
 COPY --from=builder /go/bin/hydra /usr/local/bin/hydra
+# telemetrygen: generate traces
 COPY --from=builder /go/bin/telemetrygen /usr/local/bin/telemetrygen
+# tls-scanner: required by e2e-openshift-tls-profile tests
 COPY --from=builder /go/bin/tls-scanner /usr/local/bin/tls-scanner
 
-# Install testssl.sh (required by tls-scanner)
-# testssl.sh requires coreutils and procps
+# testssl.sh: used by tls-scanner
 ARG TESTSSL_VERSION=3.2.2
 RUN curl -L "https://testssl.sh/testssl.sh-${TESTSSL_VERSION}.tar.gz" -o /tmp/testssl.tar.gz && \
     mkdir -p /opt/testssl && \


### PR DESCRIPTION
The upstream minio and hydra images did not support s390x and/or ppc64 architectures.