### PR TITLE
chore: update e2e tests to use all test utils from test-utils image

### DIFF
--- a/tests/e2e-long-running/tempostack-retention-global/00-install-storage.yaml
+++ b/tests/e2e-long-running/tempostack-retention-global/00-install-storage.yaml
@@ -38,7 +38,7 @@ spec:
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: quay.io/minio/minio:latest
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
           name: minio
           ports:
             - containerPort: 9000

--- a/tests/e2e-long-running/tempostack-retention-global/03-generate-traces.yaml
+++ b/tests/e2e-long-running/tempostack-retention-global/03-generate-traces.yaml
@@ -7,8 +7,9 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-        args:
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - telemetrygen
         - traces
         - --otlp-endpoint=tempo-global-distributor:4317
         - --otlp-insecure

--- a/tests/e2e-openshift-object-stores/aws-sts-cco-monolithic/03-generate-traces.yaml
+++ b/tests/e2e-openshift-object-stores/aws-sts-cco-monolithic/03-generate-traces.yaml
@@ -8,8 +8,9 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-        args:
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - telemetrygen
         - traces
         - --otlp-endpoint=tempo-tmonocco.chainsaw-awscco-mono.svc:4317
         - --otlp-insecure

--- a/tests/e2e-openshift-object-stores/aws-sts-cco-tempostack/04-generate-traces.yaml
+++ b/tests/e2e-openshift-object-stores/aws-sts-cco-tempostack/04-generate-traces.yaml
@@ -8,8 +8,9 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-        args:
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - telemetrygen
         - traces
         - --otlp-endpoint=tempo-tmcco-distributor.chainsaw-awscco-tempo.svc:4317
         - --otlp-insecure

--- a/tests/e2e-openshift-object-stores/aws-sts-monolithic/03-generate-traces.yaml
+++ b/tests/e2e-openshift-object-stores/aws-sts-monolithic/03-generate-traces.yaml
@@ -8,8 +8,9 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-        args:
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - telemetrygen
         - traces
         - --otlp-endpoint=tempo-tmmono.chainsaw-awssts-mono.svc:4317
         - --otlp-insecure

--- a/tests/e2e-openshift-object-stores/aws-sts-tempostack/03-generate-traces.yaml
+++ b/tests/e2e-openshift-object-stores/aws-sts-tempostack/03-generate-traces.yaml
@@ -8,8 +8,9 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-        args:
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - telemetrygen
         - traces
         - --otlp-endpoint=tempo-tmstack-distributor.chainsaw-awssts-tempo.svc:4317
         - --otlp-insecure

--- a/tests/e2e-openshift-object-stores/azure-wif-monolithic/03-generate-traces.yaml
+++ b/tests/e2e-openshift-object-stores/azure-wif-monolithic/03-generate-traces.yaml
@@ -8,8 +8,9 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-        args:
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - telemetrygen
         - traces
         - --otlp-endpoint=tempo-azurewifmn.chainsaw-azurewif-mono.svc:4317
         - --otlp-insecure

--- a/tests/e2e-openshift-object-stores/azure-wif-tempostack/03-generate-traces.yaml
+++ b/tests/e2e-openshift-object-stores/azure-wif-tempostack/03-generate-traces.yaml
@@ -8,8 +8,9 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-        args:
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - telemetrygen
         - traces
         - --otlp-endpoint=tempo-azurewiftm-distributor.chainsaw-azurewif-tempo.svc:4317
         - --otlp-insecure

--- a/tests/e2e-openshift-object-stores/gcp-wif-monolithic/03-generate-traces.yaml
+++ b/tests/e2e-openshift-object-stores/gcp-wif-monolithic/03-generate-traces.yaml
@@ -8,8 +8,9 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-        args:
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - telemetrygen
         - traces
         - --otlp-endpoint=tempo-gcpwifmn.chainsaw-gcpwif-mono.svc:4317
         - --otlp-insecure

--- a/tests/e2e-openshift-object-stores/gcp-wif-tempostack/03-generate-traces.yaml
+++ b/tests/e2e-openshift-object-stores/gcp-wif-tempostack/03-generate-traces.yaml
@@ -8,8 +8,9 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-        args:
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - telemetrygen
         - traces
         - --otlp-endpoint=tempo-gcpwiftm-distributor.chainsaw-gcpwif-tempo.svc:4317
         - --otlp-insecure

--- a/tests/e2e-openshift-object-stores/monolithic-aws/03-generate-traces.yaml
+++ b/tests/e2e-openshift-object-stores/monolithic-aws/03-generate-traces.yaml
@@ -7,8 +7,9 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.75.0
-        args:
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - telemetrygen
         - traces
         - --otlp-endpoint=tempo-simplest:4317
         - --otlp-insecure

--- a/tests/e2e-openshift-object-stores/monolithic-azure/03-generate-traces.yaml
+++ b/tests/e2e-openshift-object-stores/monolithic-azure/03-generate-traces.yaml
@@ -7,8 +7,9 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.135.0
-        args:
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - telemetrygen
         - traces
         - --otlp-endpoint=tempo-simplest:4317
         - --otlp-insecure

--- a/tests/e2e-openshift-object-stores/monolithic-gcs/03-generate-traces.yaml
+++ b/tests/e2e-openshift-object-stores/monolithic-gcs/03-generate-traces.yaml
@@ -7,8 +7,9 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.75.0
-        args:
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - telemetrygen
         - traces
         - --otlp-endpoint=tempo-simplest:4317
         - --otlp-insecure

--- a/tests/e2e-openshift-object-stores/monolithic-ibm/03-generate-traces.yaml
+++ b/tests/e2e-openshift-object-stores/monolithic-ibm/03-generate-traces.yaml
@@ -7,8 +7,9 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.75.0
-        args:
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - telemetrygen
         - traces
         - --otlp-endpoint=tempo-simplest:4317
         - --otlp-insecure

--- a/tests/e2e-openshift-object-stores/tempostack-aws/02-generate-traces.yaml
+++ b/tests/e2e-openshift-object-stores/tempostack-aws/02-generate-traces.yaml
@@ -7,8 +7,9 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:latest
-        args:
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - telemetrygen
         - traces
         - --otlp-endpoint=tempo-simplest-distributor:4317
         - --otlp-insecure

--- a/tests/e2e-openshift-object-stores/tempostack-azure/02-generate-traces.yaml
+++ b/tests/e2e-openshift-object-stores/tempostack-azure/02-generate-traces.yaml
@@ -7,8 +7,9 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:latest
-        args:
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - telemetrygen
         - traces
         - --otlp-endpoint=tempo-simplest-distributor:4317
         - --otlp-insecure

--- a/tests/e2e-openshift-object-stores/tempostack-gcs/02-generate-traces.yaml
+++ b/tests/e2e-openshift-object-stores/tempostack-gcs/02-generate-traces.yaml
@@ -7,8 +7,9 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:latest
-        args:
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - telemetrygen
         - traces
         - --otlp-endpoint=tempo-simplest-distributor:4317
         - --otlp-insecure

--- a/tests/e2e-openshift-object-stores/tempostack-ibm/02-generate-traces.yaml
+++ b/tests/e2e-openshift-object-stores/tempostack-ibm/02-generate-traces.yaml
@@ -7,8 +7,9 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:latest
-        args:
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - telemetrygen
         - traces
         - --otlp-endpoint=tempo-simplest-distributor:4317
         - --otlp-insecure

--- a/tests/e2e-openshift-ossm/ossm-monolithic-otel/08-generate-traces-otel.yaml
+++ b/tests/e2e-openshift-ossm/ossm-monolithic-otel/08-generate-traces-otel.yaml
@@ -8,8 +8,9 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-        args:
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - telemetrygen
         - traces
         - --otlp-endpoint=simplest-collector.tracing-system.svc.cluster.local:4318
         - --traces=10
@@ -30,8 +31,9 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-        args:
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - telemetrygen
         - traces
         - --otlp-endpoint=simplest-collector.tracing-system.svc.cluster.local:4317
         - --traces=10

--- a/tests/e2e-openshift-ossm/ossm-tempostack-otel/01-install-minio.yaml
+++ b/tests/e2e-openshift-ossm/ossm-tempostack-otel/01-install-minio.yaml
@@ -40,7 +40,7 @@ spec:
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: quay.io/minio/minio:latest
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
           name: minio
           ports:
             - containerPort: 9000

--- a/tests/e2e-openshift-ossm/ossm-tempostack-otel/09-generate-traces-otel.yaml
+++ b/tests/e2e-openshift-ossm/ossm-tempostack-otel/09-generate-traces-otel.yaml
@@ -8,8 +8,9 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-        args:
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - telemetrygen
         - traces
         - --otlp-endpoint=simplest-collector.tracing-system.svc.cluster.local:4318
         - --traces=10
@@ -30,8 +31,9 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-        args:
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - telemetrygen
         - traces
         - --otlp-endpoint=simplest-collector.tracing-system.svc.cluster.local:4317
         - --traces=10

--- a/tests/e2e-openshift-ossm/ossm-tempostack/01-install-minio.yaml
+++ b/tests/e2e-openshift-ossm/ossm-tempostack/01-install-minio.yaml
@@ -40,7 +40,7 @@ spec:
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: quay.io/minio/minio:latest
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
           name: minio
           ports:
             - containerPort: 9000

--- a/tests/e2e-openshift-serverless/otel-tempo-serverless/00-install-minio.yaml
+++ b/tests/e2e-openshift-serverless/otel-tempo-serverless/00-install-minio.yaml
@@ -40,7 +40,7 @@ spec:
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: quay.io/minio/minio:latest
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
           name: minio
           ports:
             - containerPort: 9000

--- a/tests/e2e-openshift-serverless/tempo-serverless/00-install-minio.yaml
+++ b/tests/e2e-openshift-serverless/tempo-serverless/00-install-minio.yaml
@@ -40,7 +40,7 @@ spec:
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: quay.io/minio/minio:latest
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
           name: minio
           ports:
             - containerPort: 9000

--- a/tests/e2e-openshift-tls-profile/01-tls-profile-override-mono/01-install-storage.yaml
+++ b/tests/e2e-openshift-tls-profile/01-tls-profile-override-mono/01-install-storage.yaml
@@ -39,13 +39,13 @@ spec:
             - -c
             - |
               mkdir -p /storage/tempo && \
-              minio server --certs-dir=/root/.minio/certs /storage
+              minio server --certs-dir=/tmp/.minio/certs /storage
           env:
             - name: MINIO_ACCESS_KEY
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: quay.io/minio/minio:latest
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
           name: minio
           ports:
             - containerPort: 9000
@@ -53,7 +53,7 @@ spec:
             - mountPath: /storage
               name: storage
             - name: cert
-              mountPath: /root/.minio/certs
+              mountPath: /tmp/.minio/certs
       volumes:
         - name: storage
           emptyDir: {}

--- a/tests/e2e-openshift-tls-profile/01-tls-profile-override-mono/03-install-tls-scanner.yaml
+++ b/tests/e2e-openshift-tls-profile/01-tls-profile-override-mono/03-install-tls-scanner.yaml
@@ -54,7 +54,7 @@ spec:
   serviceAccountName: tls-scanner
   containers:
   - name: tls-scanner
-    image: quay.io/rhn_support_ikanse/tls-scanner:latest
+    image: ghcr.io/grafana/tempo-operator/test-utils:main
     command: ["sleep", "infinity"]
     securityContext:
       privileged: true

--- a/tests/e2e-openshift-tls-profile/01-tls-profile-override-mono/06-generate-traces.yaml
+++ b/tests/e2e-openshift-tls-profile/01-tls-profile-override-mono/06-generate-traces.yaml
@@ -8,8 +8,9 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-        args:
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - telemetrygen
         - traces
         - --otlp-endpoint=dev-collector:4317
         - --service=grpc
@@ -27,8 +28,9 @@ spec:
     spec:
       containers:
         - name: telemetrygen
-          image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-          args:
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
+          command:
+            - telemetrygen
             - traces
             - --otlp-endpoint=dev-collector:4318
             - --otlp-http

--- a/tests/e2e-openshift-tls-profile/01-tls-profile-override-mono/11-generate-traces-cr-override.yaml
+++ b/tests/e2e-openshift-tls-profile/01-tls-profile-override-mono/11-generate-traces-cr-override.yaml
@@ -8,8 +8,9 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-        args:
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - telemetrygen
         - traces
         - --otlp-endpoint=dev-collector:4317
         - --service=grpc-override
@@ -27,8 +28,9 @@ spec:
     spec:
       containers:
         - name: telemetrygen
-          image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-          args:
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
+          command:
+            - telemetrygen
             - traces
             - --otlp-endpoint=dev-collector:4318
             - --otlp-http

--- a/tests/e2e-openshift-tls-profile/02-tls-profile-override-stack/01-install-storage.yaml
+++ b/tests/e2e-openshift-tls-profile/02-tls-profile-override-stack/01-install-storage.yaml
@@ -39,13 +39,13 @@ spec:
             - -c
             - |
               mkdir -p /storage/tempo && \
-              minio server --certs-dir=/root/.minio/certs /storage
+              minio server --certs-dir=/tmp/.minio/certs /storage
           env:
             - name: MINIO_ACCESS_KEY
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: quay.io/minio/minio:latest
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
           name: minio
           ports:
             - containerPort: 9000
@@ -53,7 +53,7 @@ spec:
             - mountPath: /storage
               name: storage
             - name: cert
-              mountPath: /root/.minio/certs
+              mountPath: /tmp/.minio/certs
       volumes:
         - name: storage
           emptyDir: {}

--- a/tests/e2e-openshift-tls-profile/02-tls-profile-override-stack/03-install-tls-scanner.yaml
+++ b/tests/e2e-openshift-tls-profile/02-tls-profile-override-stack/03-install-tls-scanner.yaml
@@ -54,7 +54,7 @@ spec:
   serviceAccountName: tls-scanner
   containers:
   - name: tls-scanner
-    image: quay.io/rhn_support_ikanse/tls-scanner:latest
+    image: ghcr.io/grafana/tempo-operator/test-utils:main
     command: ["sleep", "infinity"]
     securityContext:
       privileged: true

--- a/tests/e2e-openshift-tls-profile/02-tls-profile-override-stack/06-generate-traces.yaml
+++ b/tests/e2e-openshift-tls-profile/02-tls-profile-override-stack/06-generate-traces.yaml
@@ -8,8 +8,9 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-        args:
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - telemetrygen
         - traces
         - --otlp-endpoint=dev-collector:4317
         - --service=grpc
@@ -27,8 +28,9 @@ spec:
     spec:
       containers:
         - name: telemetrygen
-          image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-          args:
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
+          command:
+            - telemetrygen
             - traces
             - --otlp-endpoint=dev-collector:4318
             - --otlp-http

--- a/tests/e2e-openshift-tls-profile/02-tls-profile-override-stack/11-generate-traces-cr-override.yaml
+++ b/tests/e2e-openshift-tls-profile/02-tls-profile-override-stack/11-generate-traces-cr-override.yaml
@@ -8,8 +8,9 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-        args:
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - telemetrygen
         - traces
         - --otlp-endpoint=dev-collector:4317
         - --service=grpc-override
@@ -27,8 +28,9 @@ spec:
     spec:
       containers:
         - name: telemetrygen
-          image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-          args:
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
+          command:
+            - telemetrygen
             - traces
             - --otlp-endpoint=dev-collector:4318
             - --otlp-http

--- a/tests/e2e-openshift-tls-profile/03-tls-profile/00-install-storage.yaml
+++ b/tests/e2e-openshift-tls-profile/03-tls-profile/00-install-storage.yaml
@@ -39,13 +39,13 @@ spec:
             - -c
             - |
               mkdir -p /storage/tempo && \
-              minio server --certs-dir=/root/.minio/certs /storage
+              minio server --certs-dir=/tmp/.minio/certs /storage
           env:
             - name: MINIO_ACCESS_KEY
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: quay.io/minio/minio:latest
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
           name: minio
           ports:
             - containerPort: 9000
@@ -53,7 +53,7 @@ spec:
             - mountPath: /storage
               name: storage
             - name: cert
-              mountPath: /root/.minio/certs
+              mountPath: /tmp/.minio/certs
       volumes:
         - name: storage
           emptyDir: {}

--- a/tests/e2e-openshift-tls-profile/03-tls-profile/02-install-tls-scanner.yaml
+++ b/tests/e2e-openshift-tls-profile/03-tls-profile/02-install-tls-scanner.yaml
@@ -54,7 +54,7 @@ spec:
   serviceAccountName: tls-scanner
   containers:
   - name: tls-scanner
-    image: quay.io/rhn_support_ikanse/tls-scanner:latest
+    image: ghcr.io/grafana/tempo-operator/test-utils:main
     command: ["sleep", "infinity"]
     securityContext:
       privileged: true

--- a/tests/e2e-openshift-tls-profile/03-tls-profile/05-generate-traces.yaml
+++ b/tests/e2e-openshift-tls-profile/03-tls-profile/05-generate-traces.yaml
@@ -8,8 +8,9 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-        args:
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - telemetrygen
         - traces
         - --otlp-endpoint=dev-collector:4317
         - --service=grpc
@@ -27,8 +28,9 @@ spec:
     spec:
       containers:
         - name: telemetrygen
-          image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-          args:
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
+          command:
+            - telemetrygen
             - traces
             - --otlp-endpoint=dev-collector:4318
             - --otlp-http
@@ -47,8 +49,9 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-        args:
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - telemetrygen
         - traces
         - --otlp-endpoint=dev-mono-collector:4317
         - --service=grpc-mono
@@ -66,8 +69,9 @@ spec:
     spec:
       containers:
         - name: telemetrygen
-          image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-          args:
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
+          command:
+            - telemetrygen
             - traces
             - --otlp-endpoint=dev-mono-collector:4318
             - --otlp-http

--- a/tests/e2e-openshift-tls-profile/03-tls-profile/08-verify-modern.sh
+++ b/tests/e2e-openshift-tls-profile/03-tls-profile/08-verify-modern.sh
@@ -33,7 +33,7 @@ spec:
   serviceAccountName: tls-scanner
   containers:
   - name: tls-scanner
-    image: quay.io/rhn_support_ikanse/tls-scanner:latest
+    image: ghcr.io/grafana/tempo-operator/test-utils:main
     command: ["sleep", "infinity"]
     securityContext:
       privileged: true

--- a/tests/e2e-openshift-tls-profile/03-tls-profile/09-generate-traces-modern.yaml
+++ b/tests/e2e-openshift-tls-profile/03-tls-profile/09-generate-traces-modern.yaml
@@ -8,8 +8,9 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-        args:
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - telemetrygen
         - traces
         - --otlp-endpoint=dev-collector:4317
         - --service=grpc-modern
@@ -27,8 +28,9 @@ spec:
     spec:
       containers:
         - name: telemetrygen
-          image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-          args:
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
+          command:
+            - telemetrygen
             - traces
             - --otlp-endpoint=dev-collector:4318
             - --otlp-http
@@ -47,8 +49,9 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-        args:
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - telemetrygen
         - traces
         - --otlp-endpoint=dev-mono-collector:4317
         - --service=grpc-mono-modern
@@ -66,8 +69,9 @@ spec:
     spec:
       containers:
         - name: telemetrygen
-          image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-          args:
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
+          command:
+            - telemetrygen
             - traces
             - --otlp-endpoint=dev-mono-collector:4318
             - --otlp-http

--- a/tests/e2e-openshift-tls-profile/README.md
+++ b/tests/e2e-openshift-tls-profile/README.md
@@ -7,7 +7,7 @@ This directory contains end-to-end tests for TLS profile management in the Tempo
 - OpenShift cluster with OLM-managed Tempo Operator
 - `oc` and `kubectl` CLI tools
 - Chainsaw test runner (`chainsaw`)
-- The `tls-scanner` image (`quay.io/rhn_support_ikanse/tls-scanner:latest`)
+- The `tls-scanner` image (`ghcr.io/grafana/tempo-operator/test-utils:main`)
 
 ## Running the Tests
 

--- a/tests/e2e-openshift-tshirt-sizes/tshirt-size-demo/00-install-storage.yaml
+++ b/tests/e2e-openshift-tshirt-sizes/tshirt-size-demo/00-install-storage.yaml
@@ -25,7 +25,7 @@ spec:
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: quay.io/minio/minio:latest
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
           name: minio
           ports:
             - containerPort: 9000

--- a/tests/e2e-openshift-tshirt-sizes/tshirt-size-extra-small/00-install-storage.yaml
+++ b/tests/e2e-openshift-tshirt-sizes/tshirt-size-extra-small/00-install-storage.yaml
@@ -25,7 +25,7 @@ spec:
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: quay.io/minio/minio:latest
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
           name: minio
           ports:
             - containerPort: 9000

--- a/tests/e2e-openshift-tshirt-sizes/tshirt-size-medium/00-install-storage.yaml
+++ b/tests/e2e-openshift-tshirt-sizes/tshirt-size-medium/00-install-storage.yaml
@@ -25,7 +25,7 @@ spec:
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: quay.io/minio/minio:latest
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
           name: minio
           ports:
             - containerPort: 9000

--- a/tests/e2e-openshift-tshirt-sizes/tshirt-size-oauth-proxy/00-install-storage.yaml
+++ b/tests/e2e-openshift-tshirt-sizes/tshirt-size-oauth-proxy/00-install-storage.yaml
@@ -25,7 +25,7 @@ spec:
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: quay.io/minio/minio:latest
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
           name: minio
           ports:
             - containerPort: 9000

--- a/tests/e2e-openshift-tshirt-sizes/tshirt-size-override/00-install-storage.yaml
+++ b/tests/e2e-openshift-tshirt-sizes/tshirt-size-override/00-install-storage.yaml
@@ -25,7 +25,7 @@ spec:
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: quay.io/minio/minio:latest
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
           name: minio
           ports:
             - containerPort: 9000

--- a/tests/e2e-openshift-tshirt-sizes/tshirt-size-pico/00-install-storage.yaml
+++ b/tests/e2e-openshift-tshirt-sizes/tshirt-size-pico/00-install-storage.yaml
@@ -25,7 +25,7 @@ spec:
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: quay.io/minio/minio:latest
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
           name: minio
           ports:
             - containerPort: 9000

--- a/tests/e2e-openshift-tshirt-sizes/tshirt-size-small/00-install-storage.yaml
+++ b/tests/e2e-openshift-tshirt-sizes/tshirt-size-small/00-install-storage.yaml
@@ -25,7 +25,7 @@ spec:
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: quay.io/minio/minio:latest
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
           name: minio
           ports:
             - containerPort: 9000

--- a/tests/e2e-openshift-upgrade/upgrade/01-install-storage.yaml
+++ b/tests/e2e-openshift-upgrade/upgrade/01-install-storage.yaml
@@ -46,7 +46,7 @@ spec:
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: quay.io/minio/minio:latest
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
           name: minio
           ports:
             - containerPort: 9000

--- a/tests/e2e-openshift-upgrade/upgrade/08-tempostack-rbac-sa-1-traces-gen.yaml
+++ b/tests/e2e-openshift-upgrade/upgrade/08-tempostack-rbac-sa-1-traces-gen.yaml
@@ -8,8 +8,9 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-        args:
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - telemetrygen
         - traces
         - --otlp-endpoint=dev-collector.chainsaw-rbac.svc:4317
         - --service=grpc-rbac-1
@@ -29,8 +30,9 @@ spec:
     spec:
       containers:
         - name: telemetrygen
-          image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-          args:
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
+          command:
+            - telemetrygen
             - traces
             - --otlp-endpoint=dev-collector.chainsaw-rbac.svc:4318
             - --otlp-http

--- a/tests/e2e-openshift-upgrade/upgrade/09-tempo-mono-rbac-sa-1-traces-gen.yaml
+++ b/tests/e2e-openshift-upgrade/upgrade/09-tempo-mono-rbac-sa-1-traces-gen.yaml
@@ -8,8 +8,9 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-        args:
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - telemetrygen
         - traces
         - --otlp-endpoint=dev-collector.chainsaw-mmo-rbac.svc:4317
         - --service=grpc-rbac-1
@@ -29,8 +30,9 @@ spec:
     spec:
       containers:
         - name: telemetrygen
-          image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-          args:
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
+          command:
+            - telemetrygen
             - traces
             - --otlp-endpoint=dev-collector.chainsaw-mmo-rbac.svc:4318
             - --otlp-http

--- a/tests/e2e-openshift-upgrade/upgrade/10-tempostack-rbac-sa-2-traces-gen.yaml
+++ b/tests/e2e-openshift-upgrade/upgrade/10-tempostack-rbac-sa-2-traces-gen.yaml
@@ -8,8 +8,9 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-        args:
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - telemetrygen
         - traces
         - --otlp-endpoint=dev-collector.chainsaw-rbac.svc:4317
         - --service=grpc-rbac-2
@@ -29,8 +30,9 @@ spec:
     spec:
       containers:
         - name: telemetrygen
-          image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-          args:
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
+          command:
+            - telemetrygen
             - traces
             - --otlp-endpoint=dev-collector.chainsaw-rbac.svc:4318
             - --otlp-http

--- a/tests/e2e-openshift-upgrade/upgrade/11-tempo-mono-rbac-sa-2-traces-gen.yaml
+++ b/tests/e2e-openshift-upgrade/upgrade/11-tempo-mono-rbac-sa-2-traces-gen.yaml
@@ -8,8 +8,9 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-        args:
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - telemetrygen
         - traces
         - --otlp-endpoint=dev-collector.chainsaw-mmo-rbac.svc:4317
         - --service=grpc-rbac-2
@@ -29,8 +30,9 @@ spec:
     spec:
       containers:
         - name: telemetrygen
-          image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-          args:
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
+          command:
+            - telemetrygen
             - traces
             - --otlp-endpoint=dev-collector.chainsaw-mmo-rbac.svc:4318
             - --otlp-http

--- a/tests/e2e-openshift/component-replicas/00-install-storage.yaml
+++ b/tests/e2e-openshift/component-replicas/00-install-storage.yaml
@@ -41,7 +41,7 @@ spec:
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: quay.io/minio/minio:latest
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
           name: minio
           ports:
             - containerPort: 9000

--- a/tests/e2e-openshift/component-replicas/04-generate-traces.yaml
+++ b/tests/e2e-openshift/component-replicas/04-generate-traces.yaml
@@ -8,8 +8,9 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-        args:
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - telemetrygen
         - traces
         - --otlp-endpoint=dev-collector:4317
         - --service=grpc
@@ -27,8 +28,9 @@ spec:
     spec:
       containers:
         - name: telemetrygen
-          image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-          args:
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
+          command:
+            - telemetrygen
             - traces
             - --otlp-endpoint=dev-collector:4318
             - --otlp-http

--- a/tests/e2e-openshift/monitoring-monolithic/02-generate-traces.yaml
+++ b/tests/e2e-openshift/monitoring-monolithic/02-generate-traces.yaml
@@ -7,8 +7,9 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-        args:
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - telemetrygen
         - traces
         - --otlp-endpoint=tempo-monitor:4317
         - --otlp-insecure

--- a/tests/e2e-openshift/monitoring-monolithic/03-verify-traces.yaml
+++ b/tests/e2e-openshift/monitoring-monolithic/03-verify-traces.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
       - name: verify-traces
-        image: registry.access.redhat.com/ubi9/ubi:9.1
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
         command:
         - /bin/bash
         - -eux

--- a/tests/e2e-openshift/monitoring-monolithic/README.md
+++ b/tests/e2e-openshift/monitoring-monolithic/README.md
@@ -146,8 +146,9 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-        args:
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - telemetrygen
         - traces
         - --otlp-endpoint=tempo-monitor:4317
         - --otlp-insecure

--- a/tests/e2e-openshift/monitoring/00-install-storage.yaml
+++ b/tests/e2e-openshift/monitoring/00-install-storage.yaml
@@ -48,7 +48,7 @@ spec:
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: quay.io/minio/minio:latest
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
           name: minio
           ports:
             - containerPort: 9000

--- a/tests/e2e-openshift/monitoring/03-generate-traces.yaml
+++ b/tests/e2e-openshift/monitoring/03-generate-traces.yaml
@@ -7,8 +7,9 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-        args:
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - telemetrygen
         - traces
         - --otlp-endpoint=tempo-tempostack-distributor.chainsaw-monitoring.svc:4317
         - --otlp-insecure

--- a/tests/e2e-openshift/monitoring/04-verify-traces.yaml
+++ b/tests/e2e-openshift/monitoring/04-verify-traces.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
       - name: verify-traces
-        image: registry.access.redhat.com/ubi9/ubi:9.1
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
         command:
         - /bin/bash
         - -eux

--- a/tests/e2e-openshift/monolithic-multitenancy-openshift/00-install-storage.yaml
+++ b/tests/e2e-openshift/monolithic-multitenancy-openshift/00-install-storage.yaml
@@ -57,13 +57,13 @@ spec:
             - -c
             - |
               mkdir -p /storage/tempo && \
-              minio server --certs-dir=/root/.minio/certs /storage
+              minio server --certs-dir=/tmp/.minio/certs /storage
           env:
             - name: MINIO_ACCESS_KEY
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: quay.io/minio/minio:latest
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
           name: minio
           ports:
             - containerPort: 9000
@@ -71,7 +71,7 @@ spec:
             - mountPath: /storage
               name: storage
             - name: cert
-              mountPath: /root/.minio/certs
+              mountPath: /tmp/.minio/certs
       volumes:
         - name: storage
           persistentVolumeClaim:

--- a/tests/e2e-openshift/monolithic-multitenancy-openshift/03-generate-traces.yaml
+++ b/tests/e2e-openshift/monolithic-multitenancy-openshift/03-generate-traces.yaml
@@ -7,8 +7,9 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-        args:
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - telemetrygen
         - traces
         - --otlp-endpoint=dev-collector:4317
         - --service=grpc
@@ -25,8 +26,9 @@ spec:
     spec:
       containers:
         - name: telemetrygen
-          image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-          args:
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
+          command:
+            - telemetrygen
             - traces
             - --otlp-endpoint=dev-collector:4318
             - --otlp-http

--- a/tests/e2e-openshift/monolithic-multitenancy-openshift/README.md
+++ b/tests/e2e-openshift/monolithic-multitenancy-openshift/README.md
@@ -372,8 +372,9 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-        args:
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - telemetrygen
         - traces
         - --otlp-endpoint=dev-collector:4317
         - --otlp-insecure

--- a/tests/e2e-openshift/monolithic-multitenancy-rbac/03-tempo-rbac-sa-1-traces-gen.yaml
+++ b/tests/e2e-openshift/monolithic-multitenancy-rbac/03-tempo-rbac-sa-1-traces-gen.yaml
@@ -8,8 +8,9 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-        args:
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - telemetrygen
         - traces
         - --otlp-endpoint=dev-collector.chainsaw-mmo-rbac.svc:4317
         - --service=grpc-rbac-1
@@ -29,8 +30,9 @@ spec:
     spec:
       containers:
         - name: telemetrygen
-          image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-          args:
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
+          command:
+            - telemetrygen
             - traces
             - --otlp-endpoint=dev-collector.chainsaw-mmo-rbac.svc:4318
             - --otlp-http

--- a/tests/e2e-openshift/monolithic-multitenancy-rbac/04-tempo-rbac-sa-2-traces-gen.yaml
+++ b/tests/e2e-openshift/monolithic-multitenancy-rbac/04-tempo-rbac-sa-2-traces-gen.yaml
@@ -8,8 +8,9 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-        args:
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - telemetrygen
         - traces
         - --otlp-endpoint=dev-collector.chainsaw-mmo-rbac.svc:4317
         - --service=grpc-rbac-2
@@ -29,8 +30,9 @@ spec:
     spec:
       containers:
         - name: telemetrygen
-          image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-          args:
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
+          command:
+            - telemetrygen
             - traces
             - --otlp-endpoint=dev-collector.chainsaw-mmo-rbac.svc:4318
             - --otlp-http

--- a/tests/e2e-openshift/monolithic-multitenancy-rbac/README.md
+++ b/tests/e2e-openshift/monolithic-multitenancy-rbac/README.md
@@ -291,8 +291,9 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-        args:
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - telemetrygen
         - traces
         - --otlp-endpoint=dev-collector.chainsaw-mmo-rbac.svc:4317
         - --service=grpc-rbac-1
@@ -312,8 +313,9 @@ spec:
     spec:
       containers:
         - name: telemetrygen
-          image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-          args:
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
+          command:
+            - telemetrygen
             - traces
             - --otlp-endpoint=dev-collector.chainsaw-mmo-rbac.svc:4318
             - --otlp-http

--- a/tests/e2e-openshift/monolithic-multitenancy-receiver-tls/03-generate-traces.yaml
+++ b/tests/e2e-openshift/monolithic-multitenancy-receiver-tls/03-generate-traces.yaml
@@ -7,8 +7,9 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-        args:
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - telemetrygen
         - traces
         - --otlp-endpoint=dev-collector:4317
         - --service=grpc
@@ -25,8 +26,9 @@ spec:
     spec:
       containers:
         - name: telemetrygen
-          image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-          args:
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
+          command:
+            - telemetrygen
             - traces
             - --otlp-endpoint=dev-collector:4318
             - --otlp-http

--- a/tests/e2e-openshift/monolithic-multitenancy-static/00-install-hydra.yaml
+++ b/tests/e2e-openshift/monolithic-multitenancy-static/00-install-hydra.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: hydra
-        image: docker.io/oryd/hydra:v2.2.0
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
         command: ["hydra", "serve", "all", "--dev", "--sqa-opt-out"]
         env:
         - name: DSN

--- a/tests/e2e-openshift/monolithic-multitenancy-static/04-generate-traces.yaml
+++ b/tests/e2e-openshift/monolithic-multitenancy-static/04-generate-traces.yaml
@@ -7,8 +7,9 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-        args:
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - telemetrygen
         - traces
         - --otlp-endpoint=opentelemetry-collector:4317
         - --otlp-insecure

--- a/tests/e2e-openshift/monolithic-multitenancy-static/README.md
+++ b/tests/e2e-openshift/monolithic-multitenancy-static/README.md
@@ -66,7 +66,7 @@ spec:
     spec:
       containers:
       - name: hydra
-        image: docker.io/oryd/hydra:v2.2.0
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
         command: ["hydra", "serve", "all", "--dev", "--sqa-opt-out"]
         env:
         - name: DSN
@@ -744,7 +744,7 @@ spec:
     spec:
       containers:
       - name: hydra
-        image: docker.io/oryd/hydra:v2.2.0
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
         env:
         - name: DSN
           value: postgres://user:password@postgres:5432/hydra

--- a/tests/e2e-openshift/monolithic-route/README.md
+++ b/tests/e2e-openshift/monolithic-route/README.md
@@ -132,14 +132,14 @@ TEMPO_NAMESPACE=$(oc get pods -A \
 # Execute must-gather
 oc adm must-gather \
   --dest-dir=$MUST_GATHER_DIR \
-  --image=quay.io/rhn_support_ikanse/tempo-must-gather:latest \
+  --image=ghcr.io/grafana/tempo-operator/must-gather:latest \
   -- /usr/bin/must-gather --operator-namespace $TEMPO_NAMESPACE
 ```
 
 **Must-Gather Execution Details**:
 
 #### Must-Gather Image
-- **Container Image**: `quay.io/rhn_support_ikanse/tempo-must-gather:latest`
+- **Container Image**: `ghcr.io/grafana/tempo-operator/must-gather:latest`
 - **Purpose**: Specialized data collection for Tempo Operator
 - **Scope**: Comprehensive resource and configuration collection
 
@@ -439,7 +439,7 @@ OUTPUT_DIR="/support-data/${CLUSTER_NAME}-${TIMESTAMP}"
 # Run must-gather with automatic cleanup
 oc adm must-gather \
   --dest-dir="$OUTPUT_DIR" \
-  --image=quay.io/rhn_support_ikanse/tempo-must-gather:latest \
+  --image=ghcr.io/grafana/tempo-operator/must-gather:latest \
   -- /usr/bin/must-gather --all-namespaces
 
 # Create support bundle
@@ -463,7 +463,7 @@ spec:
         spec:
           containers:
           - name: health-check
-            image: quay.io/rhn_support_ikanse/tempo-must-gather:latest
+            image: ghcr.io/grafana/tempo-operator/must-gather:latest
             command:
             - /bin/bash
             - -c
@@ -474,7 +474,7 @@ spec:
               
               # Collect must-gather if issues detected
               if ! oc get tempomonolithic -A --no-headers | grep -q Ready; then
-                oc adm must-gather --image=quay.io/rhn_support_ikanse/tempo-must-gather:latest
+                oc adm must-gather --image=ghcr.io/grafana/tempo-operator/must-gather:latest
               fi
           restartPolicy: OnFailure
 ```
@@ -515,7 +515,7 @@ if [[ "$SEVERITY" == "critical" ]]; then
   TIMESTAMP=$(date +%Y%m%d-%H%M%S)
   oc adm must-gather \
     --dest-dir="/tmp/critical-${ALERT_NAME}-${TIMESTAMP}" \
-    --image=quay.io/rhn_support_ikanse/tempo-must-gather:latest
+    --image=ghcr.io/grafana/tempo-operator/must-gather:latest
     
   # Upload to support system or S3 bucket
   # Send notification to support team
@@ -558,7 +558,7 @@ oc get secret -n openshift-ingress | grep router-certs
 #### Image Pull Problems
 ```bash
 # Check must-gather image availability
-oc run test-must-gather --image=quay.io/rhn_support_ikanse/tempo-must-gather:latest --rm -it -- /bin/bash
+oc run test-must-gather --image=ghcr.io/grafana/tempo-operator/must-gather:latest --rm -it -- /bin/bash
 
 # Verify image registry access
 oc describe pod <must-gather-pod-name> | grep -A10 "Events:"

--- a/tests/e2e-openshift/monolithic-single-tenant-auth/01-generate-traces.yaml
+++ b/tests/e2e-openshift/monolithic-single-tenant-auth/01-generate-traces.yaml
@@ -8,8 +8,9 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-        args:
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - telemetrygen
         - traces
         - --otlp-endpoint=tempo-monolithic-st:4317
         - --otlp-insecure

--- a/tests/e2e-openshift/multitenancy-rbac/00-install-storage.yaml
+++ b/tests/e2e-openshift/multitenancy-rbac/00-install-storage.yaml
@@ -46,7 +46,7 @@ spec:
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: quay.io/minio/minio:latest
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
           name: minio
           ports:
             - containerPort: 9000

--- a/tests/e2e-openshift/multitenancy-rbac/04-tempo-rbac-sa-1-traces-gen.yaml
+++ b/tests/e2e-openshift/multitenancy-rbac/04-tempo-rbac-sa-1-traces-gen.yaml
@@ -8,8 +8,9 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-        args:
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - telemetrygen
         - traces
         - --otlp-endpoint=dev-collector.chainsaw-rbac.svc:4317
         - --service=grpc-rbac-1
@@ -29,8 +30,9 @@ spec:
     spec:
       containers:
         - name: telemetrygen
-          image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-          args:
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
+          command:
+            - telemetrygen
             - traces
             - --otlp-endpoint=dev-collector.chainsaw-rbac.svc:4318
             - --otlp-http

--- a/tests/e2e-openshift/multitenancy-rbac/05-tempo-rbac-sa-2-traces-gen.yaml
+++ b/tests/e2e-openshift/multitenancy-rbac/05-tempo-rbac-sa-2-traces-gen.yaml
@@ -8,8 +8,9 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-        args:
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - telemetrygen
         - traces
         - --otlp-endpoint=dev-collector.chainsaw-rbac.svc:4317
         - --service=grpc-rbac-2
@@ -29,8 +30,9 @@ spec:
     spec:
       containers:
         - name: telemetrygen
-          image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-          args:
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
+          command:
+            - telemetrygen
             - traces
             - --otlp-endpoint=dev-collector.chainsaw-rbac.svc:4318
             - --otlp-http

--- a/tests/e2e-openshift/multitenancy/00-install-storage.yaml
+++ b/tests/e2e-openshift/multitenancy/00-install-storage.yaml
@@ -57,13 +57,13 @@ spec:
             - -c
             - |
               mkdir -p /storage/tempo && \
-              minio server --certs-dir=/root/.minio/certs /storage
+              minio server --certs-dir=/tmp/.minio/certs /storage
           env:
             - name: MINIO_ACCESS_KEY
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: quay.io/minio/minio:latest
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
           name: minio
           ports:
             - containerPort: 9000
@@ -71,7 +71,7 @@ spec:
             - mountPath: /storage
               name: storage
             - name: cert
-              mountPath: /root/.minio/certs
+              mountPath: /tmp/.minio/certs
       volumes:
         - name: storage
           persistentVolumeClaim:

--- a/tests/e2e-openshift/multitenancy/03-generate-traces.yaml
+++ b/tests/e2e-openshift/multitenancy/03-generate-traces.yaml
@@ -8,8 +8,9 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-        args:
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - telemetrygen
         - traces
         - --otlp-endpoint=dev-collector:4317
         - --service=grpc
@@ -27,8 +28,9 @@ spec:
     spec:
       containers:
         - name: telemetrygen
-          image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-          args:
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
+          command:
+            - telemetrygen
             - traces
             - --otlp-endpoint=dev-collector:4318
             - --otlp-http

--- a/tests/e2e-openshift/red-metrics/00-install-storage.yaml
+++ b/tests/e2e-openshift/red-metrics/00-install-storage.yaml
@@ -39,7 +39,7 @@ spec:
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: quay.io/minio/minio:latest
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
           name: minio
           ports:
             - containerPort: 9000

--- a/tests/e2e-openshift/red-metrics/06-install-assert-job.yaml
+++ b/tests/e2e-openshift/red-metrics/06-install-assert-job.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
         - name: verify-metrics
-          image: registry.access.redhat.com/ubi9/ubi:9.1
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
           command:
             - /bin/bash
             - -eux

--- a/tests/e2e-openshift/route/00-install-storage.yaml
+++ b/tests/e2e-openshift/route/00-install-storage.yaml
@@ -38,7 +38,7 @@ spec:
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: quay.io/minio/minio:latest
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
           name: minio
           ports:
             - containerPort: 9000

--- a/tests/e2e-openshift/route/README.md
+++ b/tests/e2e-openshift/route/README.md
@@ -106,7 +106,7 @@ spec:
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: quay.io/minio/minio:latest
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
           name: minio
           ports:
             - containerPort: 9000
@@ -319,7 +319,7 @@ TEMPO_NAMESPACE=$(oc get pods -A \
 # Execute comprehensive must-gather
 oc adm must-gather \
   --dest-dir=$MUST_GATHER_DIR \
-  --image=quay.io/rhn_support_ikanse/tempo-must-gather:latest \
+  --image=ghcr.io/grafana/tempo-operator/must-gather:latest \
   -- /usr/bin/must-gather --operator-namespace $TEMPO_NAMESPACE
 ```
 
@@ -686,7 +686,7 @@ kind: Tenant
 metadata:
   name: tempo-storage
 spec:
-  image: quay.io/minio/minio:latest
+  image: ghcr.io/grafana/tempo-operator/test-utils:main
   pools:
   - servers: 4
     volumesPerServer: 4

--- a/tests/e2e-openshift/tempo-single-tenant-auth/00-install-storage.yaml
+++ b/tests/e2e-openshift/tempo-single-tenant-auth/00-install-storage.yaml
@@ -40,7 +40,7 @@ spec:
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: quay.io/minio/minio:latest
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
           name: minio
           ports:
             - containerPort: 9000

--- a/tests/e2e-openshift/tempo-single-tenant-auth/02-generate-traces.yaml
+++ b/tests/e2e-openshift/tempo-single-tenant-auth/02-generate-traces.yaml
@@ -8,8 +8,9 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-        args:
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - telemetrygen
         - traces
         - --otlp-endpoint=tempo-tempo-st-distributor:4317
         - --otlp-insecure

--- a/tests/e2e-openshift/tempostack-resources/00-install-storage.yaml
+++ b/tests/e2e-openshift/tempostack-resources/00-install-storage.yaml
@@ -39,7 +39,7 @@ spec:
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: quay.io/minio/minio:latest
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
           name: minio
           ports:
             - containerPort: 9000

--- a/tests/e2e-openshift/tls-monolithic-singletenant/00-install-storage.yaml
+++ b/tests/e2e-openshift/tls-monolithic-singletenant/00-install-storage.yaml
@@ -40,7 +40,7 @@ spec:
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: quay.io/minio/minio:latest
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
           name: minio
           ports:
             - containerPort: 9000

--- a/tests/e2e-openshift/tls-monolithic-singletenant/03-generate-traces.yaml
+++ b/tests/e2e-openshift/tls-monolithic-singletenant/03-generate-traces.yaml
@@ -8,8 +8,9 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-        args:
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - telemetrygen
         - traces
         - --otlp-endpoint=dev-collector:4317
         - --service=grpc
@@ -27,8 +28,9 @@ spec:
     spec:
       containers:
         - name: telemetrygen
-          image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-          args:
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
+          command:
+            - telemetrygen
             - traces
             - --otlp-endpoint=dev-collector:4318
             - --otlp-http

--- a/tests/e2e-openshift/tls-monolithic-singletenant/README.md
+++ b/tests/e2e-openshift/tls-monolithic-singletenant/README.md
@@ -94,7 +94,7 @@ spec:
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: quay.io/minio/minio:latest
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
           name: minio
           ports:
             - containerPort: 9000
@@ -283,8 +283,9 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-        args:
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - telemetrygen
         - traces
         - --otlp-endpoint=dev-collector:4317
         - --otlp-insecure

--- a/tests/e2e-openshift/tls-singletenant/00-install-storage.yaml
+++ b/tests/e2e-openshift/tls-singletenant/00-install-storage.yaml
@@ -46,7 +46,7 @@ spec:
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: quay.io/minio/minio:latest
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
           name: minio
           ports:
             - containerPort: 9000

--- a/tests/e2e-openshift/tls-singletenant/03-generate-traces.yaml
+++ b/tests/e2e-openshift/tls-singletenant/03-generate-traces.yaml
@@ -8,8 +8,9 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-        args:
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - telemetrygen
         - traces
         - --otlp-endpoint=dev-collector:4317
         - --service=grpc
@@ -27,8 +28,9 @@ spec:
     spec:
       containers:
         - name: telemetrygen
-          image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-          args:
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
+          command:
+            - telemetrygen
             - traces
             - --otlp-endpoint=dev-collector:4318
             - --otlp-http

--- a/tests/e2e-openshift/tls-singletenant/README.md
+++ b/tests/e2e-openshift/tls-singletenant/README.md
@@ -205,8 +205,9 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-        args:
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - telemetrygen
         - traces
         - --otlp-endpoint=dev-collector:4317
         - --otlp-insecure

--- a/tests/e2e-upgrade/upgrade/00-install-storage.yaml
+++ b/tests/e2e-upgrade/upgrade/00-install-storage.yaml
@@ -38,7 +38,7 @@ spec:
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: quay.io/minio/minio:latest
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
           name: minio
           ports:
             - containerPort: 9000

--- a/tests/e2e-upgrade/upgrade/40-generate-traces.yaml
+++ b/tests/e2e-upgrade/upgrade/40-generate-traces.yaml
@@ -7,8 +7,9 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-        args:
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - telemetrygen
         - traces
         - --otlp-endpoint=tempo-simplest-distributor:4317
         - --otlp-insecure

--- a/tests/e2e/ca-bundle/00-install-storage.yaml
+++ b/tests/e2e/ca-bundle/00-install-storage.yaml
@@ -65,13 +65,13 @@ spec:
             - -c
             - |
               mkdir -p /storage/tempo && \
-              minio server --certs-dir=/root/.minio/certs /storage
+              minio server --certs-dir=/tmp/.minio/certs /storage
           env:
             - name: MINIO_ACCESS_KEY
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: quay.io/minio/minio:latest
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
           name: minio
           ports:
             - containerPort: 9000
@@ -79,7 +79,7 @@ spec:
             - mountPath: /storage
               name: storage
             - name: cert
-              mountPath: /root/.minio/certs
+              mountPath: /tmp/.minio/certs
       volumes:
         - name: storage
           emptyDir: {}

--- a/tests/e2e/ca-bundle/02-generate-traces.yaml
+++ b/tests/e2e/ca-bundle/02-generate-traces.yaml
@@ -7,8 +7,9 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-        args:
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - telemetrygen
         - traces
         - --otlp-endpoint=tempo-simplest-distributor:4317
         - --otlp-insecure

--- a/tests/e2e/compatibility/00-install-storage.yaml
+++ b/tests/e2e/compatibility/00-install-storage.yaml
@@ -38,7 +38,7 @@ spec:
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: quay.io/minio/minio:latest
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
           name: minio
           ports:
             - containerPort: 9000

--- a/tests/e2e/compatibility/03-generate-traces.yaml
+++ b/tests/e2e/compatibility/03-generate-traces.yaml
@@ -7,8 +7,9 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-        args:
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - telemetrygen
         - traces
         - --otlp-endpoint=tempo-simplest-distributor:4317
         - --otlp-insecure

--- a/tests/e2e/custom-ca/00-install-storage.yaml
+++ b/tests/e2e/custom-ca/00-install-storage.yaml
@@ -27,13 +27,13 @@ spec:
             - -c
             - |
               mkdir -p /storage/tempo && \
-              minio server --certs-dir=/root/.minio/certs /storage
+              minio server --certs-dir=/tmp/.minio/certs /storage
           env:
             - name: MINIO_ACCESS_KEY
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: quay.io/minio/minio:latest
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
           name: minio
           ports:
             - containerPort: 9000
@@ -41,7 +41,7 @@ spec:
             - mountPath: /storage
               name: storage
             - name: cert
-              mountPath: /root/.minio/certs
+              mountPath: /tmp/.minio/certs
       volumes:
         - name: storage
           emptyDir: {}

--- a/tests/e2e/custom-ca/02-generate-traces.yaml
+++ b/tests/e2e/custom-ca/02-generate-traces.yaml
@@ -7,8 +7,9 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-        args:
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - telemetrygen
         - traces
         - --otlp-endpoint=tempo-simplest-distributor:4317
         - --otlp-insecure

--- a/tests/e2e/gateway/00-install-storage.yaml
+++ b/tests/e2e/gateway/00-install-storage.yaml
@@ -38,7 +38,7 @@ spec:
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: quay.io/minio/minio:latest
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
           name: minio
           ports:
             - containerPort: 9000

--- a/tests/e2e/gateway/01-install-hydra.yaml
+++ b/tests/e2e/gateway/01-install-hydra.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: hydra
-        image: docker.io/oryd/hydra:v2.2.0
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
         command: ["hydra", "serve", "all", "--dev", "--sqa-opt-out"]
         env:
         - name: DSN

--- a/tests/e2e/mcp-monolithic/04-generate-traces.yaml
+++ b/tests/e2e/mcp-monolithic/04-generate-traces.yaml
@@ -7,8 +7,9 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-        args:
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - telemetrygen
         - traces
         - --otlp-endpoint=tempo-simplest:4317
         - --otlp-insecure

--- a/tests/e2e/mcp-tempostack/00-install-storage.yaml
+++ b/tests/e2e/mcp-tempostack/00-install-storage.yaml
@@ -38,7 +38,7 @@ spec:
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: quay.io/minio/minio:latest
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
           name: minio
           ports:
             - containerPort: 9000

--- a/tests/e2e/mcp-tempostack/04-generate-traces.yaml
+++ b/tests/e2e/mcp-tempostack/04-generate-traces.yaml
@@ -7,8 +7,9 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-        args:
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - telemetrygen
         - traces
         - --otlp-endpoint=tempo-simplest-distributor:4317
         - --otlp-insecure

--- a/tests/e2e/monolithic-ca-bundle/00-install-storage.yaml
+++ b/tests/e2e/monolithic-ca-bundle/00-install-storage.yaml
@@ -65,13 +65,13 @@ spec:
             - -c
             - |
               mkdir -p /storage/tempo && \
-              minio server --certs-dir=/root/.minio/certs /storage
+              minio server --certs-dir=/tmp/.minio/certs /storage
           env:
             - name: MINIO_ACCESS_KEY
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: quay.io/minio/minio:latest
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
           name: minio
           ports:
             - containerPort: 9000
@@ -79,7 +79,7 @@ spec:
             - mountPath: /storage
               name: storage
             - name: cert
-              mountPath: /root/.minio/certs
+              mountPath: /tmp/.minio/certs
       volumes:
         - name: storage
           emptyDir: {}

--- a/tests/e2e/monolithic-ca-bundle/03-generate-traces.yaml
+++ b/tests/e2e/monolithic-ca-bundle/03-generate-traces.yaml
@@ -7,8 +7,9 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-        args:
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - telemetrygen
         - traces
         - --otlp-endpoint=tempo-simplest:4317
         - --otlp-insecure

--- a/tests/e2e/monolithic-ingestion-mtls/03-generate-traces.yaml
+++ b/tests/e2e/monolithic-ingestion-mtls/03-generate-traces.yaml
@@ -7,8 +7,9 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-        args:
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - telemetrygen
         - traces
         - --otlp-endpoint=opentelemetry-collector:4317
         - --otlp-insecure

--- a/tests/e2e/monolithic-memory/03-generate-traces.yaml
+++ b/tests/e2e/monolithic-memory/03-generate-traces.yaml
@@ -7,8 +7,9 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-        args:
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - telemetrygen
         - traces
         - --otlp-endpoint=tempo-simplest:4317
         - --otlp-insecure

--- a/tests/e2e/monolithic-pv/03-generate-traces.yaml
+++ b/tests/e2e/monolithic-pv/03-generate-traces.yaml
@@ -7,8 +7,9 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-        args:
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - telemetrygen
         - traces
         - --otlp-endpoint=tempo-simplest:4317
         - --otlp-insecure

--- a/tests/e2e/monolithic-receivers-tls/03-generate-traces.yaml
+++ b/tests/e2e/monolithic-receivers-tls/03-generate-traces.yaml
@@ -7,8 +7,9 @@ spec:
     spec:
       containers:
         - name: telemetrygen
-          image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-          args:
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
+          command:
+            - telemetrygen
             - traces
             - --otlp-endpoint=opentelemetry-collector:4317
             - --service=grpc
@@ -25,8 +26,9 @@ spec:
     spec:
       containers:
         - name: telemetrygen
-          image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-          args:
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
+          command:
+            - telemetrygen
             - traces
             - --otlp-endpoint=opentelemetry-collector:4318
             - --otlp-http

--- a/tests/e2e/monolithic-s3-tls/00-install-storage.yaml
+++ b/tests/e2e/monolithic-s3-tls/00-install-storage.yaml
@@ -27,13 +27,13 @@ spec:
             - -c
             - |
               mkdir -p /storage/tempo && \
-              minio server --certs-dir=/root/.minio/certs /storage
+              minio server --certs-dir=/tmp/.minio/certs /storage
           env:
             - name: MINIO_ACCESS_KEY
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: quay.io/minio/minio:latest
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
           name: minio
           ports:
             - containerPort: 9000
@@ -41,7 +41,7 @@ spec:
             - mountPath: /storage
               name: storage
             - name: cert
-              mountPath: /root/.minio/certs
+              mountPath: /tmp/.minio/certs
       volumes:
         - name: storage
           emptyDir: {}

--- a/tests/e2e/monolithic-s3-tls/03-generate-traces.yaml
+++ b/tests/e2e/monolithic-s3-tls/03-generate-traces.yaml
@@ -7,8 +7,9 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-        args:
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - telemetrygen
         - traces
         - --otlp-endpoint=tempo-simplest:4317
         - --otlp-insecure

--- a/tests/e2e/networkpolicies-operands/00-install-storage.yaml
+++ b/tests/e2e/networkpolicies-operands/00-install-storage.yaml
@@ -26,7 +26,7 @@ spec:
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: quay.io/minio/minio:latest
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
           name: minio
           ports:
             - containerPort: 9000

--- a/tests/e2e/receivers-mtls/00-install-storage.yaml
+++ b/tests/e2e/receivers-mtls/00-install-storage.yaml
@@ -38,7 +38,7 @@ spec:
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: quay.io/minio/minio:latest
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
           name: minio
           ports:
             - containerPort: 9000

--- a/tests/e2e/receivers-mtls/03-generate-traces.yaml
+++ b/tests/e2e/receivers-mtls/03-generate-traces.yaml
@@ -7,8 +7,9 @@ spec:
     spec:
       containers:
         - name: telemetrygen
-          image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-          args:
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
+          command:
+            - telemetrygen
             - traces
             - --otlp-endpoint=opentelemetry-collector:4317
             - --otlp-insecure

--- a/tests/e2e/receivers-tls/00-install-storage.yaml
+++ b/tests/e2e/receivers-tls/00-install-storage.yaml
@@ -38,7 +38,7 @@ spec:
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: quay.io/minio/minio:latest
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
           name: minio
           ports:
             - containerPort: 9000

--- a/tests/e2e/receivers-tls/03-generate-traces.yaml
+++ b/tests/e2e/receivers-tls/03-generate-traces.yaml
@@ -7,8 +7,9 @@ spec:
     spec:
       containers:
         - name: telemetrygen
-          image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
-          args:
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
+          command:
+            - telemetrygen
             - traces
             - --otlp-endpoint=opentelemetry-collector:4317
             - --otlp-insecure

--- a/tests/e2e/reconcile/00-install-storage.yaml
+++ b/tests/e2e/reconcile/00-install-storage.yaml
@@ -26,7 +26,7 @@ spec:
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: quay.io/minio/minio:latest
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
           name: minio
           ports:
             - containerPort: 9000

--- a/tests/e2e/tempostack-extraconfig/00-install-storage.yaml
+++ b/tests/e2e/tempostack-extraconfig/00-install-storage.yaml
@@ -38,7 +38,7 @@ spec:
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: quay.io/minio/minio:latest
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
           name: minio
           ports:
             - containerPort: 9000

--- a/tests/e2e/tshirt-size-pico/00-install-storage.yaml
+++ b/tests/e2e/tshirt-size-pico/00-install-storage.yaml
@@ -25,7 +25,7 @@ spec:
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: quay.io/minio/minio:latest
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
           name: minio
           ports:
             - containerPort: 9000


### PR DESCRIPTION
This PR depends on #1542 and #1544.

This reduces our dependency on external images, which may not support s390x/ppc64 or may get unmaintained over time.