### PR TITLE
[Chore]: update e2e tests for OTel attribute rename and TLS profile scan method

### DIFF
--- a/tests/e2e-openshift-tls-profile/02-tls-profile-override-stack/04-verify-override.sh
+++ b/tests/e2e-openshift-tls-profile/02-tls-profile-override-stack/04-verify-override.sh
@@ -132,17 +132,15 @@ echo "PASS: gateway:8090 TLS functional"
 GATEWAY_IP=$(kubectl get pod -n $NAMESPACE -l app.kubernetes.io/component=gateway -o jsonpath='{.items[0].status.podIP}')
 verify_nmap_tls_profile "$GATEWAY_IP" "8080,8090" modern "Gateway (subscription TLS_PROFILE=Modern)"
 
-# --- 5. Internal gRPC TLS profile verification via -all-pods ---
-echo "=== Scanning all Tempo pods in $NAMESPACE ==="
-SCAN_OUTPUT=$(kubectl exec tls-scanner -n $NAMESPACE -- tls-scanner \
-  -all-pods \
-  -namespace-filter $NAMESPACE \
-  -json-file /tmp/override-scan.json 2>&1) || true
-echo "$SCAN_OUTPUT"
+# --- 5. Internal gRPC TLS profile verification via targeted nmap ---
+# Use targeted nmap on specific pod IPs instead of -all-pods scan for reliability
+# (-all-pods output format may not include "Found TLS information" for all ports).
+echo "=== Targeted internal gRPC scan (Modern profile from subscription TLS_PROFILE=Modern) ==="
 
-kubectl cp $NAMESPACE/tls-scanner:/tmp/override-scan.json /tmp/override-scan.json 2>/dev/null || true
+INGESTER_IP=$(kubectl get pod -n $NAMESPACE -l app.kubernetes.io/component=ingester -o jsonpath='{.items[0].status.podIP}')
+verify_nmap_tls_profile "$INGESTER_IP" "9095" modern "Ingester internal gRPC (subscription TLS_PROFILE=Modern)"
 
-# Internal gRPC (port 9095) uses Modern profile from subscription TLS_PROFILE=Modern
-verify_tls_profile "$SCAN_OUTPUT" 9095 modern "Internal gRPC (subscription TLS_PROFILE=Modern)" 2
+QF_IP=$(kubectl get pod -n $NAMESPACE -l app.kubernetes.io/component=query-frontend -o jsonpath='{.items[0].status.podIP}')
+verify_nmap_tls_profile "$QF_IP" "9095" modern "Query-frontend internal gRPC (subscription TLS_PROFILE=Modern)"
 
 echo "PASS: All TLS profile settings verified from subscription TLS_PROFILE=Modern - storage=VersionTLS13, gateway=Modern, internal gRPC=Modern, distributor receivers=1.3"

--- a/tests/e2e-openshift-tls-profile/03-tls-profile/03-verify-intermediate.sh
+++ b/tests/e2e-openshift-tls-profile/03-tls-profile/03-verify-intermediate.sh
@@ -140,18 +140,16 @@ echo "PASS: monolithic gateway:8090 TLS functional"
 MONO_GATEWAY_IP=$(kubectl get pod -n $NAMESPACE tempo-mono-0 -o jsonpath='{.status.podIP}')
 verify_nmap_tls_profile "$MONO_GATEWAY_IP" "8080,8090" intermediate "Monolithic Gateway"
 
-# --- 9. Internal gRPC TLS profile verification via -all-pods ---
-echo "=== Scanning all Tempo pods in $NAMESPACE ==="
-SCAN_OUTPUT=$(kubectl exec tls-scanner -n $NAMESPACE -- tls-scanner \
-  -all-pods \
-  -namespace-filter $NAMESPACE \
-  -json-file /tmp/intermediate-scan.json 2>&1) || true
-echo "$SCAN_OUTPUT"
+# --- 9. Internal gRPC TLS profile verification via targeted nmap ---
+# Use targeted nmap on specific pod IPs instead of -all-pods scan for reliability
+# (-all-pods output format may not include "Found TLS information" for all ports).
+echo "=== Targeted internal gRPC scan (Intermediate profile) ==="
 
-kubectl cp $NAMESPACE/tls-scanner:/tmp/intermediate-scan.json /tmp/intermediate-scan.json 2>/dev/null || true
+INGESTER_IP=$(kubectl get pod -n $NAMESPACE -l app.kubernetes.io/component=ingester -o jsonpath='{.items[0].status.podIP}')
+verify_nmap_tls_profile "$INGESTER_IP" "9095" intermediate "Ingester internal gRPC"
 
-# Verify internal gRPC TLS profile matches Intermediate on components with port 9095 (ingester, query-frontend)
-verify_tls_profile "$SCAN_OUTPUT" 9095 intermediate "Internal gRPC" 2
+QF_IP=$(kubectl get pod -n $NAMESPACE -l app.kubernetes.io/component=query-frontend -o jsonpath='{.items[0].status.podIP}')
+verify_nmap_tls_profile "$QF_IP" "9095" intermediate "Query-frontend internal gRPC"
 
 # --- 6. Operator webhook and metrics ---
 OPERATOR_NS="openshift-tempo-operator"

--- a/tests/e2e-openshift/monolithic-multitenancy-rbac/05-tempo-rbac-sa-1-traces-verify.yaml
+++ b/tests/e2e-openshift/monolithic-multitenancy-rbac/05-tempo-rbac-sa-1-traces-verify.yaml
@@ -43,7 +43,7 @@ spec:
 
               echo "Check for the strings in the trace output"
               stringsToSearch=(
-                  "\"key\":\"net.peer.ip\""
+                  "\"key\":\"net.sock.peer.addr\""
                   "\"stringValue\":\"1.2.3.4\""
                   "\"key\":\"peer.service\""
                   "\"stringValue\":\"telemetrygen-client\""
@@ -85,7 +85,7 @@ spec:
 
               echo "Check for the strings in the trace output"
               stringsToSearch=(
-                  "\"key\":\"net.peer.ip\""
+                  "\"key\":\"net.sock.peer.addr\""
                   "\"stringValue\":\"1.2.3.4\""
                   "\"key\":\"peer.service\""
                   "\"stringValue\":\"telemetrygen-client\""
@@ -147,7 +147,7 @@ spec:
 
               echo "Check for the strings in the trace output"
               stringsToSearch=(
-                  "\"key\":\"net.peer.ip\""
+                  "\"key\":\"net.sock.peer.addr\""
                   "\"stringValue\":\"1.2.3.4\""
                   "\"key\":\"peer.service\""
                   "\"stringValue\":\"telemetrygen-client\""
@@ -189,7 +189,7 @@ spec:
 
               echo "Check for the strings in the trace output"
               stringsToSearch=(
-                  "\"key\":\"net.peer.ip\""
+                  "\"key\":\"net.sock.peer.addr\""
                   "\"stringValue\":\"1.2.3.4\""
                   "\"key\":\"peer.service\""
                   "\"stringValue\":\"telemetrygen-client\""

--- a/tests/e2e-openshift/monolithic-multitenancy-rbac/06-kubeadmin-traces-verify.yaml
+++ b/tests/e2e-openshift/monolithic-multitenancy-rbac/06-kubeadmin-traces-verify.yaml
@@ -46,7 +46,7 @@ spec:
 
               echo "Check for the strings in the trace output - cluster-admin should see complete traces"
               stringsToSearch=(
-                  "\"key\":\"net.peer.ip\""
+                  "\"key\":\"net.sock.peer.addr\""
                   "\"stringValue\":\"1.2.3.4\""
                   "\"key\":\"peer.service\""
                   "\"stringValue\":\"telemetrygen-client\""
@@ -147,7 +147,7 @@ spec:
 
               echo "Check for the strings in the trace output - cluster-admin should see complete traces"
               stringsToSearch=(
-                  "\"key\":\"net.peer.ip\""
+                  "\"key\":\"net.sock.peer.addr\""
                   "\"stringValue\":\"1.2.3.4\""
                   "\"key\":\"peer.service\""
                   "\"stringValue\":\"telemetrygen-client\""

--- a/tests/e2e-openshift/multitenancy-rbac/06-tempo-rbac-sa-1-traces-verify.yaml
+++ b/tests/e2e-openshift/multitenancy-rbac/06-tempo-rbac-sa-1-traces-verify.yaml
@@ -43,7 +43,7 @@ spec:
 
               echo "Check for the strings in the trace output"
               stringsToSearch=(
-                  "\"key\":\"net.peer.ip\""
+                  "\"key\":\"net.sock.peer.addr\""
                   "\"stringValue\":\"1.2.3.4\""
                   "\"key\":\"peer.service\""
                   "\"stringValue\":\"telemetrygen-client\""
@@ -86,7 +86,7 @@ spec:
 
               echo "Check for the strings in the trace output"
               stringsToSearch=(
-                  "\"key\":\"net.peer.ip\""
+                  "\"key\":\"net.sock.peer.addr\""
                   "\"stringValue\":\"1.2.3.4\""
                   "\"key\":\"peer.service\""
                   "\"stringValue\":\"telemetrygen-client\""
@@ -150,7 +150,7 @@ spec:
 
               echo "Check for the strings in the trace output"
               stringsToSearch=(
-                  "\"key\":\"net.peer.ip\""
+                  "\"key\":\"net.sock.peer.addr\""
                   "\"stringValue\":\"1.2.3.4\""
                   "\"key\":\"peer.service\""
                   "\"stringValue\":\"telemetrygen-client\""
@@ -192,7 +192,7 @@ spec:
 
               echo "Check for the strings in the trace output"
               stringsToSearch=(
-                  "\"key\":\"net.peer.ip\""
+                  "\"key\":\"net.sock.peer.addr\""
                   "\"stringValue\":\"1.2.3.4\""
                   "\"key\":\"peer.service\""
                   "\"stringValue\":\"telemetrygen-client\""

--- a/tests/e2e-openshift/multitenancy-rbac/07-kubeadmin-traces-verify.yaml
+++ b/tests/e2e-openshift/multitenancy-rbac/07-kubeadmin-traces-verify.yaml
@@ -46,7 +46,7 @@ spec:
 
               echo "Check for the strings in the trace output - cluster-admin should see complete traces"
               stringsToSearch=(
-                  "\"key\":\"net.peer.ip\""
+                  "\"key\":\"net.sock.peer.addr\""
                   "\"stringValue\":\"1.2.3.4\""
                   "\"key\":\"peer.service\""
                   "\"stringValue\":\"telemetrygen-client\""
@@ -147,7 +147,7 @@ spec:
 
               echo "Check for the strings in the trace output - cluster-admin should see complete traces"
               stringsToSearch=(
-                  "\"key\":\"net.peer.ip\""
+                  "\"key\":\"net.sock.peer.addr\""
                   "\"stringValue\":\"1.2.3.4\""
                   "\"key\":\"peer.service\""
                   "\"stringValue\":\"telemetrygen-client\""


### PR DESCRIPTION
## Fix 1: RBAC Multitenancy Tests — Deprecated OTel Attribute Name

### Failing tests
- tests/e2e-openshift/multitenancy-rbac / multitenancy-rbac
- tests/e2e-openshift/monolithic-multitenancy-rbac / monolithic-multitenancy-rbac

### Root cause
The verify-traces Jobs search for the deprecated OpenTelemetry attribute `"key":"net.peer.ip"` in trace output, but telemetrygen (test-utils:main) now produces `"key":"net.sock.peer.addr"` per updated OTel semantic conventions. The grep check fails, the Job exits 1, retries until the chainsaw 5-minute assertion timeout expires (`status: {}`).

### Fix applied
Replaced `"key":"net.peer.ip"` with `"key":"net.sock.peer.addr"` in all verify-traces Job YAML files.

### Files changed
- `tests/e2e-openshift/multitenancy-rbac/06-tempo-rbac-sa-1-traces-verify.yaml`
- `tests/e2e-openshift/multitenancy-rbac/07-kubeadmin-traces-verify.yaml`
- `tests/e2e-openshift/monolithic-multitenancy-rbac/05-tempo-rbac-sa-1-traces-verify.yaml`
- `tests/e2e-openshift/monolithic-multitenancy-rbac/06-kubeadmin-traces-verify.yaml`

**Note**: 4 additional files in `tests/e2e-openshift-upgrade/upgrade/` also contain the deprecated `net.peer.ip` attribute and should be updated.

---

## Fix 2: TLS Profile Tests — Scanner Output Parsing

### Failing tests
- tests/e2e-openshift-tls-profile/03-tls-profile / tls-profile
- tests/e2e-openshift-tls-profile/02-tls-profile-override-stack / tls-profile-override-stack

### Root cause
The `verify_tls_profile` function greps `tls-scanner -all-pods` output for `"Found TLS information for port 9095"`, but the scanner's output format no longer includes this string for internal gRPC ports. Direct nmap scans confirm port 9095 has TLS properly configured (TLSv1.2 + TLSv1.3 Intermediate profile). The `08-verify-modern.sh` script was already updated to use targeted `verify_nmap_tls_profile` scans, but `03-verify-intermediate.sh` and `04-verify-override.sh` still use the old `-all-pods` parsing approach.

### Fix applied
Replaced `verify_tls_profile "$SCAN_OUTPUT" 9095 ...` with targeted `verify_nmap_tls_profile` on specific pod IPs (ingester and query-frontend), consistent with the approach already used in `08-verify-modern.sh`.

### Files changed
- `tests/e2e-openshift-tls-profile/03-tls-profile/03-verify-intermediate.sh`
- `tests/e2e-openshift-tls-profile/02-tls-profile-override-stack/04-verify-override.sh`

## Test plan
- [x] Rerun multitenancy-rbac — PASS
- [x] Rerun monolithic-multitenancy-rbac — PASS
- [x] Rerun tls-profile — PASS
- [x] Rerun tls-profile-override-stack — PASS

For more details refer: https://redhat.atlassian.net/browse/TRACING-6516