### PR TITLE
chore: fix noisy operator logs

### DIFF
--- a/internal/certrotation/handlers/rotate_certs.go
+++ b/internal/certrotation/handlers/rotate_certs.go
@@ -107,7 +107,7 @@ func CreateOrRotateCertificates(ctx context.Context, log logr.Logger,
 		return kverrors.Wrap(err, "failed to add certificate hash annotations", "name", req.String())
 	}
 
-	ll.Info("certificate rotation completed successfully, hash annotations added")
+	ll.V(1).Info("certificate rotation completed successfully, hash annotations added")
 	return nil
 }
 

--- a/internal/controller/tempo/common.go
+++ b/internal/controller/tempo/common.go
@@ -246,8 +246,8 @@ func getTenantParams(
 
 		tenantsData, err := gateway.GetGatewayTenantsData(ctx, k8sclient, namespace, name)
 		if err != nil {
-			// just log the error the secret is not created if the loop for an instance runs for the first time.
-			log.Info("Failed to get gateway secret and/or tenants.yaml", "error", err)
+			// The gateway secret is created during reconciliation, so it won't exist on the first reconcile.
+			log.Info("Failed to get gateway secret and/or tenants.yaml. This is expected during the first reconcile", "error", err)
 		}
 
 		return nil, tenantsData, nil

--- a/internal/manifests/gateway/openshift.go
+++ b/internal/manifests/gateway/openshift.go
@@ -236,7 +236,7 @@ func NewOpaContainer(ctrlConfig configv1alpha1.ProjectConfig, tenants v1alpha1.T
 		Args:  args,
 		Ports: []corev1.ContainerPort{
 			{
-				Name:          "public",
+				Name:          "opa-http",
 				ContainerPort: gatewayOPAHTTPPort,
 				Protocol:      corev1.ProtocolTCP,
 			},

--- a/internal/manifests/monolithic/statefulset_test.go
+++ b/internal/manifests/monolithic/statefulset_test.go
@@ -958,7 +958,7 @@ func TestStatefulsetGateway(t *testing.T) {
 		},
 		Ports: []corev1.ContainerPort{
 			{
-				Name:          "public",
+				Name:          "opa-http",
 				ContainerPort: 8082,
 				Protocol:      corev1.ProtocolTCP,
 			},
@@ -1244,7 +1244,7 @@ func TestStatefulsetGatewayRBAC(t *testing.T) {
 		},
 		Ports: []corev1.ContainerPort{
 			{
-				Name:          "public",
+				Name:          "opa-http",
 				ContainerPort: 8082,
 				Protocol:      corev1.ProtocolTCP,
 			},

--- a/internal/manifests/networkpolicies/discovery.go
+++ b/internal/manifests/networkpolicies/discovery.go
@@ -79,7 +79,7 @@ func DiscoverKubernetesAPIServer(ctx context.Context, k8sClient client.Client) m
 		return fallbackKubeAPIServerInfo()
 	}
 
-	logger.Info("discovered Kubernetes API server endpoints",
+	logger.V(1).Info("discovered Kubernetes API server endpoints",
 		"ports", len(ports), "ips", len(ips))
 
 	return manifestutils.KubeAPIServerInfo{


### PR DESCRIPTION
* "certificate rotation completed" and "discovered Kubernetes API server endpoints" was printed at every TempoStack reconcile
* `public` port name was used twice in the gateway pod, triggering a `duplicate port name` warning in the logs