### PR TITLE
Create a PodDisruptionBudget for each TempoStack component

### DIFF
--- a/.chloggen/tempostack-pod-disruption-budgets.yaml
+++ b/.chloggen/tempostack-pod-disruption-budgets.yaml
@@ -1,0 +1,22 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. tempostack, tempomonolithic, github action)
+component: tempostack
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Create a PodDisruptionBudget for each TempoStack component to protect availability during voluntary disruptions.
+
+# One or more tracking issues related to the change
+issues: [1577]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  A PodDisruptionBudget with `maxUnavailable: 1` is now created for the distributor, ingester,
+  querier, query-frontend, gateway and metrics-generator components (the gateway and
+  metrics-generator budgets are only created when those components are enabled). This ensures
+  that voluntary disruptions such as node drains during cluster upgrades can only take down a
+  single replica of a component at a time. Following the Grafana Loki Operator, no budget is
+  created for the compactor.

--- a/bundle/community/manifests/tempo-operator.clusterserviceversion.yaml
+++ b/bundle/community/manifests/tempo-operator.clusterserviceversion.yaml
@@ -1661,6 +1661,18 @@ spec:
           - list
           - watch
         - apiGroups:
+          - policy
+          resources:
+          - poddisruptionbudgets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
           - rbac.authorization.k8s.io
           resources:
           - clusterrolebindings

--- a/bundle/openshift/manifests/tempo-operator.clusterserviceversion.yaml
+++ b/bundle/openshift/manifests/tempo-operator.clusterserviceversion.yaml
@@ -1671,6 +1671,18 @@ spec:
           - list
           - watch
         - apiGroups:
+          - policy
+          resources:
+          - poddisruptionbudgets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
           - rbac.authorization.k8s.io
           resources:
           - clusterrolebindings

--- a/cmd/generate/main_test.go
+++ b/cmd/generate/main_test.go
@@ -47,7 +47,8 @@ func TestBuild(t *testing.T) {
 	objects, err := build(params)
 	require.NoError(t, err)
 	// 14 base objects + 8 network policies (gossip, metrics, DNS, distributor, ingester, compactor, querier, query-frontend)
-	require.Equal(t, 22, len(objects))
+	// + 4 pod disruption budgets (distributor, ingester, querier, query-frontend; no PDB for the compactor)
+	require.Equal(t, 26, len(objects))
 }
 
 func TestYAMLEncoding(t *testing.T) {

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -153,6 +153,18 @@ rules:
   - list
   - watch
 - apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - clusterrolebindings

--- a/internal/controller/tempo/tempostack_controller.go
+++ b/internal/controller/tempo/tempostack_controller.go
@@ -13,6 +13,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -64,6 +65,7 @@ type TempoStackReconciler struct {
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors;prometheusrules,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=grafana.integreatly.org,resources=grafanadatasources,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=discovery.k8s.io,resources=endpointslices,verbs=get;list;watch
 
 // Upgrate for 0.11.0 to Tempo 2.5
@@ -249,6 +251,7 @@ func (r *TempoStackReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&appsv1.StatefulSet{}, updateOrDeleteWithStatusPred).
 		Owns(&appsv1.Deployment{}, updateOrDeleteWithStatusPred).
 		Owns(&networkingv1.Ingress{}, updateOrDeleteOnlyPred).
+		Owns(&policyv1.PodDisruptionBudget{}, updateOrDeleteOnlyPred).
 		Owns(&rbacv1.ClusterRole{}, updateOrDeleteOnlyPred).
 		Owns(&rbacv1.ClusterRoleBinding{}, updateOrDeleteOnlyPred).
 		Owns(&rbacv1.Role{}, updateOrDeleteOnlyPred).

--- a/internal/controller/tempo/tempostack_create_or_update.go
+++ b/internal/controller/tempo/tempostack_create_or_update.go
@@ -11,6 +11,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
@@ -206,6 +207,17 @@ func (r *TempoStackReconciler) findObjectsOwnedByTempoOperator(ctx context.Conte
 	}
 	for i := range networkPolicyList.Items {
 		ownedObjects[networkPolicyList.Items[i].GetUID()] = &networkPolicyList.Items[i]
+	}
+
+	// a pod disruption budget is created per component, and the gateway and
+	// metrics-generator components can be enabled/disabled in the CR
+	podDisruptionBudgetList := &policyv1.PodDisruptionBudgetList{}
+	err = r.List(ctx, podDisruptionBudgetList, listOps)
+	if err != nil {
+		return nil, fmt.Errorf("error listing pod disruption budgets: %w", err)
+	}
+	for i := range podDisruptionBudgetList.Items {
+		ownedObjects[podDisruptionBudgetList.Items[i].GetUID()] = &podDisruptionBudgetList.Items[i]
 	}
 
 	// metrics reader for Jaeger UI Monitor Tab

--- a/internal/manifests/distributor/distributor.go
+++ b/internal/manifests/distributor/distributor.go
@@ -73,6 +73,8 @@ func BuildDistributor(params manifestutils.Params) ([]client.Object, error) {
 
 	}
 
+	objects = append(objects, manifestutils.NewPodDisruptionBudget(tempo, manifestutils.DistributorComponentName))
+
 	return objects, nil
 }
 

--- a/internal/manifests/distributor/distributor_test.go
+++ b/internal/manifests/distributor/distributor_test.go
@@ -39,7 +39,7 @@ func TestBuildDistributor(t *testing.T) {
 		{
 			name:            "Gateway disabled",
 			enableGateway:   false,
-			expectedObjects: 2,
+			expectedObjects: 3,
 			expectedContainerPorts: []corev1.ContainerPort{
 				{
 					Name:          manifestutils.PortOtlpHttpName,
@@ -185,7 +185,7 @@ func TestBuildDistributor(t *testing.T) {
 		},
 		{
 			name:            "Receiver TLS enable",
-			expectedObjects: 2,
+			expectedObjects: 3,
 			enableGateway:   false,
 			receiverTLS: v1alpha1.TLSSpec{
 				Enabled: true,
@@ -365,7 +365,7 @@ func TestBuildDistributor(t *testing.T) {
 		},
 		{
 			name:            "Receiver TLS enable with ServingCertsService feature enabled",
-			expectedObjects: 2,
+			expectedObjects: 3,
 			enableGateway:   false,
 			receiverTLS: v1alpha1.TLSSpec{
 				Enabled: true,
@@ -550,7 +550,7 @@ func TestBuildDistributor(t *testing.T) {
 			expectedServiceAnnotations: map[string]string{
 				"service.beta.openshift.io/serving-cert-secret-name": "tempo-test-distributor-serving-cert",
 			},
-			expectedObjects: 3,
+			expectedObjects: 4,
 			receiverTLS: v1alpha1.TLSSpec{
 				Enabled: true,
 			},
@@ -730,7 +730,7 @@ func TestBuildDistributor(t *testing.T) {
 		{
 			name:            "Gateway enable",
 			enableGateway:   true,
-			expectedObjects: 2,
+			expectedObjects: 3,
 			expectedContainerPorts: []corev1.ContainerPort{
 				{
 					Name:          manifestutils.PortOtlpHttpName,
@@ -822,7 +822,7 @@ func TestBuildDistributor(t *testing.T) {
 		{
 			name:            "set InstanceAddrType to PodIP",
 			enableGateway:   false,
-			expectedObjects: 2,
+			expectedObjects: 3,
 			expectedContainerPorts: []corev1.ContainerPort{
 				{
 					Name:          manifestutils.PortOtlpHttpName,

--- a/internal/manifests/gateway/gateway.go
+++ b/internal/manifests/gateway/gateway.go
@@ -134,6 +134,7 @@ func BuildGateway(params manifestutils.Params) ([]client.Object, error) {
 	}
 
 	objs = append(objs, dep)
+	objs = append(objs, manifestutils.NewPodDisruptionBudget(params.Tempo, manifestutils.GatewayComponentName))
 	return objs, nil
 }
 

--- a/internal/manifests/gateway/gateway_test.go
+++ b/internal/manifests/gateway/gateway_test.go
@@ -189,7 +189,7 @@ func TestBuildGateway_openshift(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	assert.Equal(t, 9, len(objects))
+	assert.Equal(t, 10, len(objects))
 	obj := getObjectByTypeAndName(objects, "tempo-simplest-gateway", reflect.TypeOf(&appsv1.Deployment{}))
 	require.NotNil(t, obj)
 	dep, ok := obj.(*appsv1.Deployment)
@@ -700,7 +700,7 @@ func TestTLSParameters(t *testing.T) {
 	})
 
 	require.NoError(t, err)
-	assert.Equal(t, 4, len(objects))
+	assert.Equal(t, 5, len(objects))
 	obj := getObjectByTypeAndName(objects, "tempo-simplest-gateway", reflect.TypeOf(&appsv1.Deployment{}))
 	require.NotNil(t, obj)
 
@@ -730,7 +730,7 @@ func TestTLSParameters(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	assert.Equal(t, 4, len(objects))
+	assert.Equal(t, 5, len(objects))
 	obj = getObjectByTypeAndName(objects, "tempo-simplest-gateway", reflect.TypeOf(&appsv1.Deployment{}))
 	require.NotNil(t, obj)
 
@@ -799,7 +799,7 @@ func TestIngress(t *testing.T) {
 	}})
 
 	require.NoError(t, err)
-	require.Equal(t, 5, len(objects))
+	require.Equal(t, 6, len(objects))
 	pathType := networkingv1.PathTypePrefix
 	assert.Equal(t, &networkingv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
@@ -888,7 +888,7 @@ func TestRoute(t *testing.T) {
 	}})
 
 	require.NoError(t, err)
-	require.Equal(t, 5, len(objects))
+	require.Equal(t, 6, len(objects))
 	assert.Equal(t, &routev1.Route{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      naming.Name(manifestutils.GatewayComponentName, "test"),

--- a/internal/manifests/ingester/ingester.go
+++ b/internal/manifests/ingester/ingester.go
@@ -48,7 +48,11 @@ func BuildIngester(params manifestutils.Params) ([]client.Object, error) {
 
 	manifestutils.PatchEnvVars(&ss.Spec.Template.Spec, "tempo", tempo.Spec.Env, tempo.Spec.EnvFrom)
 
-	return []client.Object{ss, service(tempo)}, nil
+	return []client.Object{
+		ss,
+		service(tempo),
+		manifestutils.NewPodDisruptionBudget(tempo, manifestutils.IngesterComponentName),
+	}, nil
 }
 
 func statefulSet(params manifestutils.Params) (*v1.StatefulSet, error) {

--- a/internal/manifests/ingester/ingester_test.go
+++ b/internal/manifests/ingester/ingester_test.go
@@ -153,7 +153,7 @@ func TestBuildIngester(t *testing.T) {
 
 			labels := manifestutils.ComponentLabels("ingester", "test")
 			annotations := manifestutils.CommonAnnotations("")
-			assert.Equal(t, 2, len(objects))
+			assert.Equal(t, 3, len(objects))
 
 			assert.Equal(t, &v1.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{

--- a/internal/manifests/manifests_test.go
+++ b/internal/manifests/manifests_test.go
@@ -84,5 +84,6 @@ func TestBuildAll(t *testing.T) {
 	})
 	require.NoError(t, err)
 	// 17 base objects + 9 network policies (gossip, metrics, DNS, distributor, ingester, compactor, querier, query-frontend, gateway)
-	assert.Len(t, objects, 26)
+	// + 5 pod disruption budgets (distributor, ingester, querier, query-frontend, gateway; no PDB for the compactor)
+	assert.Len(t, objects, 31)
 }

--- a/internal/manifests/manifestutils/pdb.go
+++ b/internal/manifests/manifestutils/pdb.go
@@ -1,0 +1,34 @@
+package manifestutils
+
+import (
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
+
+	"github.com/grafana/tempo-operator/api/tempo/v1alpha1"
+	"github.com/grafana/tempo-operator/internal/manifests/naming"
+)
+
+// NewPodDisruptionBudget returns a PodDisruptionBudget for the given TempoStack
+// component. It uses maxUnavailable: 1 so that voluntary disruptions (e.g. node
+// drains during upgrades) can only take down a single replica of the component
+// at a time, keeping the rest available.
+func NewPodDisruptionBudget(tempo v1alpha1.TempoStack, component string) *policyv1.PodDisruptionBudget {
+	labels := ComponentLabels(component, tempo.Name)
+	return &policyv1.PodDisruptionBudget{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "PodDisruptionBudget",
+			APIVersion: policyv1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      naming.Name(component, tempo.Name),
+			Namespace: tempo.Namespace,
+			Labels:    labels,
+		},
+		Spec: policyv1.PodDisruptionBudgetSpec{
+			Selector:       &metav1.LabelSelector{MatchLabels: labels},
+			MaxUnavailable: ptr.To(intstr.FromInt32(1)),
+		},
+	}
+}

--- a/internal/manifests/manifestutils/pdb_test.go
+++ b/internal/manifests/manifestutils/pdb_test.go
@@ -1,0 +1,39 @@
+package manifestutils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/grafana/tempo-operator/api/tempo/v1alpha1"
+)
+
+func TestNewPodDisruptionBudget(t *testing.T) {
+	tempo := v1alpha1.TempoStack{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "project1",
+		},
+	}
+
+	pdb := NewPodDisruptionBudget(tempo, DistributorComponentName)
+
+	require.NotNil(t, pdb)
+	assert.Equal(t, "PodDisruptionBudget", pdb.Kind)
+	assert.Equal(t, "policy/v1", pdb.APIVersion)
+	assert.Equal(t, "tempo-test-distributor", pdb.Name)
+	assert.Equal(t, "project1", pdb.Namespace)
+
+	labels := map[string]string(ComponentLabels(DistributorComponentName, "test"))
+	assert.Equal(t, labels, pdb.Labels)
+
+	require.NotNil(t, pdb.Spec.Selector)
+	assert.Equal(t, labels, pdb.Spec.Selector.MatchLabels)
+
+	require.NotNil(t, pdb.Spec.MaxUnavailable)
+	assert.Equal(t, intstr.FromInt32(1), *pdb.Spec.MaxUnavailable)
+	assert.Nil(t, pdb.Spec.MinAvailable)
+}

--- a/internal/manifests/metricsgenerator/metricsgenerator.go
+++ b/internal/manifests/metricsgenerator/metricsgenerator.go
@@ -46,7 +46,11 @@ func BuildMetricsGenerator(params manifestutils.Params) ([]client.Object, error)
 		}
 	}
 
-	return []client.Object{d, service(tempo)}, nil
+	return []client.Object{
+		d,
+		service(tempo),
+		manifestutils.NewPodDisruptionBudget(tempo, manifestutils.MetricsGeneratorComponentName),
+	}, nil
 }
 
 func resources(tempo v1alpha1.TempoStack) corev1.ResourceRequirements {

--- a/internal/manifests/metricsgenerator/metricsgenerator_test.go
+++ b/internal/manifests/metricsgenerator/metricsgenerator_test.go
@@ -73,7 +73,7 @@ func TestBuildMetricsGenerator(t *testing.T) {
 
 	objects, err := BuildMetricsGenerator(newParams(tempo))
 	require.NoError(t, err)
-	assert.Len(t, objects, 2)
+	assert.Len(t, objects, 3)
 
 	labels := manifestutils.ComponentLabels(manifestutils.MetricsGeneratorComponentName, "test")
 	annotations := manifestutils.CommonAnnotations("")
@@ -246,7 +246,7 @@ func TestBuildMetricsGeneratorUsesDefaultImage(t *testing.T) {
 
 	objects, err := BuildMetricsGenerator(params)
 	require.NoError(t, err)
-	require.Len(t, objects, 2)
+	require.Len(t, objects, 3)
 
 	d, ok := objects[0].(*v1.Deployment)
 	require.True(t, ok)
@@ -270,7 +270,7 @@ func TestBuildMetricsGeneratorOverrideResources(t *testing.T) {
 
 	objects, err := BuildMetricsGenerator(newParams(tempo))
 	require.NoError(t, err)
-	require.Len(t, objects, 2)
+	require.Len(t, objects, 3)
 
 	d, ok := objects[0].(*v1.Deployment)
 	require.True(t, ok)
@@ -289,7 +289,7 @@ func TestBuildMetricsGeneratorHashRingPodIP(t *testing.T) {
 
 	objects, err := BuildMetricsGenerator(newParams(tempo))
 	require.NoError(t, err)
-	require.Len(t, objects, 2)
+	require.Len(t, objects, 3)
 
 	d, ok := objects[0].(*v1.Deployment)
 	require.True(t, ok)

--- a/internal/manifests/mutate.go
+++ b/internal/manifests/mutate.go
@@ -14,6 +14,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -141,6 +142,10 @@ func MutateFuncFor(existing, desired client.Object) controllerutil.MutateFn {
 			ds := existing.(*networkingv1.NetworkPolicy)
 			wantDs := desired.(*networkingv1.NetworkPolicy)
 			mutateNetworkPolicy(ds, wantDs)
+		case *policyv1.PodDisruptionBudget:
+			pdb := existing.(*policyv1.PodDisruptionBudget)
+			wantPdb := desired.(*policyv1.PodDisruptionBudget)
+			mutatePodDisruptionBudget(pdb, wantPdb)
 		default:
 			t := reflect.TypeOf(existing).String()
 			return kverrors.New("missing mutate implementation for resource type", "type", t)
@@ -263,6 +268,12 @@ func mutateService(existing, desired *corev1.Service) error {
 }
 
 func mutateNetworkPolicy(existing, desired *networkingv1.NetworkPolicy) {
+	existing.Annotations = desired.Annotations
+	existing.Labels = desired.Labels
+	existing.Spec = desired.Spec
+}
+
+func mutatePodDisruptionBudget(existing, desired *policyv1.PodDisruptionBudget) {
 	existing.Annotations = desired.Annotations
 	existing.Labels = desired.Labels
 	existing.Spec = desired.Spec

--- a/internal/manifests/querier/querier.go
+++ b/internal/manifests/querier/querier.go
@@ -47,7 +47,11 @@ func BuildQuerier(params manifestutils.Params) ([]client.Object, error) {
 
 	manifestutils.PatchEnvVars(&d.Spec.Template.Spec, "tempo", tempo.Spec.Env, tempo.Spec.EnvFrom)
 
-	return []client.Object{d, service(tempo)}, nil
+	return []client.Object{
+		d,
+		service(tempo),
+		manifestutils.NewPodDisruptionBudget(tempo, manifestutils.QuerierComponentName),
+	}, nil
 }
 
 func resources(tempo v1alpha1.TempoStack) corev1.ResourceRequirements {

--- a/internal/manifests/querier/querier_test.go
+++ b/internal/manifests/querier/querier_test.go
@@ -54,7 +54,7 @@ func TestBuildQuerier(t *testing.T) {
 
 	labels := manifestutils.ComponentLabels("querier", "test")
 	annotations := manifestutils.CommonAnnotations("")
-	assert.Equal(t, 2, len(objects))
+	assert.Equal(t, 3, len(objects))
 
 	assert.Equal(t, &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/manifests/queryfrontend/query_frontend.go
+++ b/internal/manifests/queryfrontend/query_frontend.go
@@ -123,6 +123,8 @@ func BuildQueryFrontend(params manifestutils.Params) ([]client.Object, error) {
 		manifests = append(manifests, rbac...)
 	}
 
+	manifests = append(manifests, manifestutils.NewPodDisruptionBudget(tempo, manifestutils.QueryFrontendComponentName))
+
 	return manifests, nil
 }
 

--- a/internal/manifests/queryfrontend/query_frontend_test.go
+++ b/internal/manifests/queryfrontend/query_frontend_test.go
@@ -369,7 +369,7 @@ func TestBuildQueryFrontend(t *testing.T) {
 		},
 	}})
 	require.NoError(t, err)
-	require.Equal(t, 3, len(objects))
+	require.Equal(t, 4, len(objects))
 
 	// Test the services
 	frontendService := objects[0].(*corev1.Service)
@@ -426,7 +426,7 @@ func TestBuildQueryFrontendWithJaeger(t *testing.T) {
 	}})
 
 	require.NoError(t, err)
-	require.Equal(t, 3, len(objects))
+	require.Equal(t, 4, len(objects))
 
 	// Test the services
 	frontendService := objects[0].(*corev1.Service)
@@ -468,7 +468,7 @@ func TestQueryFrontendJaegerIngress(t *testing.T) {
 	}})
 
 	require.NoError(t, err)
-	require.Equal(t, 4, len(objects))
+	require.Equal(t, 5, len(objects))
 	pathType := networkingv1.PathTypePrefix
 	assert.Equal(t, &networkingv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
@@ -531,7 +531,7 @@ func TestQueryFrontendJaegerRoute(t *testing.T) {
 	}})
 
 	require.NoError(t, err)
-	require.Equal(t, 4, len(objects))
+	require.Equal(t, 5, len(objects))
 	assert.Equal(t, &routev1.Route{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      naming.Name(manifestutils.QueryFrontendComponentName, "test"),
@@ -584,7 +584,7 @@ func TestQueryFrontendJaegerTLS(t *testing.T) {
 		}})
 
 	require.NoError(t, err)
-	require.Equal(t, 3, len(objects))
+	require.Equal(t, 4, len(objects))
 	deployment := objects[2].(*v1.Deployment)
 	require.Len(t, deployment.Spec.Template.Spec.Containers, 3)
 	jaegerContainer := deployment.Spec.Template.Spec.Containers[1]
@@ -743,7 +743,7 @@ func TestBuildQueryFrontendWithJaegerMonitorTab(t *testing.T) {
 					Tempo: test.tempo,
 				})
 				require.NoError(t, err)
-				assert.Equal(t, 5, len(objects))
+				assert.Equal(t, 6, len(objects))
 
 				assert.Equal(t, "tempo-simplest-metrics-reader", objects[3].GetName())
 				assert.Equal(t, "tempo-simplest-metrics-reader", objects[4].GetName())
@@ -829,7 +829,7 @@ func TestQueryFrontendJaegerRouteSecured(t *testing.T) {
 	}})
 
 	require.NoError(t, err)
-	require.Equal(t, 5, len(objects))
+	require.Equal(t, 6, len(objects))
 	assert.Equal(t, &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      naming.Name(manifestutils.QueryFrontendComponentName, "test"),

--- a/tests/e2e/compatibility/01-assert.yaml
+++ b/tests/e2e/compatibility/01-assert.yaml
@@ -369,3 +369,78 @@ spec:
       name: tempo-simplest-query-frontend
       port:
         name: jaeger-ui
+#
+# PodDisruptionBudgets (one per component, no PDB for the compactor)
+#
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app.kubernetes.io/component: distributor
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+  name: tempo-simplest-distributor
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: distributor
+      app.kubernetes.io/instance: simplest
+      app.kubernetes.io/managed-by: tempo-operator
+      app.kubernetes.io/name: tempo
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app.kubernetes.io/component: ingester
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+  name: tempo-simplest-ingester
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: ingester
+      app.kubernetes.io/instance: simplest
+      app.kubernetes.io/managed-by: tempo-operator
+      app.kubernetes.io/name: tempo
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app.kubernetes.io/component: querier
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+  name: tempo-simplest-querier
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: querier
+      app.kubernetes.io/instance: simplest
+      app.kubernetes.io/managed-by: tempo-operator
+      app.kubernetes.io/name: tempo
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-operator
+    app.kubernetes.io/name: tempo
+  name: tempo-simplest-query-frontend
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: query-frontend
+      app.kubernetes.io/instance: simplest
+      app.kubernetes.io/managed-by: tempo-operator
+      app.kubernetes.io/name: tempo


### PR DESCRIPTION
## Description

Creates a `PodDisruptionBudget` with `maxUnavailable: 1` for the distributor, ingester, querier, query-frontend, gateway and metrics-generator components of a `TempoStack`.

This ensures that voluntary disruptions, such as node drains during cluster upgrades, can only take down a single replica of a component at a time, keeping the rest of the component available.

Following the [Grafana Loki Operator](https://github.com/grafana/loki/tree/main/operator/internal/manifests), no budget is created for the compactor, and the same `maxUnavailable: 1` default is used.

## Notes

* The gateway and metrics-generator budgets are only created when those components are enabled in the CR. They are listed in `findObjectsOwnedByTempoOperator`, so they get pruned when the component is disabled.
* The reconciler now watches `PodDisruptionBudget` (`Owns`), and the `policy` API group was added to the operator RBAC (role and both bundle CSVs).
* `TempoMonolithic` is not affected by this change.

## Testing

* Unit test for the new `manifestutils.NewPodDisruptionBudget` helper.
* Object count assertions updated in `cmd/generate` and `internal/manifests`.
* The `e2e/compatibility` test asserts the four budgets created for that CR.