### PR TITLE
chore: refactor finalizer logic to avoid concurrent writes

### DIFF
--- a/.chloggen/refactor-finalizer-logic.yaml
+++ b/.chloggen/refactor-finalizer-logic.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. tempostack, tempomonolithic, github action)
+component: operator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Refactor finalizer logic to avoid concurrent writes
+
+# One or more tracking issues related to the change
+issues: [1579]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/internal/controller/tempo/tempomonolithic_controller.go
+++ b/internal/controller/tempo/tempomonolithic_controller.go
@@ -91,11 +91,13 @@ func (r *TempoMonolithicReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		// The object is being deleted
 		if controllerutil.ContainsFinalizer(&tempo, v1alpha1.TempoFinalizer) {
 			// our finalizer is present, so let's handle any external dependency
-			if err := finalize(ctx, r.Client, log, monolithic.ClusterScopedCommonLabels(tempo.ObjectMeta)); err != nil {
-				// if fail to delete the external dependency here, return with error
-				// so that it can be retried.
-				log.Error(err, "failed to finalize, re-reconciling")
-				return ctrl.Result{}, err
+			if tempo.Spec.Management != v1alpha1.ManagementStateUnmanaged {
+				if err := finalize(ctx, r.Client, log, monolithic.ClusterScopedCommonLabels(tempo.ObjectMeta)); err != nil {
+					// if fail to delete the external dependency here, return with error
+					// so that it can be retried.
+					log.Error(err, "failed to finalize, re-reconciling")
+					return ctrl.Result{}, err
+				}
 			}
 
 			// remove our finalizer from the list and update it.

--- a/internal/controller/tempo/tempomonolithic_controller.go
+++ b/internal/controller/tempo/tempomonolithic_controller.go
@@ -62,38 +62,51 @@ func (r *TempoMonolithicReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	tempo := v1alpha1.TempoMonolithic{}
 	if err := r.Get(ctx, req.NamespacedName, &tempo); err != nil {
-		if !apierrors.IsNotFound(err) {
-			log.Error(err, "unable to fetch TempoMonolithic")
-			return ctrl.Result{}, fmt.Errorf("could not fetch tempo: %w", err)
-		}
-		// instance is not found, metrics can be cleared
-		status.ClearMonolithicMetrics(req.Namespace, req.Name)
+		if apierrors.IsNotFound(err) {
+			// instance is not found, metrics can be cleared
+			status.ClearMonolithicMetrics(req.Namespace, req.Name)
 
-		// we'll ignore not-found errors, since they can't be fixed by an immediate
-		// requeue (we'll need to wait for a new notification), and we can get them
-		// on deleted requests.
-		return ctrl.Result{}, nil
+			// we'll ignore not-found errors, since they can't be fixed by an immediate
+			// requeue (we'll need to wait for a new notification), and we can get them
+			// on deleted requests.
+			return ctrl.Result{}, nil
+		}
+
+		log.Error(err, "unable to fetch TempoMonolithic")
+		return ctrl.Result{}, fmt.Errorf("could not fetch tempo: %w", err)
 	}
 
-	// We have a deletion, short circuit and let the deletion happen
-	if deletionTimestamp := tempo.GetDeletionTimestamp(); deletionTimestamp != nil {
+	// examine DeletionTimestamp to determine if object is under deletion
+	if tempo.ObjectMeta.DeletionTimestamp.IsZero() {
+		// The object is not being deleted, so if it does not have our finalizer,
+		// then let's add the finalizer and update the object. This is equivalent
+		// to registering our finalizer.
+		if !controllerutil.ContainsFinalizer(&tempo, v1alpha1.TempoFinalizer) {
+			controllerutil.AddFinalizer(&tempo, v1alpha1.TempoFinalizer)
+			if err := r.Update(ctx, &tempo); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+	} else {
+		// The object is being deleted
 		if controllerutil.ContainsFinalizer(&tempo, v1alpha1.TempoFinalizer) {
-			// If the finalization logic fails, don't remove the finalizer so
-			// that we can retry during the next reconciliation.
+			// our finalizer is present, so let's handle any external dependency
 			if err := finalize(ctx, r.Client, log, monolithic.ClusterScopedCommonLabels(tempo.ObjectMeta)); err != nil {
+				// if fail to delete the external dependency here, return with error
+				// so that it can be retried.
+				log.Error(err, "failed to finalize, re-reconciling")
 				return ctrl.Result{}, err
 			}
 
-			// Once all finalizers have been
-			// removed, the object will be deleted.
-			if controllerutil.RemoveFinalizer(&tempo, v1alpha1.TempoFinalizer) {
-				err := r.Update(ctx, &tempo)
-				if err != nil {
-					return ctrl.Result{}, err
-				}
+			// remove our finalizer from the list and update it.
+			controllerutil.RemoveFinalizer(&tempo, v1alpha1.TempoFinalizer)
+			if err := r.Update(ctx, &tempo); err != nil {
+				log.Error(err, "failed to remove finalizer, re-reconciling")
+				return ctrl.Result{}, err
 			}
 		}
 
+		// Stop reconciliation as the item is being deleted
 		return ctrl.Result{}, nil
 	}
 
@@ -122,16 +135,6 @@ func (r *TempoMonolithicReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		err := monolithic.CreateOrRotateCertificates(ctx, log, req, r.Client, r.Scheme, r.CtrlConfig.Gates, certrotation.MonolithicComponentCertSecretNames(req.Name))
 		if err != nil {
 			return ctrl.Result{}, status.HandleTempoMonolithicStatus(ctx, r.Client, tempo, fmt.Errorf("built in cert manager error: %w", err))
-		}
-	}
-
-	// Add finalizer for this CR
-	if !controllerutil.ContainsFinalizer(&tempo, v1alpha1.TempoFinalizer) {
-		if controllerutil.AddFinalizer(&tempo, v1alpha1.TempoFinalizer) {
-			err := r.Update(ctx, &tempo)
-			if err != nil {
-				return ctrl.Result{}, err
-			}
 		}
 	}
 

--- a/internal/controller/tempo/tempostack_controller.go
+++ b/internal/controller/tempo/tempostack_controller.go
@@ -86,40 +86,51 @@ func (r *TempoStackReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	tempo := v1alpha1.TempoStack{}
 	if err := r.Get(ctx, req.NamespacedName, &tempo); err != nil {
-		if !apierrors.IsNotFound(err) {
-			log.Error(err, "unable to fetch TempoStack")
-			return ctrl.Result{}, fmt.Errorf("could not fetch tempo: %w", err)
-		}
-		// instance is not found, metrics can be cleared
-		status.ClearTempoStackMetrics(req.Namespace, req.Name)
+		if apierrors.IsNotFound(err) {
+			// instance is not found, metrics can be cleared
+			status.ClearTempoStackMetrics(req.Namespace, req.Name)
 
-		// we'll ignore not-found errors, since they can't be fixed by an immediate
-		// requeue (we'll need to wait for a new notification), and we can get them
-		// on deleted requests.
-		return ctrl.Result{}, nil
+			// we'll ignore not-found errors, since they can't be fixed by an immediate
+			// requeue (we'll need to wait for a new notification), and we can get them
+			// on deleted requests.
+			return ctrl.Result{}, nil
+		}
+
+		log.Error(err, "unable to fetch TempoStack")
+		return ctrl.Result{}, fmt.Errorf("could not fetch tempo: %w", err)
 	}
 
-	// We have a deletion, short circuit and let the deletion happen
-	if deletionTimestamp := tempo.GetDeletionTimestamp(); deletionTimestamp != nil {
+	// examine DeletionTimestamp to determine if object is under deletion
+	if tempo.ObjectMeta.DeletionTimestamp.IsZero() {
+		// The object is not being deleted, so if it does not have our finalizer,
+		// then let's add the finalizer and update the object. This is equivalent
+		// to registering our finalizer.
+		if !controllerutil.ContainsFinalizer(&tempo, v1alpha1.TempoFinalizer) {
+			controllerutil.AddFinalizer(&tempo, v1alpha1.TempoFinalizer)
+			if err := r.Update(ctx, &tempo); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+	} else {
+		// The object is being deleted
 		if controllerutil.ContainsFinalizer(&tempo, v1alpha1.TempoFinalizer) {
-			// If the finalization logic fails, don't remove the finalizer so
-			// that we can retry during the next reconciliation.
+			// our finalizer is present, so let's handle any external dependency
 			if err := finalize(ctx, r.Client, log, manifestutils.ClusterScopedCommonLabels(tempo.ObjectMeta)); err != nil {
+				// if fail to delete the external dependency here, return with error
+				// so that it can be retried.
 				log.Error(err, "failed to finalize, re-reconciling")
 				return ctrl.Result{}, err
 			}
 
-			// Once all finalizers have been
-			// removed, the object will be deleted.
-			if controllerutil.RemoveFinalizer(&tempo, v1alpha1.TempoFinalizer) {
-				err := r.Update(ctx, &tempo)
-				if err != nil {
-					log.Error(err, "failed to remove finalizer, re-reconciling")
-					return ctrl.Result{}, err
-				}
+			// remove our finalizer from the list and update it.
+			controllerutil.RemoveFinalizer(&tempo, v1alpha1.TempoFinalizer)
+			if err := r.Update(ctx, &tempo); err != nil {
+				log.Error(err, "failed to remove finalizer, re-reconciling")
+				return ctrl.Result{}, err
 			}
 		}
 
+		// Stop reconciliation as the item is being deleted
 		return ctrl.Result{}, nil
 	}
 
@@ -149,16 +160,6 @@ func (r *TempoStackReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		err := handlers.CreateOrRotateCertificates(ctx, log, req, r.Client, r.Scheme, r.CtrlConfig.Gates, certrotation.TempoStackComponentCertSecretNames(req.Name))
 		if err != nil {
 			return r.handleReconcileStatus(ctx, log, tempo, fmt.Errorf("built in cert manager error: %w", err))
-		}
-	}
-
-	// Add finalizer for this CR
-	if !controllerutil.ContainsFinalizer(&tempo, v1alpha1.TempoFinalizer) {
-		if controllerutil.AddFinalizer(&tempo, v1alpha1.TempoFinalizer) {
-			err := r.Update(ctx, &tempo)
-			if err != nil {
-				return ctrl.Result{}, err
-			}
 		}
 	}
 

--- a/internal/controller/tempo/tempostack_controller.go
+++ b/internal/controller/tempo/tempostack_controller.go
@@ -115,11 +115,13 @@ func (r *TempoStackReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		// The object is being deleted
 		if controllerutil.ContainsFinalizer(&tempo, v1alpha1.TempoFinalizer) {
 			// our finalizer is present, so let's handle any external dependency
-			if err := finalize(ctx, r.Client, log, manifestutils.ClusterScopedCommonLabels(tempo.ObjectMeta)); err != nil {
-				// if fail to delete the external dependency here, return with error
-				// so that it can be retried.
-				log.Error(err, "failed to finalize, re-reconciling")
-				return ctrl.Result{}, err
+			if tempo.Spec.ManagementState != v1alpha1.ManagementStateUnmanaged {
+				if err := finalize(ctx, r.Client, log, manifestutils.ClusterScopedCommonLabels(tempo.ObjectMeta)); err != nil {
+					// if fail to delete the external dependency here, return with error
+					// so that it can be retried.
+					log.Error(err, "failed to finalize, re-reconciling")
+					return ctrl.Result{}, err
+				}
 			}
 
 			// remove our finalizer from the list and update it.


### PR DESCRIPTION
Previously, there was a race between CreateOrRotateCertificates() (which adds cert hashes to Tempo CR) and adding the finalizer to the CR:

- in reconciler, TempoStack is fetched from cluster
- CreateOrRotateCertificates() fetches TempoStack again from cluster, adds hash annotations
- finalizer is added to the (now stale) TempoStack object, causing a conflict

The PR updates the finalizer logic to follow the Kubebuilder pattern: https://book.kubebuilder.io/reference/using-finalizers.html

This should fix the flaky `tshirt-size-pico` test.