### PR TITLE
[chore] enable operator debug logs for e2e tests in GHA

### DIFF
--- a/.chainsaw.yaml
+++ b/.chainsaw.yaml
@@ -5,6 +5,7 @@ metadata:
   name: configuration
 spec:
   timeouts:
+    apply: 30s
     assert: 2m30s
     cleanup: 2m30s
     delete: 2m30s

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -59,7 +59,7 @@ jobs:
       if: failure()
       run: |
         echo "=== Operator logs ==="
-        kubectl logs -n tempo-operator-system deployment/tempo-operator-controller --tail=100
+        kubectl logs -n tempo-operator-system deployment/tempo-operator-controller
 
 
   upgrade-tests:
@@ -156,4 +156,4 @@ jobs:
       if: failure()
       run: |
         echo "=== Operator logs ==="
-        kubectl logs -n tempo-operator-system deployment/tempo-operator-controller --tail=100
+        kubectl logs -n tempo-operator-system deployment/tempo-operator-controller

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -47,8 +47,13 @@ jobs:
       env:
         KUBE_VERSION: ${{ matrix.kube-version }}
       run: |
-        make prepare-e2e e2e test-operator-metrics KUBE_VERSION="$KUBE_VERSION"
-        make e2e-reconcile-count
+        make \
+          prepare-e2e \
+          e2e-enable-debug-logs \
+          e2e \
+          e2e-operator-metrics \
+          e2e-reconcile-count \
+          KUBE_VERSION="$KUBE_VERSION"
 
     - name: Collect diagnostics on failure
       if: failure()

--- a/Makefile
+++ b/Makefile
@@ -406,15 +406,29 @@ deploy-minio:
 .PHONY: prepare-e2e
 prepare-e2e: chainsaw start-kind cert-manager set-test-image-vars build docker-build load-image-operator deploy olm-install otel-deploy
 
+# Enable debug logs for the operator
+.PHONY: e2e-enable-debug-logs
+e2e-enable-debug-logs:
+	@echo "Patching operator deployment to set log level to debug"
+	kubectl patch deployment -n $(OPERATOR_NAMESPACE) tempo-operator-controller --type=json \
+		-p '[{"op":"replace","path":"/spec/template/spec/containers/0/args/0","value":"--zap-log-level=debug"}]'
+	kubectl rollout --namespace $(OPERATOR_NAMESPACE) status deployment/tempo-operator-controller
+	@echo "Waiting for webhook to become ready..."
+	@until kubectl create -n default --dry-run=server -f ./tests/e2e-reconcile-count/01-install-tempo.yaml > /dev/null 2>&1; do sleep 2; done
+
 TEST_DIR ?= ./tests/e2e
 
 .PHONY: e2e
 e2e:
 	$(CHAINSAW) test --test-dir $(TEST_DIR)
 
-.PHONY: test-operator-metrics
-test-operator-metrics:
+.PHONY: e2e-operator-metrics
+e2e-operator-metrics:
 	$(CHAINSAW) test --test-dir ./tests/operator-metrics
+
+.PHONY: e2e-reconcile-count
+e2e-reconcile-count:
+	$(CHAINSAW) test --test-dir ./tests/e2e-reconcile-count
 
 # OpenShift end-to-tests
 .PHONY: e2e-openshift
@@ -425,17 +439,6 @@ e2e-openshift:
 .PHONY: e2e-openshift-tshirt-sizes
 e2e-openshift-tshirt-sizes:
 	$(CHAINSAW) test --test-dir ./tests/e2e-openshift-tshirt-sizes --config .chainsaw-openshift.yaml
-
-# reconcile count tests
-.PHONY: e2e-reconcile-count
-e2e-reconcile-count: chainsaw
-	@echo "Patching operator deployment to set log level to debug"
-	kubectl patch deployment -n $(OPERATOR_NAMESPACE) tempo-operator-controller --type=json \
-		-p '[{"op":"replace","path":"/spec/template/spec/containers/0/args/0","value":"--zap-log-level=1"}]'
-	kubectl rollout --namespace $(OPERATOR_NAMESPACE) status deployment/tempo-operator-controller
-	@echo "Waiting for webhook to become ready..."
-	@until kubectl create -n default --dry-run=server -f ./tests/e2e-reconcile-count/01-install-tempo.yaml > /dev/null 2>&1; do sleep 2; done
-	$(CHAINSAW) test --test-dir ./tests/e2e-reconcile-count
 
 # upgrade tests
 e2e-upgrade:

--- a/tests/e2e-reconcile-count/chainsaw-test.yaml
+++ b/tests/e2e-reconcile-count/chainsaw-test.yaml
@@ -52,7 +52,7 @@ spec:
           echo "Threshold: $THRESHOLD"
 
           if [ "$COUNT" -eq 0 ]; then
-            echo "FAIL: Reconcile count is 0, operator may not be running with --zap-log-level=1"
+            echo "FAIL: Reconcile count is 0, operator may not be running with --zap-log-level=debug"
             echo "Sample log lines:"
             echo "$LOGS" | grep "$NAMESPACE" | head -5
             exit 1

--- a/tests/e2e/tshirt-size-pico/chainsaw-test.yaml
+++ b/tests/e2e/tshirt-size-pico/chainsaw-test.yaml
@@ -4,6 +4,8 @@ kind: Test
 metadata:
   name: tshirt-size-pico
 spec:
+  timeouts:
+    cleanup: 5m
   steps:
   - name: step-00
     try:


### PR DESCRIPTION
Enable debug logs for the operator when running e2e tests in GitHub Actions.