### PR TITLE
[chore] fix metricsgenerator status field

### DIFF
--- a/api/tempo/v1alpha1/tempostack_types.go
+++ b/api/tempo/v1alpha1/tempostack_types.go
@@ -352,7 +352,7 @@ type ComponentStatus struct {
 	// +optional
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=status,xDescriptors="urn:alm:descriptor:com.tectonic.ui:podStatuses",displayName="Metrics Generator",order=7
-	MetricsGenerator PodStatusMap `json:"metricsGenerator,omitempty"`
+	MetricsGenerator PodStatusMap `json:"metricsGenerator"`
 }
 
 // TempoStackStatus defines the observed state of TempoStack.


### PR DESCRIPTION
`urn:alm:descriptor:com.tectonic.ui:podStatuses` fields must be present always, i.e. no `omitempty`.