### PR TITLE
Warn that the Jaeger UI is deprecated when it is enabled

### DIFF
--- a/.chloggen/deprecate-jaeger-ui.yaml
+++ b/.chloggen/deprecate-jaeger-ui.yaml
@@ -1,0 +1,24 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. tempostack, tempomonolithic, github action)
+component: tempostack, tempomonolithic
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Warn that the Jaeger UI is deprecated when it is enabled.
+
+# One or more tracking issues related to the change
+issues: [1587]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The validating webhook now returns a warning when `spec.template.queryFrontend.jaegerQuery.enabled`
+  of a TempoStack or `spec.jaegerui.enabled` of a TempoMonolithic is set to `true`:
+
+  ```
+  Warning: spec.template.queryFrontend.jaegerQuery.enabled is deprecated and will be removed in a future release
+  ```
+
+  This is only a warning, existing instances keep working and nothing else changes.

--- a/internal/webhooks/tempomonolithic_webhook.go
+++ b/internal/webhooks/tempomonolithic_webhook.go
@@ -94,6 +94,7 @@ func (v *monolithicValidator) validateTempoMonolithic(ctx context.Context, tempo
 	errors = append(errors, v.validateConflictWithTempoStack(ctx, tempo)...)
 
 	warnings = append(warnings, v.validateExtraConfig(tempo)...)
+	warnings = append(warnings, v.validateJaegerUIDeprecation(tempo)...)
 
 	return warnings, errors
 }
@@ -106,6 +107,18 @@ func (v *monolithicValidator) validateStorage(ctx context.Context, tempo tempov1
 		return admission.Warnings{errs[0].Detail}, field.ErrorList{}
 	}
 	return nil, errs
+}
+
+// jaegerUIDeprecationWarning is returned when the deprecated Jaeger UI is enabled.
+const jaegerUIDeprecationWarning = "spec.jaegerui.enabled is deprecated and will be removed in a future release"
+
+// validateJaegerUIDeprecation warns that the Jaeger UI is deprecated.
+// The deployment keeps working, therefore this is a warning and not an error.
+func (v *monolithicValidator) validateJaegerUIDeprecation(tempo tempov1alpha1.TempoMonolithic) admission.Warnings {
+	if tempo.Spec.JaegerUI != nil && tempo.Spec.JaegerUI.Enabled {
+		return admission.Warnings{jaegerUIDeprecationWarning}
+	}
+	return nil
 }
 
 func (v *monolithicValidator) validateJaegerUI(tempo tempov1alpha1.TempoMonolithic) field.ErrorList {

--- a/internal/webhooks/tempomonolithic_webhook_test.go
+++ b/internal/webhooks/tempomonolithic_webhook_test.go
@@ -96,7 +96,7 @@ func TestMonolithicValidate(t *testing.T) {
 					},
 				},
 			},
-			warnings: admission.Warnings{},
+			warnings: admission.Warnings{jaegerUIDeprecationWarning},
 			errors: field.ErrorList{field.Invalid(
 				field.NewPath("spec", "jaegerui", "route", "enabled"),
 				true,
@@ -122,7 +122,7 @@ func TestMonolithicValidate(t *testing.T) {
 					},
 				},
 			},
-			warnings: admission.Warnings{},
+			warnings: admission.Warnings{jaegerUIDeprecationWarning},
 			errors:   field.ErrorList{},
 		},
 
@@ -167,7 +167,7 @@ func TestMonolithicValidate(t *testing.T) {
 					},
 				},
 			},
-			warnings: admission.Warnings{},
+			warnings: admission.Warnings{jaegerUIDeprecationWarning},
 			errors: field.ErrorList{field.Invalid(
 				field.NewPath("spec", "rbac", "enabled"),
 				true,
@@ -488,6 +488,41 @@ func TestConflictTempoStackValidation(t *testing.T) {
 			v := &monolithicValidator{ctrlConfig: configv1alpha1.ProjectConfig{}, client: test.client}
 			err := v.validateConflictWithTempoStack(ctx, *tempoMonolithic)
 			assert.Equal(t, test.expected, err)
+		})
+	}
+}
+
+func TestValidateJaegerUIDeprecation(t *testing.T) {
+	validator := &monolithicValidator{}
+
+	tests := []struct {
+		name     string
+		jaegerUI *v1alpha1.MonolithicJaegerUISpec
+		expected admission.Warnings
+	}{
+		{
+			name:     "jaegerui not configured",
+			jaegerUI: nil,
+			expected: nil,
+		},
+		{
+			name:     "jaegerui disabled",
+			jaegerUI: &v1alpha1.MonolithicJaegerUISpec{Enabled: false},
+			expected: nil,
+		},
+		{
+			name:     "jaegerui enabled",
+			jaegerUI: &v1alpha1.MonolithicJaegerUISpec{Enabled: true},
+			expected: admission.Warnings{jaegerUIDeprecationWarning},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			tempo := v1alpha1.TempoMonolithic{
+				Spec: v1alpha1.TempoMonolithicSpec{JaegerUI: test.jaegerUI},
+			}
+			assert.Equal(t, test.expected, validator.validateJaegerUIDeprecation(tempo))
 		})
 	}
 }

--- a/internal/webhooks/tempostack_webhook.go
+++ b/internal/webhooks/tempostack_webhook.go
@@ -302,6 +302,18 @@ func (v *validator) validateReplicationFactor(tempo v1alpha1.TempoStack) field.E
 	return nil
 }
 
+// jaegerQueryDeprecationWarning is returned when the deprecated Jaeger Query component is enabled.
+const jaegerQueryDeprecationWarning = "spec.template.queryFrontend.jaegerQuery.enabled is deprecated and will be removed in a future release"
+
+// validateJaegerQueryDeprecation warns that the Jaeger Query component is deprecated.
+// The stack keeps working, therefore this is a warning and not an error.
+func (v *validator) validateJaegerQueryDeprecation(tempo v1alpha1.TempoStack) admission.Warnings {
+	if tempo.Spec.Template.QueryFrontend.JaegerQuery.Enabled {
+		return admission.Warnings{jaegerQueryDeprecationWarning}
+	}
+	return nil
+}
+
 func (v *validator) validateQueryFrontend(tempo v1alpha1.TempoStack) field.ErrorList {
 	path := field.NewPath("spec").Child("template").Child("queryFrontend").Child("jaegerQuery").Child("ingress").Child("type")
 
@@ -588,6 +600,7 @@ func (v *validator) validate(ctx context.Context, tempo *v1alpha1.TempoStack) (a
 
 	allErrors = append(allErrors, v.validateReplicationFactor(*tempo)...)
 	allErrors = append(allErrors, v.validateQueryFrontend(*tempo)...)
+	allWarnings = append(allWarnings, v.validateJaegerQueryDeprecation(*tempo)...)
 	addValidationResults(v.validateGateway(ctx, *tempo))
 	allErrors = append(allErrors, v.validateTenantConfigs(*tempo)...)
 	allErrors = append(allErrors, v.validateObservability(*tempo)...)

--- a/internal/webhooks/tempostack_webhook_test.go
+++ b/internal/webhooks/tempostack_webhook_test.go
@@ -2776,6 +2776,38 @@ func TestWarning(t *testing.T) {
 			},
 		},
 		{
+			name: "warning for the deprecated jaeger query",
+			input: &v1alpha1.TempoStack{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-obj",
+					Namespace: "abc",
+				},
+				TypeMeta: gvType,
+				Spec: v1alpha1.TempoStackSpec{
+					ServiceAccount: naming.DefaultServiceAccountName("test-obj"),
+					Storage: v1alpha1.ObjectStorageSpec{
+						Secret: v1alpha1.ObjectStorageSecretSpec{
+							Name: "not-found",
+						},
+					},
+					Template: v1alpha1.TempoTemplateSpec{
+						Ingester: v1alpha1.TempoComponentSpec{
+							Replicas: func(i int32) *int32 { return &i }(1),
+						},
+						QueryFrontend: v1alpha1.TempoQueryFrontendSpec{
+							JaegerQuery: v1alpha1.JaegerQuerySpec{
+								Enabled: true,
+							},
+						},
+					},
+				},
+			},
+			client: &k8sFake{
+				secret: &corev1.Secret{},
+			},
+			expected: admission.Warnings{jaegerQueryDeprecationWarning},
+		},
+		{
 			name: "no extra config used",
 			input: &v1alpha1.TempoStack{
 				ObjectMeta: metav1.ObjectMeta{
@@ -2968,6 +3000,42 @@ func TestValidateMetricsGenerator(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			assert.Equal(t, tc.expected, v.validateMetricsGenerator(tc.input))
+		})
+	}
+}
+
+func TestValidateJaegerQueryDeprecation(t *testing.T) {
+	validator := &validator{}
+
+	tests := []struct {
+		name     string
+		enabled  bool
+		expected admission.Warnings
+	}{
+		{
+			name:     "jaegerQuery disabled",
+			enabled:  false,
+			expected: nil,
+		},
+		{
+			name:     "jaegerQuery enabled",
+			enabled:  true,
+			expected: admission.Warnings{jaegerQueryDeprecationWarning},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			tempo := v1alpha1.TempoStack{
+				Spec: v1alpha1.TempoStackSpec{
+					Template: v1alpha1.TempoTemplateSpec{
+						QueryFrontend: v1alpha1.TempoQueryFrontendSpec{
+							JaegerQuery: v1alpha1.JaegerQuerySpec{Enabled: test.enabled},
+						},
+					},
+				},
+			}
+			assert.Equal(t, test.expected, validator.validateJaegerQueryDeprecation(tempo))
 		})
 	}
 }


### PR DESCRIPTION
Resolves #1587

## Description

The validating webhook now returns an admission warning when the Jaeger UI is enabled, on either CR:

| CR | Field |
|---|---|
| `TempoStack` | `spec.template.queryFrontend.jaegerQuery.enabled` |
| `TempoMonolithic` | `spec.jaegerui.enabled` |

```
$ kubectl apply -f tempostack.yaml
Warning: spec.template.queryFrontend.jaegerQuery.enabled is deprecated and will be removed in a future release
tempostack.tempo.grafana.com/simplest configured
```

This is only a warning: the CR stays valid, existing instances keep working, and no manifest is changed. Users learn about the deprecation on their next apply, rather than when the component is eventually removed.

Both webhooks already aggregated an `admission.Warnings` list and emit warnings for other cases (for example `spec.extraConfig`), so this follows the existing pattern. The warning text lives in a constant per file, shared with the tests instead of repeating the literal.

## Notes for reviewers

* **The wording promises no replacement.** It says the field is deprecated and will be removed, and stops there, since there is no migration target recorded anywhere in this repo. Happy to point users somewhere specific if there is an agreed destination.
* **The API doc comments are untouched on purpose.** Marking the fields with a `Deprecated:` prefix would surface the notice in the CRD and in `docs/spec/`, but `jaegerQuery` is read throughout `internal/manifests`, so staticcheck would then flag every use (SA1019) and need an exclusion in `.golangci.yaml`. Worth doing as a follow-up if you want it, but it seemed a separate decision from adding the warning.

## Testing

* `TestValidateJaegerQueryDeprecation` and `TestValidateJaegerUIDeprecation` cover the new functions directly, including the nil `spec.jaegerui` case.
* A new `TestWarning` case covers the TempoStack warning end to end through `validate()`. Worth calling out: no existing TempoStack test reached that path, since they all call the individual validators directly, so nothing failed when the warning was added. I verified the new case actually bites by temporarily removing the wiring and confirming it fails.
* Three existing `TestMonolithicValidate` cases enable the Jaeger UI and assert the exact warning list, so their expectations were updated.

`go build ./...`, the full `go test ./...` suite and `golangci-lint` all pass.