### PR TITLE
feat: add READY column to output of kubectl get

### DIFF
--- a/.chloggen/add-ready-column.yaml
+++ b/.chloggen/add-ready-column.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. tempostack, tempomonolithic, github action)
+component: tempostack, tempomonolithic
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add READY column to the output of `kubectl get`
+
+# One or more tracking issues related to the change
+issues: [1600]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/api/tempo/v1alpha1/tempomonolithic_types.go
+++ b/api/tempo/v1alpha1/tempomonolithic_types.go
@@ -564,8 +564,9 @@ type TempoMonolithicStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
-//+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 //+kubebuilder:printcolumn:name="Tempo Version",type="string",JSONPath=".status.tempoVersion",description="Tempo Version"
+//+kubebuilder:printcolumn:name="Ready",type="string",JSONPath=`.status.conditions[?(@.type=="Ready")].status`
+//+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // TempoMonolithic manages a Tempo deployment in monolithic mode.
 //

--- a/api/tempo/v1alpha1/tempostack_types.go
+++ b/api/tempo/v1alpha1/tempostack_types.go
@@ -1055,9 +1055,10 @@ type RetentionConfig struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
-//+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
-//+kubebuilder:printcolumn:name="Tempo Version",type="string",JSONPath=".status.tempoVersion",description="Tempo Version"
 //+kubebuilder:printcolumn:name="Management",type="string",JSONPath=".spec.managementState",description="Management State"
+//+kubebuilder:printcolumn:name="Tempo Version",type="string",JSONPath=".status.tempoVersion",description="Tempo Version"
+//+kubebuilder:printcolumn:name="Ready",type="string",JSONPath=`.status.conditions[?(@.type=="Ready")].status`
+//+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // TempoStack manages a Tempo deployment in microservices mode.
 //

--- a/bundle/community/manifests/tempo-operator.clusterserviceversion.yaml
+++ b/bundle/community/manifests/tempo-operator.clusterserviceversion.yaml
@@ -74,7 +74,7 @@ metadata:
     capabilities: Deep Insights
     categories: Logging & Tracing,Monitoring,Observability
     containerImage: ghcr.io/grafana/tempo-operator/tempo-operator:v0.21.0
-    createdAt: "2026-07-24T12:47:10Z"
+    createdAt: "2026-08-07T17:08:00Z"
     description: Create and manage deployments of Tempo, a high-scale distributed
       tracing backend.
     operatorframework.io/cluster-monitoring: "true"

--- a/bundle/community/manifests/tempo.grafana.com_tempomonolithics.yaml
+++ b/bundle/community/manifests/tempo.grafana.com_tempomonolithics.yaml
@@ -19,13 +19,16 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
     - description: Tempo Version
       jsonPath: .status.tempoVersion
       name: Tempo Version
       type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/bundle/community/manifests/tempo.grafana.com_tempostacks.yaml
+++ b/bundle/community/manifests/tempo.grafana.com_tempostacks.yaml
@@ -22,17 +22,20 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    - description: Tempo Version
-      jsonPath: .status.tempoVersion
-      name: Tempo Version
-      type: string
     - description: Management State
       jsonPath: .spec.managementState
       name: Management
       type: string
+    - description: Tempo Version
+      jsonPath: .status.tempoVersion
+      name: Tempo Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/bundle/openshift/manifests/tempo-operator.clusterserviceversion.yaml
+++ b/bundle/openshift/manifests/tempo-operator.clusterserviceversion.yaml
@@ -74,7 +74,7 @@ metadata:
     capabilities: Deep Insights
     categories: Logging & Tracing,Monitoring,Observability
     containerImage: ghcr.io/grafana/tempo-operator/tempo-operator:v0.21.0
-    createdAt: "2026-07-24T12:47:09Z"
+    createdAt: "2026-08-07T17:07:58Z"
     description: Create and manage deployments of Tempo, a high-scale distributed
       tracing backend.
     operatorframework.io/cluster-monitoring: "true"

--- a/bundle/openshift/manifests/tempo.grafana.com_tempomonolithics.yaml
+++ b/bundle/openshift/manifests/tempo.grafana.com_tempomonolithics.yaml
@@ -19,13 +19,16 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
     - description: Tempo Version
       jsonPath: .status.tempoVersion
       name: Tempo Version
       type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/bundle/openshift/manifests/tempo.grafana.com_tempostacks.yaml
+++ b/bundle/openshift/manifests/tempo.grafana.com_tempostacks.yaml
@@ -22,17 +22,20 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    - description: Tempo Version
-      jsonPath: .status.tempoVersion
-      name: Tempo Version
-      type: string
     - description: Management State
       jsonPath: .spec.managementState
       name: Management
       type: string
+    - description: Tempo Version
+      jsonPath: .status.tempoVersion
+      name: Tempo Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/tempo.grafana.com_tempomonolithics.yaml
+++ b/config/crd/bases/tempo.grafana.com_tempomonolithics.yaml
@@ -15,13 +15,16 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
     - description: Tempo Version
       jsonPath: .status.tempoVersion
       name: Tempo Version
       type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/tempo.grafana.com_tempostacks.yaml
+++ b/config/crd/bases/tempo.grafana.com_tempostacks.yaml
@@ -18,17 +18,20 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    - description: Tempo Version
-      jsonPath: .status.tempoVersion
-      name: Tempo Version
-      type: string
     - description: Management State
       jsonPath: .spec.managementState
       name: Management
       type: string
+    - description: Tempo Version
+      jsonPath: .status.tempoVersion
+      name: Tempo Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1alpha1
     schema:
       openAPIV3Schema:


### PR DESCRIPTION
Example:

```
$ k get -A tempostacks.tempo.grafana.com
NAMESPACE           NAME       MANAGEMENT   TEMPO VERSION   READY   AGE
chainsaw-free-elf   simplest   Managed      2.10.7          True    22m

$ k get -A tempomonolithics.tempo.grafana.com
NAMESPACE               NAME       TEMPO VERSION   READY   AGE
chainsaw-exact-minnow   simplest   2.10.7          True    2m3s
```