### PR TITLE
Add option to disable gateway's ingress in OpenShift

### DIFF
--- a/.chloggen/allow_to_disable_ingress_in_openshift.yaml
+++ b/.chloggen/allow_to_disable_ingress_in_openshift.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, github action)
+component: tempostack
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Make it possible to disable the gateway's Ingress when tenant mode is OpenShift
+
+# One or more tracking issues related to the change
+issues: [1416]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/api/tempo/v1alpha1/ingress_types.go
+++ b/api/tempo/v1alpha1/ingress_types.go
@@ -2,19 +2,32 @@ package v1alpha1
 
 type (
 	// IngressType represents how a service should be exposed (ingress vs route).
-	// +kubebuilder:validation:Enum=ingress;route;""
+	// +kubebuilder:validation:Enum=ingress;route;none;""
 	// +kubebuilder:default=""
 	IngressType string
 )
 
 const (
 	// IngressTypeNone specifies that no ingress or route entry should be created.
-	IngressTypeNone IngressType = ""
+	IngressTypeNone IngressType = "none"
+	// IngressTypeUnspecified specifies that ingress or route entry should only be created if necessary.
+	IngressTypeUnspecified IngressType = ""
 	// IngressTypeIngress specifies that an ingress entry should be created.
 	IngressTypeIngress IngressType = "ingress"
 	// IngressTypeRoute specifies that a route entry should be created.
 	IngressTypeRoute IngressType = "route"
 )
+
+// IsEnabled returns true if the ingress type is explicitly set to a specific resource.
+func (i IngressType) IsEnabled() bool {
+	switch i {
+	case IngressTypeNone, IngressTypeUnspecified:
+		return false
+	case IngressTypeIngress, IngressTypeRoute:
+		return true
+	}
+	return false
+}
 
 type (
 	// TLSRouteTerminationType is used to indicate which TLS settings should be used.

--- a/api/tempo/v1alpha1/ingress_types_test.go
+++ b/api/tempo/v1alpha1/ingress_types_test.go
@@ -1,0 +1,42 @@
+package v1alpha1
+
+import (
+	"testing"
+)
+
+func TestIngressTypeIsEnabled(t *testing.T) {
+	tests := []struct {
+		name        string
+		ingressType IngressType
+		expected    bool
+	}{
+		{
+			name:        "unspecified type returns false",
+			ingressType: IngressTypeUnspecified,
+			expected:    false,
+		},
+		{
+			name:        "none type returns false",
+			ingressType: IngressTypeNone,
+			expected:    false,
+		},
+		{
+			name:        "ingress type returns true",
+			ingressType: IngressTypeIngress,
+			expected:    true,
+		},
+		{
+			name:        "route type returns true",
+			ingressType: IngressTypeRoute,
+			expected:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.ingressType.IsEnabled(); got != tt.expected {
+				t.Errorf("IngressType.IsEnabled() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}

--- a/api/tempo/v1alpha1/tempostack_types.go
+++ b/api/tempo/v1alpha1/tempostack_types.go
@@ -919,7 +919,7 @@ type JaegerQueryMonitor struct {
 // IngressSpec defines Jaeger Query Ingress options.
 type IngressSpec struct {
 	// Type defines the type of Ingress for the Jaeger Query UI.
-	// Currently ingress, route and none are supported.
+	// Supported values: ingress, route, none
 	//
 	// +optional
 	// +kubebuilder:validation:Optional

--- a/bundle/community/manifests/tempo-operator.clusterserviceversion.yaml
+++ b/bundle/community/manifests/tempo-operator.clusterserviceversion.yaml
@@ -1174,7 +1174,7 @@ spec:
         path: template.gateway.ingress.route.termination
       - description: |-
           Type defines the type of Ingress for the Jaeger Query UI.
-          Currently ingress, route and none are supported.
+          Supported values: ingress, route, none
         displayName: Type
         path: template.gateway.ingress.type
       - description: NodeSelector defines the simple form of the node-selection constraint.
@@ -1341,7 +1341,7 @@ spec:
         path: template.queryFrontend.jaegerQuery.ingress.route.termination
       - description: |-
           Type defines the type of Ingress for the Jaeger Query UI.
-          Currently ingress, route and none are supported.
+          Supported values: ingress, route, none
         displayName: Type
         path: template.queryFrontend.jaegerQuery.ingress.type
       - description: MonitorTab defines the monitor tab configuration.

--- a/bundle/community/manifests/tempo.grafana.com_tempostacks.yaml
+++ b/bundle/community/manifests/tempo.grafana.com_tempostacks.yaml
@@ -1947,10 +1947,11 @@ spec:
                           type:
                             description: |-
                               Type defines the type of Ingress for the Jaeger Query UI.
-                              Currently ingress, route and none are supported.
+                              Supported values: ingress, route, none
                             enum:
                             - ingress
                             - route
+                            - none
                             - ""
                             type: string
                         type: object
@@ -3540,10 +3541,11 @@ spec:
                               type:
                                 description: |-
                                   Type defines the type of Ingress for the Jaeger Query UI.
-                                  Currently ingress, route and none are supported.
+                                  Supported values: ingress, route, none
                                 enum:
                                 - ingress
                                 - route
+                                - none
                                 - ""
                                 type: string
                             type: object

--- a/bundle/openshift/manifests/tempo-operator.clusterserviceversion.yaml
+++ b/bundle/openshift/manifests/tempo-operator.clusterserviceversion.yaml
@@ -1174,7 +1174,7 @@ spec:
         path: template.gateway.ingress.route.termination
       - description: |-
           Type defines the type of Ingress for the Jaeger Query UI.
-          Currently ingress, route and none are supported.
+          Supported values: ingress, route, none
         displayName: Type
         path: template.gateway.ingress.type
       - description: NodeSelector defines the simple form of the node-selection constraint.
@@ -1341,7 +1341,7 @@ spec:
         path: template.queryFrontend.jaegerQuery.ingress.route.termination
       - description: |-
           Type defines the type of Ingress for the Jaeger Query UI.
-          Currently ingress, route and none are supported.
+          Supported values: ingress, route, none
         displayName: Type
         path: template.queryFrontend.jaegerQuery.ingress.type
       - description: MonitorTab defines the monitor tab configuration.

--- a/bundle/openshift/manifests/tempo.grafana.com_tempostacks.yaml
+++ b/bundle/openshift/manifests/tempo.grafana.com_tempostacks.yaml
@@ -1947,10 +1947,11 @@ spec:
                           type:
                             description: |-
                               Type defines the type of Ingress for the Jaeger Query UI.
-                              Currently ingress, route and none are supported.
+                              Supported values: ingress, route, none
                             enum:
                             - ingress
                             - route
+                            - none
                             - ""
                             type: string
                         type: object
@@ -3540,10 +3541,11 @@ spec:
                               type:
                                 description: |-
                                   Type defines the type of Ingress for the Jaeger Query UI.
-                                  Currently ingress, route and none are supported.
+                                  Supported values: ingress, route, none
                                 enum:
                                 - ingress
                                 - route
+                                - none
                                 - ""
                                 type: string
                             type: object

--- a/config/crd/bases/tempo.grafana.com_tempostacks.yaml
+++ b/config/crd/bases/tempo.grafana.com_tempostacks.yaml
@@ -1943,10 +1943,11 @@ spec:
                           type:
                             description: |-
                               Type defines the type of Ingress for the Jaeger Query UI.
-                              Currently ingress, route and none are supported.
+                              Supported values: ingress, route, none
                             enum:
                             - ingress
                             - route
+                            - none
                             - ""
                             type: string
                         type: object
@@ -3536,10 +3537,11 @@ spec:
                               type:
                                 description: |-
                                   Type defines the type of Ingress for the Jaeger Query UI.
-                                  Currently ingress, route and none are supported.
+                                  Supported values: ingress, route, none
                                 enum:
                                 - ingress
                                 - route
+                                - none
                                 - ""
                                 type: string
                             type: object

--- a/config/manifests/community/bases/tempo-operator.clusterserviceversion.yaml
+++ b/config/manifests/community/bases/tempo-operator.clusterserviceversion.yaml
@@ -1103,7 +1103,7 @@ spec:
         path: template.gateway.ingress.route.termination
       - description: |-
           Type defines the type of Ingress for the Jaeger Query UI.
-          Currently ingress, route and none are supported.
+          Supported values: ingress, route, none
         displayName: Type
         path: template.gateway.ingress.type
       - description: NodeSelector defines the simple form of the node-selection constraint.
@@ -1270,7 +1270,7 @@ spec:
         path: template.queryFrontend.jaegerQuery.ingress.route.termination
       - description: |-
           Type defines the type of Ingress for the Jaeger Query UI.
-          Currently ingress, route and none are supported.
+          Supported values: ingress, route, none
         displayName: Type
         path: template.queryFrontend.jaegerQuery.ingress.type
       - description: MonitorTab defines the monitor tab configuration.

--- a/config/manifests/openshift/bases/tempo-operator.clusterserviceversion.yaml
+++ b/config/manifests/openshift/bases/tempo-operator.clusterserviceversion.yaml
@@ -1103,7 +1103,7 @@ spec:
         path: template.gateway.ingress.route.termination
       - description: |-
           Type defines the type of Ingress for the Jaeger Query UI.
-          Currently ingress, route and none are supported.
+          Supported values: ingress, route, none
         displayName: Type
         path: template.gateway.ingress.type
       - description: NodeSelector defines the simple form of the node-selection constraint.
@@ -1270,7 +1270,7 @@ spec:
         path: template.queryFrontend.jaegerQuery.ingress.route.termination
       - description: |-
           Type defines the type of Ingress for the Jaeger Query UI.
-          Currently ingress, route and none are supported.
+          Supported values: ingress, route, none
         displayName: Type
         path: template.queryFrontend.jaegerQuery.ingress.type
       - description: MonitorTab defines the monitor tab configuration.

--- a/docs/spec/tempo.grafana.com_tempostacks.yaml
+++ b/docs/spec/tempo.grafana.com_tempostacks.yaml
@@ -268,7 +268,7 @@ spec:                                    # TempoStackSpec defines the desired st
         ingressClassName: ""             # IngressClassName defines the name of an IngressClass cluster resource. Defines which ingress controller serves this ingress resource.
         route:                           # Route defines the options for the OpenShift route.
           termination: ""                # Termination defines the termination type. The default is "edge".
-        type: ""                         # Type defines the type of Ingress for the Jaeger Query UI. Currently ingress, route and none are supported.
+        type: ""                         # Type defines the type of Ingress for the Jaeger Query UI. Supported values: ingress, route, none
       rbac:                              # RBAC defines query RBAC options.
         enabled: false                   # Enabled defines if the query RBAC should be enabled.
     ingester:                            # Ingester defines the ingester component spec.
@@ -472,7 +472,7 @@ spec:                                    # TempoStackSpec defines the desired st
           ingressClassName: ""           # IngressClassName defines the name of an IngressClass cluster resource. Defines which ingress controller serves this ingress resource.
           route:                         # Route defines the options for the OpenShift route.
             termination: ""              # Termination defines the termination type. The default is "edge".
-          type: ""                       # Type defines the type of Ingress for the Jaeger Query UI. Currently ingress, route and none are supported.
+          type: ""                       # Type defines the type of Ingress for the Jaeger Query UI. Supported values: ingress, route, none
         monitorTab:                      # MonitorTab defines the monitor tab configuration.
           enabled: false                 # Enabled enables the monitor tab in the Jaeger console. The PrometheusEndpoint must be configured to enable this feature.
           prometheusEndpoint: ""         # PrometheusEndpoint defines the endpoint to the Prometheus instance that contains the span rate, error, and duration (RED) metrics. For instance on OpenShift this is set to https://thanos-querier.openshift-monitoring.svc.cluster.local:9091

--- a/internal/webhooks/tempostack_webhook.go
+++ b/internal/webhooks/tempostack_webhook.go
@@ -361,7 +361,7 @@ func (v *validator) validateJaegerQueryDeprecation(tempo v1alpha1.TempoStack) ad
 func (v *validator) validateQueryFrontend(tempo v1alpha1.TempoStack) field.ErrorList {
 	path := field.NewPath("spec").Child("template").Child("queryFrontend").Child("jaegerQuery").Child("ingress").Child("type")
 
-	if tempo.Spec.Template.QueryFrontend.JaegerQuery.Ingress.Type != v1alpha1.IngressTypeNone && !tempo.Spec.Template.QueryFrontend.JaegerQuery.Enabled {
+	if tempo.Spec.Template.QueryFrontend.JaegerQuery.Ingress.Type.IsEnabled() && !tempo.Spec.Template.QueryFrontend.JaegerQuery.Enabled {
 		return field.ErrorList{field.Invalid(
 			path,
 			tempo.Spec.Template.QueryFrontend.JaegerQuery.Ingress.Type,
@@ -394,7 +394,7 @@ func (v *validator) validateQueryFrontend(tempo v1alpha1.TempoStack) field.Error
 func (v *validator) validateGateway(ctx context.Context, tempo v1alpha1.TempoStack) (admission.Warnings, field.ErrorList) {
 	path := field.NewPath("spec").Child("template").Child("gateway").Child("enabled")
 	if tempo.Spec.Template.Gateway.Enabled {
-		if tempo.Spec.Template.QueryFrontend.JaegerQuery.Ingress.Type != v1alpha1.IngressTypeNone {
+		if tempo.Spec.Template.QueryFrontend.JaegerQuery.Ingress.Type.IsEnabled() {
 			return nil, field.ErrorList{
 				field.Invalid(path, tempo.Spec.Template.Gateway.Enabled,
 					"cannot enable gateway and jaeger query ingress at the same time, please use the Jaeger UI from the gateway",

--- a/internal/webhooks/tempostack_webhook_test.go
+++ b/internal/webhooks/tempostack_webhook_test.go
@@ -962,6 +962,199 @@ func TestDefault(t *testing.T) {
 			},
 			ctrlConfig: defaultCfgConfig,
 		},
+		{
+			name: "set ingress type to route if tenant mode is OpenShift and ingress type is not specified",
+			input: &v1alpha1.TempoStack{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Spec: v1alpha1.TempoStackSpec{
+					Tenants: &v1alpha1.TenantsSpec{
+						Mode: v1alpha1.ModeOpenShift,
+					},
+					Template: v1alpha1.TempoTemplateSpec{
+						Gateway: v1alpha1.TempoGatewaySpec{
+							Ingress: v1alpha1.IngressSpec{
+								Type: "",
+							},
+						},
+					},
+				},
+			},
+			expected: &v1alpha1.TempoStack{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+					Labels: map[string]string{
+						"app.kubernetes.io/managed-by":   "tempo-operator",
+						"tempo.grafana.com/distribution": "upstream",
+					},
+				},
+				Spec: v1alpha1.TempoStackSpec{
+					ReplicationFactor: 1,
+					Timeout:           metav1.Duration{Duration: time.Second * 30},
+					Images:            configv1alpha1.ImagesSpec{},
+					ServiceAccount:    "tempo-test",
+					Retention: v1alpha1.RetentionSpec{
+						Global: v1alpha1.RetentionConfig{
+							Traces: metav1.Duration{Duration: 48 * time.Hour},
+						},
+					},
+					StorageSize: resource.MustParse("10Gi"),
+					LimitSpec: v1alpha1.LimitSpec{
+						Global: v1alpha1.RateLimitSpec{
+							Query: v1alpha1.QueryLimit{
+								MaxSearchDuration: metav1.Duration{Duration: 0},
+							},
+						},
+					},
+					SearchSpec: v1alpha1.SearchSpec{
+						MaxDuration:        metav1.Duration{Duration: 0},
+						DefaultResultLimit: &defaultDefaultResultLimit,
+					},
+					Template: v1alpha1.TempoTemplateSpec{
+						Compactor: v1alpha1.TempoComponentSpec{
+							Replicas:           ptr.To(int32(1)),
+							PodSecurityContext: defaultPodSecurityContext,
+						},
+						Distributor: v1alpha1.TempoDistributorSpec{
+							TempoComponentSpec: v1alpha1.TempoComponentSpec{
+								Replicas:           ptr.To(int32(1)),
+								PodSecurityContext: defaultPodSecurityContext,
+							},
+							TLS: v1alpha1.TLSSpec{},
+						},
+						Ingester: v1alpha1.TempoComponentSpec{
+							Replicas:           ptr.To(int32(1)),
+							PodSecurityContext: defaultPodSecurityContext,
+						},
+						Querier: v1alpha1.TempoComponentSpec{
+							Replicas:           ptr.To(int32(1)),
+							PodSecurityContext: defaultPodSecurityContext,
+						},
+						QueryFrontend: v1alpha1.TempoQueryFrontendSpec{
+							TempoComponentSpec: v1alpha1.TempoComponentSpec{
+								Replicas:           ptr.To(int32(1)),
+								PodSecurityContext: defaultPodSecurityContext,
+							},
+							JaegerQuery: v1alpha1.JaegerQuerySpec{
+								ServicesQueryDuration: &defaultServicesDuration,
+							},
+						},
+						Gateway: v1alpha1.TempoGatewaySpec{
+							TempoComponentSpec: v1alpha1.TempoComponentSpec{
+								Replicas:           ptr.To(int32(1)),
+								PodSecurityContext: defaultPodSecurityContext,
+							},
+							Ingress: v1alpha1.IngressSpec{
+								Type: v1alpha1.IngressTypeRoute,
+								Route: v1alpha1.RouteSpec{
+									Termination: "reencrypt",
+								},
+							},
+						},
+					},
+					Tenants: &v1alpha1.TenantsSpec{
+						Mode: v1alpha1.ModeOpenShift,
+					},
+				},
+			},
+			ctrlConfig: defaultCfgConfig,
+		},
+		{
+			name: "honor explicit disabling of ingress if tenant mode is OpenShift",
+			input: &v1alpha1.TempoStack{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Spec: v1alpha1.TempoStackSpec{
+					Tenants: &v1alpha1.TenantsSpec{
+						Mode: v1alpha1.ModeOpenShift,
+					},
+					Template: v1alpha1.TempoTemplateSpec{
+						Gateway: v1alpha1.TempoGatewaySpec{
+							Ingress: v1alpha1.IngressSpec{
+								Type: "none",
+							},
+						},
+					},
+				},
+			},
+			expected: &v1alpha1.TempoStack{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+					Labels: map[string]string{
+						"app.kubernetes.io/managed-by":   "tempo-operator",
+						"tempo.grafana.com/distribution": "upstream",
+					},
+				},
+				Spec: v1alpha1.TempoStackSpec{
+					ReplicationFactor: 1,
+					Timeout:           metav1.Duration{Duration: time.Second * 30},
+					Images:            configv1alpha1.ImagesSpec{},
+					ServiceAccount:    "tempo-test",
+					Retention: v1alpha1.RetentionSpec{
+						Global: v1alpha1.RetentionConfig{
+							Traces: metav1.Duration{Duration: 48 * time.Hour},
+						},
+					},
+					StorageSize: resource.MustParse("10Gi"),
+					LimitSpec: v1alpha1.LimitSpec{
+						Global: v1alpha1.RateLimitSpec{
+							Query: v1alpha1.QueryLimit{
+								MaxSearchDuration: metav1.Duration{Duration: 0},
+							},
+						},
+					},
+					SearchSpec: v1alpha1.SearchSpec{
+						MaxDuration:        metav1.Duration{Duration: 0},
+						DefaultResultLimit: &defaultDefaultResultLimit,
+					},
+					Template: v1alpha1.TempoTemplateSpec{
+						Compactor: v1alpha1.TempoComponentSpec{
+							Replicas:           ptr.To(int32(1)),
+							PodSecurityContext: defaultPodSecurityContext,
+						},
+						Distributor: v1alpha1.TempoDistributorSpec{
+							TempoComponentSpec: v1alpha1.TempoComponentSpec{
+								Replicas:           ptr.To(int32(1)),
+								PodSecurityContext: defaultPodSecurityContext,
+							},
+							TLS: v1alpha1.TLSSpec{},
+						},
+						Ingester: v1alpha1.TempoComponentSpec{
+							Replicas:           ptr.To(int32(1)),
+							PodSecurityContext: defaultPodSecurityContext,
+						},
+						Querier: v1alpha1.TempoComponentSpec{
+							Replicas:           ptr.To(int32(1)),
+							PodSecurityContext: defaultPodSecurityContext,
+						},
+						QueryFrontend: v1alpha1.TempoQueryFrontendSpec{
+							TempoComponentSpec: v1alpha1.TempoComponentSpec{
+								Replicas:           ptr.To(int32(1)),
+								PodSecurityContext: defaultPodSecurityContext,
+							},
+							JaegerQuery: v1alpha1.JaegerQuerySpec{
+								ServicesQueryDuration: &defaultServicesDuration,
+							},
+						},
+						Gateway: v1alpha1.TempoGatewaySpec{
+							TempoComponentSpec: v1alpha1.TempoComponentSpec{
+								Replicas:           ptr.To(int32(1)),
+								PodSecurityContext: defaultPodSecurityContext,
+							},
+							Ingress: v1alpha1.IngressSpec{
+								Type: v1alpha1.IngressTypeNone,
+							},
+						},
+					},
+					Tenants: &v1alpha1.TenantsSpec{
+						Mode: v1alpha1.ModeOpenShift,
+					},
+				},
+			},
+			ctrlConfig: defaultCfgConfig,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Resolves #1416 

## Description

This adds `none` as a value for `tempostasck.spec.template.gateway.ingress.type`. This serves to make it possible to disable the creation of an Ingress/Route for Tempo's Gateway even if the tenant mode is `openshift`.

In OpenShift clusters, if `tempostasck.spec.template.gateway.ingress.type` is not set (or set to the default value `""`), the Tempo operator will still create a Route for the Gateway, which is a useful default behavior in many cases. However, if no access to the Gateway is required via Route/Ingress, for security reasons it should be possible to disable the creation of the Route.

## Summary of changes

- Added `"none"` to `IngressType` enum constants and kubebuilder validation markers in `api/v1alpha1`.
- Implemented `(i IngressType) IsEnabled() bool` helper method to simplify reconciler checks.
- Regenerated CRDs and OLM bundle manifests (`make manifests bundle`).
- Added unit tests for `IngressType.IsEnabled()`.
- Added unit test cases for `TempoStackWebhook.Default()` when tenant mode is `openshift` and ingress type is either `""` or `"none"`.

## How to test

1. Deploy the operator locally or on a test cluster.
2. Apply a `TempoStack` CR with `spec.template.gateway.ingress.type: "none"`.
3. No `Ingress` or `Route` resource should be created for the `TempoStack`.
4. In contrast, for a `TempoStack` CR with `spec.template.gateway.ingress.type: ""`, a `Route` should still be created.