### PR TITLE
[chore] use canoncial form of CPU limits in tempostack-resources e2e test

### DIFF
--- a/tests/e2e-openshift/tempostack-resources/01-install-tempostack.yaml
+++ b/tests/e2e-openshift/tempostack-resources/01-install-tempostack.yaml
@@ -12,7 +12,7 @@ spec:
     total:
       limits:
         memory: 2Gi
-        cpu: 2000m
+        cpu: "2"
   tenants:
     mode: openshift
     authentication:

--- a/tests/e2e-openshift/tempostack-resources/03-update-tempostack.yaml
+++ b/tests/e2e-openshift/tempostack-resources/03-update-tempostack.yaml
@@ -12,7 +12,7 @@ spec:
     total:
       limits:
         memory: 2Gi
-        cpu: 2000m
+        cpu: "2"
   tenants:
     mode: openshift
     authentication:


### PR DESCRIPTION
If the operator updates the TempoStack CR, it canonicalizes the limits automatically (via `resource.Quantity`).
If this didn't happen, then the following benign error occurred:

```
* spec.resources.total.limits.cpu: Invalid value: "2000m": Expected value: "2"

--- expected
+++ actual
@@ -7,7 +7,7 @@
   resources:
     total:
       limits:
-        cpu: "2"
+        cpu: 2000m
```