### PR TITLE
[chore] drop Observability category from the community manifests

### DIFF
--- a/bundle/community/manifests/tempo-operator.clusterserviceversion.yaml
+++ b/bundle/community/manifests/tempo-operator.clusterserviceversion.yaml
@@ -72,9 +72,9 @@ metadata:
         }
       ]
     capabilities: Deep Insights
-    categories: Logging & Tracing,Monitoring,Observability
+    categories: Logging & Tracing,Monitoring
     containerImage: ghcr.io/grafana/tempo-operator/tempo-operator:v0.22.0
-    createdAt: "2026-08-18T14:14:36Z"
+    createdAt: "2026-08-19T14:17:44Z"
     description: Create and manage deployments of Tempo, a high-scale distributed
       tracing backend.
     operatorframework.io/cluster-monitoring: "true"

--- a/config/manifests/community/bases/tempo-operator.clusterserviceversion.yaml
+++ b/config/manifests/community/bases/tempo-operator.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Deep Insights
-    categories: Logging & Tracing,Monitoring,Observability
+    categories: Logging & Tracing,Monitoring
     containerImage: ghcr.io/grafana/tempo-operator/tempo-operator:v0.22.0
     description: Create and manage deployments of Tempo, a high-scale distributed
       tracing backend.


### PR DESCRIPTION
`Observability` category is not supported on community OperatorHub: https://github.com/k8s-operatorhub/community-operators/pull/9073#issuecomment-5330885414