### PR TITLE
Use custom gateway ingress host in OpenShift tenant redirect URLs.

### DIFF
--- a/.chloggen/use-custom-gateway-ingress-host.yaml
+++ b/.chloggen/use-custom-gateway-ingress-host.yaml
@@ -1,0 +1,19 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. tempostack, tempomonolithic, github action)
+component: tempostack
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Use the configured gateway ingress host in OpenShift tenant redirect URLs.
+
+# One or more tracking issues related to the change
+issues: [1629]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  When spec.template.gateway.ingress.host is set, the OpenShift Route already uses that
+  hostname. Tenant redirectURL values in tenants.yaml now use the same host instead of
+  the generated default Route hostname.

--- a/internal/manifests/gateway/gateway.go
+++ b/internal/manifests/gateway/gateway.go
@@ -37,7 +37,7 @@ func BuildGateway(params manifestutils.Params) ([]client.Object, error) {
 		tempo.Namespace,
 		tempo.Name,
 		gatewayObjectName,
-		naming.RouteFqdn(tempo.Namespace, tempo.Name, manifestutils.GatewayComponentName, params.CtrlConfig.Gates.OpenShift.BaseDomain),
+		gatewayRouteHost(tempo, params.CtrlConfig.Gates.OpenShift.BaseDomain),
 		"tempostack",
 		*tempo.Spec.Tenants,
 		params.GatewayTenantSecret,
@@ -141,6 +141,16 @@ func BuildGateway(params manifestutils.Params) ([]client.Object, error) {
 	objs = append(objs, dep)
 	objs = append(objs, manifestutils.NewPodDisruptionBudget(params.Tempo, manifestutils.GatewayComponentName))
 	return objs, nil
+}
+
+// gatewayRouteHost returns the hostname used for OpenShift tenant redirect URLs.
+// It uses spec.template.gateway.ingress.host when configured so the redirect URL
+// matches the OpenShift Route, otherwise it falls back to the generated Route FQDN.
+func gatewayRouteHost(tempo v1alpha1.TempoStack, baseDomain string) string {
+	if host := tempo.Spec.Template.Gateway.Ingress.Host; host != "" {
+		return host
+	}
+	return naming.RouteFqdn(tempo.Namespace, tempo.Name, manifestutils.GatewayComponentName, baseDomain)
 }
 
 // HttpScheme determines the HTTP scheme based on the provided TLS flag.

--- a/internal/manifests/gateway/gateway_test.go
+++ b/internal/manifests/gateway/gateway_test.go
@@ -259,6 +259,132 @@ func TestBuildGateway_openshift(t *testing.T) {
 	}, caConfigMap.Annotations)
 }
 
+func TestGatewayRouteHost(t *testing.T) {
+	tempo := v1alpha1.TempoStack{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sample",
+			Namespace: "tracing-system",
+		},
+	}
+	baseDomain := "apps.mycluster.mydomain"
+
+	assert.Equal(t,
+		naming.RouteFqdn(tempo.Namespace, tempo.Name, manifestutils.GatewayComponentName, baseDomain),
+		gatewayRouteHost(tempo, baseDomain),
+	)
+
+	tempo.Spec.Template.Gateway.Ingress.Host = "mytempo.apps.mycluster.mydomain"
+	assert.Equal(t, "mytempo.apps.mycluster.mydomain", gatewayRouteHost(tempo, baseDomain))
+}
+
+func TestBuildGateway_openshiftRedirectURL(t *testing.T) {
+	tests := []struct {
+		name             string
+		ingressHost      string
+		tenants          []v1alpha1.AuthenticationSpec
+		wantRouteHost    string
+		wantRedirectURLs []string
+	}{
+		{
+			name:        "custom ingress host",
+			ingressHost: "mytempo.apps.mycluster.mydomain",
+			tenants: []v1alpha1.AuthenticationSpec{
+				{TenantName: "dev", TenantID: "1610b0c3-c509-4592-a256-a1871353dbfa"},
+			},
+			wantRouteHost: "mytempo.apps.mycluster.mydomain",
+			wantRedirectURLs: []string{
+				"https://mytempo.apps.mycluster.mydomain/openshift/dev/callback",
+			},
+		},
+		{
+			name: "default generated ingress host",
+			tenants: []v1alpha1.AuthenticationSpec{
+				{TenantName: "dev", TenantID: "1610b0c3-c509-4592-a256-a1871353dbfa"},
+			},
+			wantRouteHost: "",
+			wantRedirectURLs: []string{
+				"https://" + naming.RouteFqdn("tracing-system", "sample", manifestutils.GatewayComponentName, "apps.mycluster.mydomain") + "/openshift/dev/callback",
+			},
+		},
+		{
+			name:        "multiple tenants share the same gateway host",
+			ingressHost: "mytempo.apps.mycluster.mydomain",
+			tenants: []v1alpha1.AuthenticationSpec{
+				{TenantName: "dev", TenantID: "1610b0c3-c509-4592-a256-a1871353dbfa"},
+				{TenantName: "test", TenantID: "2610b0c3-c509-4592-a256-a1871353dbfb"},
+			},
+			wantRouteHost: "mytempo.apps.mycluster.mydomain",
+			wantRedirectURLs: []string{
+				"https://mytempo.apps.mycluster.mydomain/openshift/dev/callback",
+				"https://mytempo.apps.mycluster.mydomain/openshift/test/callback",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tempo := v1alpha1.TempoStack{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "sample",
+					Namespace: "tracing-system",
+				},
+				Spec: v1alpha1.TempoStackSpec{
+					Template: v1alpha1.TempoTemplateSpec{
+						Gateway: v1alpha1.TempoGatewaySpec{
+							Enabled: true,
+							Ingress: v1alpha1.IngressSpec{
+								Type: v1alpha1.IngressTypeRoute,
+								Host: tt.ingressHost,
+								Route: v1alpha1.RouteSpec{
+									Termination: v1alpha1.TLSRouteTerminationTypeReencrypt,
+								},
+							},
+						},
+					},
+					Tenants: &v1alpha1.TenantsSpec{
+						Mode:           v1alpha1.ModeOpenShift,
+						Authentication: tt.tenants,
+					},
+				},
+			}
+
+			objects, err := BuildGateway(manifestutils.Params{
+				Tempo: tempo,
+				CtrlConfig: configv1alpha1.ProjectConfig{
+					Gates: configv1alpha1.FeatureGates{
+						OpenShift: configv1alpha1.OpenShiftFeatureGates{
+							ServingCertsService: true,
+							OpenShiftRoute:      true,
+							BaseDomain:          "apps.mycluster.mydomain",
+						},
+					},
+				},
+			})
+			require.NoError(t, err)
+
+			obj := getObjectByTypeAndName(objects, "tempo-sample-gateway", reflect.TypeOf(&routev1.Route{}))
+			require.NotNil(t, obj)
+			route, ok := obj.(*routev1.Route)
+			require.True(t, ok)
+			assert.Equal(t, tt.wantRouteHost, route.Spec.Host)
+
+			obj = getObjectByTypeAndName(objects, "tempo-sample-gateway", reflect.TypeOf(&corev1.Secret{}))
+			require.NotNil(t, obj)
+			secret, ok := obj.(*corev1.Secret)
+			require.True(t, ok)
+			tenantsCfg := string(secret.Data[manifestutils.GatewayTenantFileName])
+			require.NotEmpty(t, tenantsCfg)
+			for _, redirectURL := range tt.wantRedirectURLs {
+				assert.Contains(t, tenantsCfg, "redirectURL: "+redirectURL)
+			}
+			if tt.ingressHost != "" {
+				generatedHost := naming.RouteFqdn("tracing-system", "sample", manifestutils.GatewayComponentName, "apps.mycluster.mydomain")
+				assert.NotContains(t, tenantsCfg, generatedHost)
+			}
+		})
+	}
+}
+
 func getObjectByTypeAndName(objects []client.Object, name string, t reflect.Type) client.Object { // nolint: unparam
 	for _, o := range objects {
 		objType := reflect.TypeOf(o)


### PR DESCRIPTION
## Summary

- When `spec.template.gateway.ingress.host` is set, the OpenShift gateway Route already uses that hostname, but OpenShift tenant `redirectURL` values in `tenants.yaml` were still built from the generated Route FQDN (`tempo-<name>-gateway-<namespace>.<baseDomain>`).
- Tenant redirect URLs now use the same effective hostname as the Route: the configured ingress host when present, otherwise the existing generated Route hostname.
- Default behavior is unchanged when no custom gateway ingress host is configured.

## Test plan

- [x] `go test ./internal/manifests/gateway/`
- [x] Custom ingress host produces `https://<custom-host>/openshift/<tenant>/callback`
- [x] No custom host still uses `naming.RouteFqdn` for `redirectURL`
- [x] Multiple tenants share the same gateway host and keep tenant-specific callback paths (`/openshift/dev/callback`, `/openshift/test/callback`)
- [ ] Existing gateway unit tests continue to pass