### PR TITLE
fix(test): use translation_strategy in red-metrics collector config

### DIFF
--- a/tests/e2e-openshift/red-metrics/02-install-otel-collector.yaml
+++ b/tests/e2e-openshift/red-metrics/02-install-otel-collector.yaml
@@ -29,7 +29,9 @@ spec:
     
     exporters:
       prometheus:
-        add_metric_suffixes: false
+        # Collector >=0.154.0 ignores add_metric_suffixes by default (DisableAddMetricSuffixes
+        # gate promoted to Beta); set translation_strategy explicitly to keep unsuffixed names.
+        translation_strategy: "UnderscoreEscapingWithoutSuffixes"
         endpoint: 0.0.0.0:8889
         resource_to_telemetry_conversion: 
           enabled: true # by default resource attributes are dropped


### PR DESCRIPTION
## Description

The `red-metrics` e2e test configured the collector's prometheus exporter with `add_metric_suffixes: false`. This is a no-op on collector >= 0.154.0: the `exporter.prometheus.DisableAddMetricSuffixes` feature gate was promoted to **Beta (enabled by default)**, which makes the exporter ignore `add_metric_suffixes` entirely. The gate name is misleading — it means "disable the old config field," not "disable metric suffixes."

As a result, on RHOSDT 3.11 (collector v0.158.0) span RED metrics gain unit/type suffixes (`traces_span_metrics_calls_total`, `traces_span_metrics_duration_milliseconds`), so the Jaeger monitor tab and alert rules querying the unsuffixed names return empty.

This switches the exporter to set `translation_strategy: "UnderscoreEscapingWithoutSuffixes"` explicitly. When `translation_strategy` is set, it wins regardless of the gate state, so the config is forward-compatible and keeps producing the unsuffixed names the rest of the test (and the Jaeger monitor tab) expects.

This is the upstream-endorsed migration path — see the maintainer explanation in [open-telemetry/opentelemetry-collector-contrib#49446 (comment)](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/49446#issuecomment-5360441148).

## Notes

- Test-only change; no operator behavior changes, so no changelog entry.
- Downstream (RHOSDT) release notes should call out that `add_metric_suffixes` is no longer honored by default and users must migrate to `translation_strategy` — tracked in TRACING-6783.

Refs: https://redhat.atlassian.net/browse/TRACING-6783

🤖 Generated with [Claude Code](https://claude.com/claude-code)