### PR TITLE
fix metricsgenerator status field (initialize map)

### DIFF
--- a/.chloggen/fix-metricsgenerator-status.yaml
+++ b/.chloggen/fix-metricsgenerator-status.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. tempostack, tempomonolithic, github action)
+component: tempostack
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix invalid `components.metricsGenerator` status field
+
+# One or more tracking issues related to the change
+issues: [1642]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: Fixes the "The field components.metricsGenerator is invalid." error in the OpenShift console.

--- a/internal/status/components.go
+++ b/internal/status/components.go
@@ -67,6 +67,8 @@ func componentsStatus(ctx context.Context, c StatusClient, s v1alpha1.TempoStack
 		return v1alpha1.ComponentStatus{}, kverrors.Wrap(err, "failed lookup TempoStack component pods status", "name", manifestutils.GatewayComponentName)
 	}
 
+	// Initialize to a non-nil map so it serializes as {} instead of null (which the API server prunes).
+	components.MetricsGenerator = v1alpha1.PodStatusMap{}
 	if s.Spec.Template.MetricsGenerator.Enabled {
 		components.MetricsGenerator, err = appendPodStatus(ctx, c, manifestutils.MetricsGeneratorComponentName, s)
 		if err != nil {

--- a/internal/status/components_test.go
+++ b/internal/status/components_test.go
@@ -2,6 +2,7 @@ package status
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -421,4 +422,37 @@ func TestSetComponentsStatus_WhenAllReady(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, expected, components)
+}
+
+func TestComponentStatus_Serialization(t *testing.T) {
+	k := &statusClientStub{}
+
+	k.GetPodsComponentStub = func(ctx context.Context, componentName string, stack v1alpha1.TempoStack) (*corev1.PodList, error) {
+		return &corev1.PodList{}, nil
+	}
+
+	s := v1alpha1.TempoStack{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-stack",
+			Namespace: "some-ns",
+		},
+	}
+
+	status, err := GetComponentsStatus(context.TODO(), k, s)
+	require.NoError(t, err)
+
+	// Components must serialize to empty maps ({}) rather than null.
+	// A null map would be pruned by the API server, dropping the field from the status,
+	// which results in "The field components.<name> is invalid." in the OCP console.
+	serialized, err := json.Marshal(status.Components)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{
+		"compactor": {},
+		"distributor": {},
+		"ingester": {},
+		"querier": {},
+		"queryFrontend": {},
+		"gateway": {},
+		"metricsGenerator": {}
+	}`, string(serialized))
 }

--- a/internal/status/components_test.go
+++ b/internal/status/components_test.go
@@ -109,12 +109,13 @@ func TestSetComponentsStatus_WhenSomePodPending(t *testing.T) {
 
 	expected := v1alpha1.TempoStackStatus{
 		Components: v1alpha1.ComponentStatus{
-			Compactor:     expectedComponents,
-			Ingester:      expectedComponents,
-			Distributor:   expectedComponents,
-			Querier:       expectedComponents,
-			QueryFrontend: expectedComponents,
-			Gateway:       expectedComponents,
+			Compactor:        expectedComponents,
+			Ingester:         expectedComponents,
+			Distributor:      expectedComponents,
+			Querier:          expectedComponents,
+			QueryFrontend:    expectedComponents,
+			Gateway:          expectedComponents,
+			MetricsGenerator: v1alpha1.PodStatusMap{},
 		},
 	}
 
@@ -180,12 +181,13 @@ func TestSetComponentsStatus_WhenSomePodFailed(t *testing.T) {
 
 	expected := v1alpha1.TempoStackStatus{
 		Components: v1alpha1.ComponentStatus{
-			Compactor:     expectedComponents,
-			Ingester:      expectedComponents,
-			Distributor:   expectedComponents,
-			Querier:       expectedComponents,
-			QueryFrontend: expectedComponents,
-			Gateway:       expectedComponents,
+			Compactor:        expectedComponents,
+			Ingester:         expectedComponents,
+			Distributor:      expectedComponents,
+			Querier:          expectedComponents,
+			QueryFrontend:    expectedComponents,
+			Gateway:          expectedComponents,
+			MetricsGenerator: v1alpha1.PodStatusMap{},
 		},
 	}
 
@@ -251,12 +253,13 @@ func TestSetComponentsStatus_WhenSomePodUnknow(t *testing.T) {
 
 	expected := v1alpha1.TempoStackStatus{
 		Components: v1alpha1.ComponentStatus{
-			Compactor:     expectedComponents,
-			Ingester:      expectedComponents,
-			Distributor:   expectedComponents,
-			Querier:       expectedComponents,
-			QueryFrontend: expectedComponents,
-			Gateway:       expectedComponents,
+			Compactor:        expectedComponents,
+			Ingester:         expectedComponents,
+			Distributor:      expectedComponents,
+			Querier:          expectedComponents,
+			QueryFrontend:    expectedComponents,
+			Gateway:          expectedComponents,
+			MetricsGenerator: v1alpha1.PodStatusMap{},
 		},
 	}
 
@@ -325,12 +328,13 @@ func TestSetComponentsStatus_WhenSomePodRunningNotReady(t *testing.T) {
 
 	expected := v1alpha1.TempoStackStatus{
 		Components: v1alpha1.ComponentStatus{
-			Compactor:     expectedComponents,
-			Ingester:      expectedComponents,
-			Distributor:   expectedComponents,
-			Querier:       expectedComponents,
-			QueryFrontend: expectedComponents,
-			Gateway:       expectedComponents,
+			Compactor:        expectedComponents,
+			Ingester:         expectedComponents,
+			Distributor:      expectedComponents,
+			Querier:          expectedComponents,
+			QueryFrontend:    expectedComponents,
+			Gateway:          expectedComponents,
+			MetricsGenerator: v1alpha1.PodStatusMap{},
 		},
 	}
 
@@ -398,12 +402,13 @@ func TestSetComponentsStatus_WhenAllReady(t *testing.T) {
 
 	expected := v1alpha1.TempoStackStatus{
 		Components: v1alpha1.ComponentStatus{
-			Compactor:     expectedComponents,
-			Ingester:      expectedComponents,
-			Distributor:   expectedComponents,
-			Querier:       expectedComponents,
-			QueryFrontend: expectedComponents,
-			Gateway:       expectedComponents,
+			Compactor:        expectedComponents,
+			Ingester:         expectedComponents,
+			Distributor:      expectedComponents,
+			Querier:          expectedComponents,
+			QueryFrontend:    expectedComponents,
+			Gateway:          expectedComponents,
+			MetricsGenerator: v1alpha1.PodStatusMap{},
 		},
 	}
 


### PR DESCRIPTION
This fixes the following error in the OCP console:

    The field components.metricsGenerator is invalid.